### PR TITLE
fix integer overflow on purge cutoff calculation

### DIFF
--- a/src/main/java/us/talabrek/ultimateskyblock/command/admin/task/PurgeScanTask.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/command/admin/task/PurgeScanTask.java
@@ -30,7 +30,7 @@ public class PurgeScanTask extends BukkitRunnable implements IncrementalTask {
     public PurgeScanTask(uSkyBlock plugin, File islandDir, int time) {
         this.plugin = plugin;
         now = System.currentTimeMillis();
-        this.cutOff = now - (time * 3600000);
+        this.cutOff = now - (time * 3600000L);
         String[] islandList = islandDir.list(FileUtil.createIslandFilenameFilter());
         this.islandList = new ArrayList<>(Arrays.asList(islandList));
         size = islandList.length;


### PR DESCRIPTION
This is probably system dependent or you'd have caught it, but on mine purge will delete all the islands older than 1 day, no matter how many days I tell it. Calculates correctly if I force a long in there.