### PR TITLE
change to purgescan calculation

### DIFF
--- a/src/main/java/us/talabrek/ultimateskyblock/player/PlayerInfo.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/player/PlayerInfo.java
@@ -30,6 +30,7 @@ public class PlayerInfo implements Serializable {
     private final Map<String, ChallengeCompletion> challenges = new ConcurrentHashMap<>();
     private FileConfiguration playerData;
     private File playerConfigFile;
+    public long timestamp;
 
     public PlayerInfo(final String playerName) {
         this.playerName = playerName;
@@ -230,6 +231,7 @@ public class PlayerInfo implements Serializable {
     // TODO: 09/12/2014 - R4zorax: All this should be made UUID
     private void reloadPlayerConfig() {
         playerConfigFile = new File(uSkyBlock.getInstance().directoryPlayers, playerName + ".yml");
+        timestamp = playerConfigFile.lastModified();
         playerData = YamlConfiguration.loadConfiguration(playerConfigFile);
     }
 


### PR DESCRIPTION
Use timestamp of player config files to determine island abandonment status instead of getOnlinePlayer()

I'm not certain of the result if a player is currently online - not sure when the config file gets written - but not seeing reliable results from getOnlinePlayer()  so just ditching it.   Writing the current time to the player and island config when they log in would be better going forward, but I'd still need a purge that can deal with older islands.

Explicitly add island leader to the member list, since older islands don't include the leader in members and a lot of solo islands were getting tagged for purge that shouldn't have been.

added  L specification calculating cutoff time - I was getting int overflow and incorrect result without it.

