### PR TITLE
Improvements

### DIFF
--- a/src/main/java/us/talabrek/ultimateskyblock/command/admin/GotoIslandCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/command/admin/GotoIslandCommand.java
@@ -1,6 +1,7 @@
 package us.talabrek.ultimateskyblock.command.admin;
 
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import us.talabrek.ultimateskyblock.player.PlayerInfo;
@@ -27,12 +28,21 @@ public class GotoIslandCommand extends AbstractPlayerInfoCommand {
         Player player = (Player) sender;
         if (playerInfo.getHomeLocation() != null) {
             sender.sendMessage(tr("\u00a7aTeleporting to {0}'s island.", playerInfo.getPlayerName()));
-            player.teleport(playerInfo.getHomeLocation());
+
+            Location homeLocation = playerInfo.getHomeLocation();
+            if (!homeLocation.getWorld().isChunkLoaded(homeLocation.getBlockX() >> 4, homeLocation.getBlockZ() >> 4)) {
+                homeLocation.getWorld().loadChunk(homeLocation.getBlockX() >> 4, homeLocation.getBlockZ() >> 4);
+            }
+            player.teleport(homeLocation);
             return;
         }
         if (playerInfo.getIslandLocation() != null) {
             sender.sendMessage(tr("\u00a7aTeleporting to {0}'s island.", playerInfo.getPlayerName()));
-            player.teleport(playerInfo.getIslandLocation());
+            Location islandLocation = playerInfo.getIslandLocation();
+            if (!islandLocation.getWorld().isChunkLoaded(islandLocation.getBlockX() >> 4, islandLocation.getBlockZ() >> 4)) {
+                islandLocation.getWorld().loadChunk(islandLocation.getBlockX() >> 4, islandLocation.getBlockZ() >> 4);
+            }
+            player.teleport(islandLocation);
             return;
         }
         sender.sendMessage(tr("\u00a74That player does not have an island!"));

--- a/src/main/java/us/talabrek/ultimateskyblock/command/island/CreateCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/command/island/CreateCommand.java
@@ -23,6 +23,14 @@ public class CreateCommand extends RequirePlayerCommand {
         PlayerInfo pi = plugin.getPlayerInfo(player);
         int cooldown = plugin.getCooldownHandler().getCooldown(player, "restart");
         if (LocationUtil.isEmptyLocation(pi.getIslandLocation()) && cooldown == 0) {
+            if (pi.isIslandGenerating()) {
+                player.sendMessage(tr("\u00a7cYour island is in the process of generating, you cannot create now."));
+                return true;
+            }
+            if (pi.isIslandRestarting()) {
+                player.sendMessage(tr("\u00a7cYour island is in the process of restarting, you cannot create now."));
+                return true;
+            }
             plugin.createIsland(player, pi);
         } else if (pi.getHasIsland()) {
             IslandInfo island = plugin.getIslandInfo(pi);

--- a/src/main/java/us/talabrek/ultimateskyblock/command/island/RestartCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/command/island/RestartCommand.java
@@ -27,9 +27,18 @@ public class RestartCommand extends RequireIslandCommand {
         }
         int cooldown = plugin.getCooldownHandler().getCooldown(player, "restart");
         if (cooldown > 0) {
-            player.sendMessage(tr("\u00a7eYou can restart your island in {0} seconds.", cooldown));
+            player.sendMessage(tr("\u00a7cYou can restart your island in {0} seconds.", cooldown));
             return true;
         } else {
+            if (pi.isIslandRestarting()) {
+                player.sendMessage(tr("\u00a7cYour island is already in the process of restarting."));
+                return true;
+            }
+            if (pi.isIslandGenerating()) {
+                player.sendMessage(tr("\u00a7cYour island is in the process of generating, you cannot restart now."));
+                return true;
+            }
+
             if (plugin.getConfirmHandler().checkCommand(player, "/is restart")) {
                 plugin.getCooldownHandler().resetCooldown(player, "restart", Settings.general_cooldownRestart);
                 return plugin.restartPlayerIsland(player, pi.getIslandLocation());

--- a/src/main/java/us/talabrek/ultimateskyblock/handler/task/WorldEditClearTask.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/handler/task/WorldEditClearTask.java
@@ -59,6 +59,7 @@ public class WorldEditClearTask extends BukkitRunnable implements IncrementalTas
         Iterator<Region> border = borderRegions.iterator();
         for (int i = 0; i < length; i++) {
             EditSession editSession = new EditSession(bukkitWorld, maxBlocks);
+            editSession.setFastMode(true);
             if (inner.hasNext()) {
                 Vector2D chunk = inner.next();
                 inner.remove();

--- a/src/main/java/us/talabrek/ultimateskyblock/handler/task/WorldEditRegenTask.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/handler/task/WorldEditRegenTask.java
@@ -31,6 +31,7 @@ public class WorldEditRegenTask implements IncrementalTask {
     public WorldEditRegenTask(World world, Set<Region> borderRegions) {
         bukkitWorld = new BukkitWorld(world);
         editSession = new EditSession(bukkitWorld, 255 * Settings.island_protectionRange * Settings.island_protectionRange);
+        editSession.setFastMode(true);
         editSession.enableQueue();
         log.log(Level.FINE, "Planning regen of borders: " + borderRegions);
         regions = createRegions(borderRegions);

--- a/src/main/java/us/talabrek/ultimateskyblock/handler/worldedit/WorldEdit6Adaptor.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/handler/worldedit/WorldEdit6Adaptor.java
@@ -61,6 +61,7 @@ public class WorldEdit6Adaptor implements WorldEditAdaptor {
 
             EditSession editSession = new EditSession(bukkitWorld, 255 * Settings.island_protectionRange * Settings.island_protectionRange);
             editSession.enableQueue();
+            editSession.setFastMode(true);
             Vector to = new Vector(origin.getBlockX(), origin.getBlockY(), origin.getBlockZ());
             Operation operation = holder
                     .createPaste(editSession, worldData)

--- a/src/main/java/us/talabrek/ultimateskyblock/island/IslandGenerator.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/island/IslandGenerator.java
@@ -1,6 +1,9 @@
 package us.talabrek.ultimateskyblock.island;
 
+import java.io.File;
+import java.util.logging.Logger;
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -14,9 +17,6 @@ import us.talabrek.ultimateskyblock.handler.VaultHandler;
 import us.talabrek.ultimateskyblock.handler.WorldEditHandler;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 import us.talabrek.ultimateskyblock.util.ItemStackUtil;
-
-import java.io.File;
-import java.util.logging.Logger;
 
 /**
  * The factory for creating islands (actual blocks).
@@ -86,15 +86,17 @@ public class IslandGenerator {
                 log.fine("generating a skySMP island");
                 oldGenerateIslandBlocks(next.getBlockX(), next.getBlockZ(), player, uSkyBlock.skyBlockWorld);
             }
+            hasIslandNow = true;
         }
         next.setY((double) Settings.island_height);
+
         log.exiting(CN, "createIsland");
     }
 
     public void generateIslandBlocks(final int x, final int z, final Player player, final World world) {
         final int y = Settings.island_height;
         final Block blockToChange = world.getBlockAt(x, y, z);
-        blockToChange.setTypeId(7);
+        blockToChange.setTypeIdAndData(7, (byte) 0, false);
         this.islandLayer1(x, z, player, world);
         this.islandLayer2(x, z, player, world);
         this.islandLayer3(x, z, player, world);
@@ -108,7 +110,7 @@ public class IslandGenerator {
             for (int y_operate = y; y_operate < y + 3; ++y_operate) {
                 for (int z_operate = z; z_operate < z + 6; ++z_operate) {
                     final Block blockToChange = world.getBlockAt(x_operate, y_operate, z_operate);
-                    blockToChange.setTypeId(2);
+                    blockToChange.setTypeIdAndData(2, (byte) 0, false);
                 }
             }
         }
@@ -116,7 +118,7 @@ public class IslandGenerator {
             for (int y_operate = y; y_operate < y + 3; ++y_operate) {
                 for (int z_operate = z + 3; z_operate < z + 6; ++z_operate) {
                     final Block blockToChange = world.getBlockAt(x_operate, y_operate, z_operate);
-                    blockToChange.setTypeId(2);
+                    blockToChange.setTypeIdAndData(2, (byte) 0, false);
                 }
             }
         }
@@ -124,25 +126,25 @@ public class IslandGenerator {
             for (int y_operate = y + 7; y_operate < y + 10; ++y_operate) {
                 for (int z_operate = z + 3; z_operate < z + 7; ++z_operate) {
                     final Block blockToChange = world.getBlockAt(x_operate, y_operate, z_operate);
-                    blockToChange.setTypeId(18);
+                    blockToChange.setTypeIdAndData(18, (byte) 0, false);
                 }
             }
         }
         for (int y_operate2 = y + 3; y_operate2 < y + 9; ++y_operate2) {
             final Block blockToChange2 = world.getBlockAt(x + 5, y_operate2, z + 5);
-            blockToChange2.setTypeId(17);
+            blockToChange2.setTypeIdAndData(17, (byte) 0, false);
         }
         Block blockToChange3 = world.getBlockAt(x + 1, y + 3, z + 1);
-        blockToChange3.setTypeId(54);
+        blockToChange3.setTypeIdAndData(54, (byte) 0, false);
         final Chest chest = (Chest) blockToChange3.getState();
         blockToChange3 = world.getBlockAt(x, y, z);
-        blockToChange3.setTypeId(7);
+        blockToChange3.setTypeIdAndData(7, (byte) 0, false);
         blockToChange3 = world.getBlockAt(x + 2, y + 1, z + 1);
-        blockToChange3.setTypeId(12);
+        blockToChange3.setTypeIdAndData(12, (byte) 0, false);
         blockToChange3 = world.getBlockAt(x + 2, y + 1, z + 2);
-        blockToChange3.setTypeId(12);
+        blockToChange3.setTypeIdAndData(12, (byte) 0, false);
         blockToChange3 = world.getBlockAt(x + 2, y + 1, z + 3);
-        blockToChange3.setTypeId(12);
+        blockToChange3.setTypeIdAndData(12, (byte) 0, false);
         setChest(chest.getLocation(), player);
     }
 
@@ -151,17 +153,17 @@ public class IslandGenerator {
         for (int x_operate = x - 3; x_operate <= x + 3; ++x_operate) {
             for (int z_operate = z - 3; z_operate <= z + 3; ++z_operate) {
                 final Block blockToChange = world.getBlockAt(x_operate, y, z_operate);
-                blockToChange.setTypeId(2);
+                blockToChange.setTypeIdAndData(2, (byte) 0, false);
             }
         }
         Block blockToChange2 = world.getBlockAt(x - 3, y, z + 3);
-        blockToChange2.setTypeId(0);
+        blockToChange2.setTypeIdAndData(0, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x - 3, y, z - 3);
-        blockToChange2.setTypeId(0);
+        blockToChange2.setTypeIdAndData(0, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x + 3, y, z - 3);
-        blockToChange2.setTypeId(0);
+        blockToChange2.setTypeIdAndData(0, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x + 3, y, z + 3);
-        blockToChange2.setTypeId(0);
+        blockToChange2.setTypeIdAndData(0, (byte) 0, false);
     }
 
     private void islandLayer2(final int x, final int z, final Player player, final World world) {
@@ -169,19 +171,19 @@ public class IslandGenerator {
         for (int x_operate = x - 2; x_operate <= x + 2; ++x_operate) {
             for (int z_operate = z - 2; z_operate <= z + 2; ++z_operate) {
                 final Block blockToChange = world.getBlockAt(x_operate, y, z_operate);
-                blockToChange.setTypeId(3);
+                blockToChange.setTypeIdAndData(3, (byte) 0, false);
             }
         }
         Block blockToChange2 = world.getBlockAt(x - 3, y, z);
-        blockToChange2.setTypeId(3);
+        blockToChange2.setTypeIdAndData(3, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x + 3, y, z);
-        blockToChange2.setTypeId(3);
+        blockToChange2.setTypeIdAndData(3, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x, y, z - 3);
-        blockToChange2.setTypeId(3);
+        blockToChange2.setTypeIdAndData(3, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x, y, z + 3);
-        blockToChange2.setTypeId(3);
+        blockToChange2.setTypeIdAndData(3, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x, y, z);
-        blockToChange2.setTypeId(12);
+        blockToChange2.setTypeIdAndData(12, (byte) 0, false);
     }
 
     private void islandLayer3(final int x, final int z, final Player player, final World world) {
@@ -189,93 +191,92 @@ public class IslandGenerator {
         for (int x_operate = x - 1; x_operate <= x + 1; ++x_operate) {
             for (int z_operate = z - 1; z_operate <= z + 1; ++z_operate) {
                 final Block blockToChange = world.getBlockAt(x_operate, y, z_operate);
-                blockToChange.setTypeId(3);
+                blockToChange.setTypeIdAndData(3, (byte) 0, false);
             }
         }
         Block blockToChange2 = world.getBlockAt(x - 2, y, z);
-        blockToChange2.setTypeId(3);
+        blockToChange2.setTypeIdAndData(3, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x + 2, y, z);
-        blockToChange2.setTypeId(3);
+        blockToChange2.setTypeIdAndData(3, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x, y, z - 2);
-        blockToChange2.setTypeId(3);
+        blockToChange2.setTypeIdAndData(3, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x, y, z + 2);
-        blockToChange2.setTypeId(3);
+        blockToChange2.setTypeIdAndData(3, (byte) 0, false);
         blockToChange2 = world.getBlockAt(x, y, z);
-        blockToChange2.setTypeId(12);
+        blockToChange2.setTypeIdAndData(12, (byte) 0, false);
     }
 
     private void islandLayer4(final int x, final int z, final Player player, final World world) {
         int y = Settings.island_height + 1;
         Block blockToChange = world.getBlockAt(x - 1, y, z);
-        blockToChange.setTypeId(3);
+        blockToChange.setTypeIdAndData(3, (byte) 0, false);
         blockToChange = world.getBlockAt(x + 1, y, z);
-        blockToChange.setTypeId(3);
+        blockToChange.setTypeIdAndData(3, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y, z - 1);
-        blockToChange.setTypeId(3);
+        blockToChange.setTypeIdAndData(3, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y, z + 1);
-        blockToChange.setTypeId(3);
+        blockToChange.setTypeIdAndData(3, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y, z);
-        blockToChange.setTypeId(12);
+        blockToChange.setTypeIdAndData(12, (byte) 0, false);
     }
 
     private void islandExtras(final int x, final int z, final Player player, final World world) {
         int y = Settings.island_height;
         Block blockToChange = world.getBlockAt(x, y + 5, z);
-        blockToChange.setTypeId(17);
+        blockToChange.setTypeIdAndData(17, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y + 6, z);
-        blockToChange.setTypeId(17);
+        blockToChange.setTypeIdAndData(17, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y + 7, z);
-        blockToChange.setTypeId(17);
+        blockToChange.setTypeIdAndData(17, (byte) 0, false);
         y = Settings.island_height + 8;
         for (int x_operate = x - 2; x_operate <= x + 2; ++x_operate) {
             for (int z_operate = z - 2; z_operate <= z + 2; ++z_operate) {
                 blockToChange = world.getBlockAt(x_operate, y, z_operate);
-                blockToChange.setTypeId(18);
+                blockToChange.setTypeIdAndData(18, (byte) 0, false);
             }
         }
         blockToChange = world.getBlockAt(x + 2, y, z + 2);
-        blockToChange.setTypeId(0);
+        blockToChange.setTypeIdAndData(0, (byte) 0, false);
         blockToChange = world.getBlockAt(x + 2, y, z - 2);
-        blockToChange.setTypeId(0);
+        blockToChange.setTypeIdAndData(0, (byte) 0, false);
         blockToChange = world.getBlockAt(x - 2, y, z + 2);
-        blockToChange.setTypeId(0);
+        blockToChange.setTypeIdAndData(0, (byte) 0, false);
         blockToChange = world.getBlockAt(x - 2, y, z - 2);
-        blockToChange.setTypeId(0);
+        blockToChange.setTypeIdAndData(0, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y, z);
-        blockToChange.setTypeId(17);
+        blockToChange.setTypeIdAndData(17, (byte) 0, false);
         y = Settings.island_height + 9;
         for (int x_operate = x - 1; x_operate <= x + 1; ++x_operate) {
             for (int z_operate = z - 1; z_operate <= z + 1; ++z_operate) {
                 blockToChange = world.getBlockAt(x_operate, y, z_operate);
-                blockToChange.setTypeId(18);
+                blockToChange.setTypeIdAndData(18, (byte) 0, false);
             }
         }
         blockToChange = world.getBlockAt(x - 2, y, z);
-        blockToChange.setTypeId(18);
+        blockToChange.setTypeIdAndData(18, (byte) 0, false);
         blockToChange = world.getBlockAt(x + 2, y, z);
-        blockToChange.setTypeId(18);
+        blockToChange.setTypeIdAndData(18, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y, z - 2);
-        blockToChange.setTypeId(18);
+        blockToChange.setTypeIdAndData(18, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y, z + 2);
-        blockToChange.setTypeId(18);
+        blockToChange.setTypeIdAndData(18, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y, z);
-        blockToChange.setTypeId(17);
+        blockToChange.setTypeIdAndData(17, (byte) 0, false);
         y = Settings.island_height + 10;
         blockToChange = world.getBlockAt(x - 1, y, z);
-        blockToChange.setTypeId(18);
+        blockToChange.setTypeIdAndData(18, (byte) 0, false);
         blockToChange = world.getBlockAt(x + 1, y, z);
-        blockToChange.setTypeId(18);
+        blockToChange.setTypeIdAndData(18, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y, z - 1);
-        blockToChange.setTypeId(18);
+        blockToChange.setTypeIdAndData(18, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y, z + 1);
-        blockToChange.setTypeId(18);
+        blockToChange.setTypeIdAndData(18, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y, z);
-        blockToChange.setTypeId(17);
+        blockToChange.setTypeIdAndData(17, (byte) 0, false);
         blockToChange = world.getBlockAt(x, y + 1, z);
-        blockToChange.setTypeId(18);
+        blockToChange.setTypeIdAndData(18, (byte) 0, false);
         blockToChange = world.getBlockAt(x, Settings.island_height + 5, z + 1);
-        blockToChange.setTypeId(54);
-        blockToChange.setData((byte) 3);
+        blockToChange.setTypeIdAndData(54, (byte)3, false);
         final Chest chest = (Chest) blockToChange.getState();
         setChest(chest.getLocation(), player);
     }

--- a/src/main/java/us/talabrek/ultimateskyblock/island/IslandLogic.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/island/IslandLogic.java
@@ -92,7 +92,7 @@ public class IslandLogic {
         ProtectedRegion region = WorldGuardHandler.getIslandRegionAt(loc);
         if (region != null) {
             for (Player player : WorldEditHandler.getPlayersInRegion(plugin.getWorld(), region)) {
-                if (player != null && player.isOnline() && !player.isFlying()) {
+                if (player != null && player.isOnline()) {
                     player.sendMessage(tr("\u00a7cThe island you are on is being deleted! Sending you to spawn."));
                     plugin.spawnTeleport(player, true);
                 }

--- a/src/main/java/us/talabrek/ultimateskyblock/player/PlayerInfo.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/player/PlayerInfo.java
@@ -28,6 +28,9 @@ public class PlayerInfo implements Serializable {
     private UUID uuid;
     private boolean hasIsland;
 
+    private boolean islandGenerating = false;
+    private boolean islandRestarting = false;
+
     private Location islandLocation;
     private Location homeLocation;
 
@@ -380,5 +383,21 @@ public class PlayerInfo implements Serializable {
         trustedOn.remove(name);
         playerData.set("trustedOn", trustedOn);
         save();
+    }
+
+    public boolean isIslandGenerating() {
+        return this.islandGenerating;
+    }
+
+    public void setIslandGenerating(boolean value) {
+        this.islandGenerating = value;
+    }
+
+    public boolean isIslandRestarting() {
+        return this.islandRestarting;
+    }
+
+    public void setIslandRestarting(boolean value) {
+        this.islandRestarting = value;
     }
 }

--- a/src/main/java/us/talabrek/ultimateskyblock/player/PlayerLogic.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/player/PlayerLogic.java
@@ -1,22 +1,17 @@
 package us.talabrek.ultimateskyblock.player;
 
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import us.talabrek.ultimateskyblock.handler.WorldGuardHandler;
 import us.talabrek.ultimateskyblock.island.IslandInfo;
 import us.talabrek.ultimateskyblock.uSkyBlock;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import static us.talabrek.ultimateskyblock.util.I18nUtil.tr;
 
 /**
  * Holds the active players
@@ -121,6 +116,19 @@ public class PlayerLogic {
                     throw e;
                 } finally {
                     locked.remove(player.getName());
+
+                    Bukkit.getScheduler().runTask(plugin, new Runnable() {
+                        @Override
+                        public void run() {
+                            if (player != null && player.isOnline()) {
+                                PlayerInfo playerInfo = plugin.getPlayerInfo(player);
+                                if (!playerInfo.getHasIsland() && player.getLocation().getWorld().getName().equalsIgnoreCase(uSkyBlock.skyBlockWorld.getName())) {
+                                    plugin.spawnTeleport(player, true);
+                                    player.sendMessage(tr("\u00a7cIt seems you logged out in the sky world, however you are not a member of an island. Teleporting you to spawn."));
+                                }
+                            }
+                        }
+                    });
                 }
             }
         });

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -184,7 +184,7 @@ options:
     clearEnderChest: true
 
     # [ticks] The number of ticks to wait, before porting the player back
-    # on /is restart (default: 20)
+    # on /is restart or /is create (default: 20)
     teleportDelay: 20
 
 # DO NOT TOUCH THE FIELDS BELOW


### PR DESCRIPTION
This changes the following:
* Prevents concurrent island creates/restarts.
* Load chunks before teleporting a player to prevent visual glitches
* Skips physics updates when setting blocks to reduce tps lag
(EditSession#FastMode, setTypeIdAndData(x, x, false). Shows major
improvements to server performance.
* Adds delay to teleporting the player when creating an island, had
//TODO: Later in the notes.
* Teleports a player to spawn if they logged out in the sky world
without an island.
* Removes a redundant(and breaking) isFlying() check that prevented
players that were flying from being teleport to spawn on island restart.
Many servers allow players to fly with donation perks.