### PR TITLE
Update plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: ${project.version}-${buildNumber}
 description: Ultimate SkyBlock. 
 author: Talabrek (based on code by Qgel and others)
 load: STARTUP
-depend: [WorldEdit]
+depend: [Vault, WorldEdit]
 commands:
     island:
         description: Commands to use your island


### PR DESCRIPTION
Added Vault to the depend list.
1. Because without it uSB wont run.
2. If uSB loads before vault currency rewards for challenges are not awarded.
