### PR TITLE
Fix mainthreaded Mojang API UUID lookups.

### DIFF
--- a/src/main/java/us/talabrek/ultimateskyblock/command/island/KickCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/command/island/KickCommand.java
@@ -26,10 +26,6 @@ public class KickCommand extends RequireIslandCommand {
             }
             String playerName = args[0];
             Player otherPlayer = Bukkit.getPlayer(playerName);
-            if (otherPlayer == null && Bukkit.getOfflinePlayer(playerName) == null) {
-                player.sendMessage(tr("\u00a74That player doesn't exist."));
-                return true;
-            }
             if (island.isLeader(playerName)) {
                 player.sendMessage(tr("\u00a74You can't remove the leader from the Island!"));
                 return true;

--- a/src/main/java/us/talabrek/ultimateskyblock/command/island/PartyCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/command/island/PartyCommand.java
@@ -33,15 +33,11 @@ public class PartyCommand extends CompositeUSBCommand {
             @Override
             public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
                 IslandInfo islandInfo = plugin.getIslandInfo((Player) sender);
-                Set<UUID> pendingInvites = inviteHandler.getPendingInvites(islandInfo);
-                if (pendingInvites == null || pendingInvites.isEmpty()) {
+                Collection<String> pendingInvitesAsNames = inviteHandler.getPendingInvitesAsNames(islandInfo);
+                if (pendingInvitesAsNames == null || pendingInvitesAsNames.isEmpty()) {
                     sender.sendMessage(tr("\u00a7eNo pending invites"));
                 } else {
-                    List<String> invites = new ArrayList<>();
-                    for (UUID uuid : pendingInvites) {
-                        invites.add(plugin.getServer().getOfflinePlayer(uuid).getName());
-                    }
-                    sender.sendMessage("\u00a7ePending invites: " + invites);
+                    sender.sendMessage("\u00a7ePending invites: " + pendingInvitesAsNames);
                 }
                 return true;
             }

--- a/src/main/java/us/talabrek/ultimateskyblock/command/island/TrustCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/command/island/TrustCommand.java
@@ -18,31 +18,36 @@ public class TrustCommand extends RequireIslandCommand {
     }
 
     @Override
-    protected boolean doExecute(String alias, Player player, PlayerInfo pi, IslandInfo island, Map<String, Object> data, String... args) {
+    protected boolean doExecute(final String alias, final Player player, PlayerInfo pi, final IslandInfo island, Map<String, Object> data, String... args) {
         if (args.length == 0) {
             player.sendMessage(tr("\u00a7eThe following players are trusted on your island:"));
             player.sendMessage(tr("\u00a74{0}", island.getTrustees()));
             player.sendMessage(tr("\u00a7eTo trust/untrust from your island, use /island trust <player>"));
             return true;
         } else if (args.length == 1) {
-            String name = args[0];
+            final String name = args[0];
             if (island.getMembers().contains(name)) {
                 player.sendMessage(tr("\u00a74Members are already trusted!"));
                 return true;
             }
-            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(name);
-            if (offlinePlayer == null || !offlinePlayer.hasPlayedBefore()) {
-                player.sendMessage(tr("\u00a74Unknown player {0}", name));
-                return true;
-            }
-            if (alias.equals("trust")) {
-                island.trust(name);
-                player.sendMessage(tr("\u00a7eYou have trusted \u00a74{0}\u00a7e on your island.", name));
-            } else {
-                island.untrust(name);
-                player.sendMessage(tr("\u00a7eYou have revoked your trust in \u00a7a{0}\u00a7e on your island.", name));
-            }
-            WorldGuardHandler.updateRegion(player, island);
+            plugin.getServer().getScheduler().runTaskAsynchronously(plugin, new Runnable() {
+                @Override
+                public void run() {
+                    OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(name);
+                    if (offlinePlayer == null) {
+                        player.sendMessage(tr("\u00a74Unknown player {0}", name));
+                        return;
+                    }
+                    if (alias.equals("trust")) {
+                        island.trust(name);
+                        player.sendMessage(tr("\u00a7eYou have trusted \u00a74{0}\u00a7e on your island.", name));
+                    } else {
+                        island.untrust(name);
+                        player.sendMessage(tr("\u00a7eYou have revoked your trust in \u00a7a{0}\u00a7e on your island.", name));
+                    }
+                    WorldGuardHandler.updateRegion(player, island);
+                }
+            });
             return true;
         }
         return false;

--- a/src/main/java/us/talabrek/ultimateskyblock/island/IslandInfo.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/island/IslandInfo.java
@@ -494,13 +494,13 @@ public class IslandInfo {
             for (String memberName : members.getKeys(false)) {
                 String uuid = members.getString(memberName + ".uuid", null);
                 if (uuid != null) {
-                    OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(UUIDUtil.fromString(uuid));
-                    if (offlinePlayer != null && offlinePlayer.isOnline()) {
+                    Player onlinePlayer = Bukkit.getPlayer(UUIDUtil.fromString(uuid));
+                    if (onlinePlayer != null) {
                         return true;
                     }
                 } else {
-                    OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(memberName);
-                    if (offlinePlayer != null && offlinePlayer.isOnline()) {
+                    Player onlinePlayer = Bukkit.getPlayer(memberName);
+                    if (onlinePlayer != null) {
                         return true;
                     }
                 }


### PR DESCRIPTION
This pull request fixes the main-threaded UUID lookups the plugin does by using getOfflinePlayer().

Reason:
These UUID lookups cause TPS drops, and can occasionally even crash the server.

Cause:
getOfflinePlayer() in CraftServer will do a UUID lookup if the server is in online-mode and the players profile cannot be found.

Reason for each file change:
* src/main/java/us/talabrek/ultimateskyblock/command/InviteHandler.java
  * This stores the players name along with the UUID now when a player is invited, used in one of the other changes.
* src/main/java/us/talabrek/ultimateskyblock/command/admin/CooldownCommand.java
  * This before did a UUID lookup when an argument was presented, fixed with a asynchronus callback.
*  src/main/java/us/talabrek/ultimateskyblock/command/island/KickCommand.java
  * This removes a useless UUID lookup, since the code below handles if the player is null.
* src/main/java/us/talabrek/ultimateskyblock/command/island/PartyCommand.java
  * Instead of converting its own UUID's->Names, this now uses the new getPendingInvitesAsNames method in InviteHandler which is thread-safe.
* src/main/java/us/talabrek/ultimateskyblock/command/island/TrustCommand.java
 * This now executes the UUID lookup asynchronusly.
 * This also fixes a bug where hasPlayedBefore was used. This only returns true the second time a player logs in, making a player untrustable the first time they login.
* src/main/java/us/talabrek/ultimateskyblock/island/IslandInfo.java
  * This removes a completely useless UUID lookup, which is executed on join causing lag.


