### PR TITLE
Fix commands executed from console

### DIFF
--- a/src/main/java/us/talabrek/ultimateskyblock/DevCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/DevCommand.java
@@ -1,4 +1,4 @@
-package src.main.java.us.talabrek.ultimateskyblock;
+package us.talabrek.ultimateskyblock;
 
 import org.bukkit.command.*;
 import org.bukkit.entity.*;


### PR DESCRIPTION
Since Vault uses Bukkit's hasPermission check, no point in using Vault to check for permissions. Also, checking for op has little (no?) point since OPs should have all permissions.

Moved the (sender instanceof player) checks to the couple commands that can only be run in-game. Replaced player with sender everywhere else.
