### PR TITLE
Improvements

### DIFF
--- a/src/main/java/us/talabrek/ultimateskyblock/SkyBlockChunkGenerator.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/SkyBlockChunkGenerator.java
@@ -1,5 +1,6 @@
 package us.talabrek.ultimateskyblock;
 
+import java.util.ArrayList;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.generator.BlockPopulator;
@@ -13,6 +14,7 @@ public class SkyBlockChunkGenerator extends ChunkGenerator {
     private static final byte[] generate = new byte[32768];
     private static final byte[][] blockSections = new byte[16][];
     private static final short[][] extBlockSections = new short[16][];
+    private static final List<BlockPopulator> blockPopulatorList = Collections.unmodifiableList(new ArrayList<BlockPopulator>());
 
     @Override
     public byte[] generate(World world, Random random, int x, int z) {
@@ -31,7 +33,7 @@ public class SkyBlockChunkGenerator extends ChunkGenerator {
 
     @Override
     public List<BlockPopulator> getDefaultPopulators(World world) {
-        return Collections.emptyList();
+        return blockPopulatorList;
     }
 
     @Override

--- a/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengesCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengesCommand.java
@@ -22,7 +22,7 @@ public class ChallengesCommand implements CommandExecutor, TabCompleter {
     public ChallengesCommand(uSkyBlock plugin) {
         this.plugin = plugin;
     }
-    
+
     public boolean onCommand(final CommandSender sender, final Command command, final String label, final String[] split) {
         if (!plugin.isRequirementsMet(sender)) {
             return false;

--- a/src/main/java/us/talabrek/ultimateskyblock/command/island/BiomeCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/command/island/BiomeCommand.java
@@ -37,15 +37,17 @@ public class BiomeCommand extends RequireIslandCommand {
                     return true;
                 }
                 if (plugin.playerIsOnIsland(player)) {
-                    if (plugin.changePlayerBiome(player, biome)) {
-                        player.sendMessage(tr("\u00a7aYou have changed your island''s biome to {0}", biome.toUpperCase()));
-                        player.sendMessage(tr("\u00a7aYou may need to go to spawn, or relog, to see the changes."));
-                        island.sendMessageToIslandGroup(tr("{0} changed the island biome to {1}", player.getName(), biome.toUpperCase()));
-                        plugin.getCooldownHandler().resetCooldown(player, "biome", Settings.general_biomeChange);
+                    if (plugin.biomeExists(biome)) {
+                        if (plugin.changePlayerBiome(player, biome)) {
+                            player.sendMessage(tr("\u00a7aYou have changed your island''s biome to {0}", biome.toUpperCase()));
+                            player.sendMessage(tr("\u00a7aYou may need to go to spawn, or relog, to see the changes."));
+                            island.sendMessageToIslandGroup(tr("{0} changed the island biome to {1}", player.getName(), biome.toUpperCase()));
+                            plugin.getCooldownHandler().resetCooldown(player, "biome", Settings.general_biomeChange);
+                        } else {
+                            player.sendMessage(tr("\u00a7cYou do not have permission to change your biome to that type."));
+                        }
                     } else {
-                        player.sendMessage(tr("\u00a7aYou have misspelled the biome name, changing your biome to OCEAN"));
-                        player.sendMessage(tr("\u00a7aYou may need to go to spawn, or relog, to see the changes."));
-                        island.sendMessageToIslandGroup(tr("{0} changed the island biome to OCEAN", player.getName()));
+                        player.sendMessage(tr("\u00a7cYou have misspelled the biome name."));
                     }
                 } else {
                     player.sendMessage(tr("\u00a7eYou must be on your island to change the biome!"));

--- a/src/main/java/us/talabrek/ultimateskyblock/command/island/HomeCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/command/island/HomeCommand.java
@@ -16,6 +16,14 @@ public class HomeCommand extends RequireIslandCommand {
 
     @Override
     protected boolean doExecute(String alias, Player player, PlayerInfo pi, IslandInfo island, Map<String, Object> data, String... args) {
+        if (pi.isIslandGenerating()) {
+            player.sendMessage(tr("\u00a7cYour island is in the process of generating, you cannot teleport home right now."));
+            return true;
+        }
+        if (pi.isIslandRestarting()) {
+            player.sendMessage(tr("\u00a7cYour island is in the process of restarting, you cannot teleport home right now."));
+            return true;
+        }
         if (pi.getHomeLocation() == null) {
             pi.setHomeLocation(pi.getIslandLocation());
         }

--- a/src/main/java/us/talabrek/ultimateskyblock/command/island/WarpCommand.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/command/island/WarpCommand.java
@@ -42,18 +42,36 @@ public class WarpCommand extends RequirePlayerCommand {
             return true;
         } else if (args.length == 1) {
             if (VaultHandler.checkPerk(player.getName(), "usb.island.warp", player.getWorld())) {
-                PlayerInfo playerInfo = plugin.getPlayerInfo(args[0]);
-                if (playerInfo == null || !playerInfo.getHasIsland()) {
+                PlayerInfo senderPlayerInfo = plugin.getPlayerInfo(player);
+                if (senderPlayerInfo.isIslandGenerating()) {
+                    player.sendMessage(tr("\u00a7cYour island is in the process of generating, you cannot warp to other players islands right now."));
+                    return true;
+                }
+                if (senderPlayerInfo.isIslandRestarting()) {
+                    player.sendMessage(tr("\u00a7cYour island is in the process of restarting, you cannot warp to other players islands right now."));
+                    return true;
+                }
+
+                PlayerInfo targetPlayerInfo = plugin.getPlayerInfo(args[0]);
+                if (targetPlayerInfo == null || !targetPlayerInfo.getHasIsland()) {
                     player.sendMessage(tr("\u00a74That player does not exist!"));
                     return true;
                 }
-                IslandInfo island = plugin.getIslandInfo(playerInfo);
+                IslandInfo island = plugin.getIslandInfo(targetPlayerInfo);
                 if (!island.hasWarp()) {
                     player.sendMessage(tr("\u00a74That player does not have an active warp."));
                     return true;
                 }
+                if (targetPlayerInfo.isIslandGenerating()) {
+                    player.sendMessage(tr("\u00a7cThat players island is in the process of generating, you cannot warp to it right now."));
+                    return true;
+                }
+                if (targetPlayerInfo.isIslandRestarting()) {
+                    player.sendMessage(tr("\u00a7cThat players island is in the process of restarting, you cannot warp to it right now."));
+                    return true;
+                }
                 if (!island.isBanned(player)) {
-                    plugin.warpTeleport(player, playerInfo, false);
+                    plugin.warpTeleport(player, targetPlayerInfo, false);
                 } else {
                     player.sendMessage(tr("\u00a74That player has forbidden you from warping to their island."));
                 }

--- a/src/main/java/us/talabrek/ultimateskyblock/handler/WorldEditHandler.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/handler/WorldEditHandler.java
@@ -36,8 +36,8 @@ public class WorldEditHandler {
         return (WorldEditPlugin) plugin;
     }
 
-    public static boolean loadIslandSchematic(Player player, final World world, final File file, final Location origin) {
-        return WorldEditAdaptor.Factory.create(getWorldEdit()).loadIslandSchematic(player, world, file, origin);
+    public static boolean loadIslandSchematic(final World world, final File file, final Location origin) {
+        return WorldEditAdaptor.Factory.create(getWorldEdit()).loadIslandSchematic(world, file, origin);
     }
 
     /**
@@ -149,7 +149,8 @@ public class WorldEditHandler {
         final Region cube = getRegion(skyWorld, region);
         Set<Vector2D> innerChunks = getInnerChunks(cube);
         WorldRegenTask worldRegenTask = new WorldRegenTask(skyWorld, innerChunks);
-        WorldEditRegenTask worldEditTask = new WorldEditRegenTask(skyWorld, getBorderRegions(cube));
+        Set<Region> borderRegions = getBorderRegions(cube);
+        WorldEditRegenTask worldEditTask = new WorldEditRegenTask(skyWorld, borderRegions);
         uSkyBlock.getInstance().getExecutor().execute(uSkyBlock.getInstance(), new CompositeIncrementalTask(worldEditTask, worldRegenTask), new Runnable() {
             @Override
             public void run() {

--- a/src/main/java/us/talabrek/ultimateskyblock/handler/task/WorldEditRegenTask.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/handler/task/WorldEditRegenTask.java
@@ -1,39 +1,30 @@
 package us.talabrek.ultimateskyblock.handler.task;
 
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.Vector;
-import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
-import org.bukkit.World;
-import org.bukkit.plugin.Plugin;
-import us.talabrek.ultimateskyblock.Settings;
-import us.talabrek.ultimateskyblock.async.IncrementalTask;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.plugin.Plugin;
+import us.talabrek.ultimateskyblock.async.IncrementalTask;
 
 /**
  * Do WorldEdit stuff in increments
  */
 public class WorldEditRegenTask implements IncrementalTask {
-    private static final BaseBlock AIR = new BaseBlock(0);
-    private static final BaseBlock GLASS = new BaseBlock(20);
     public static final int INCREMENT = 4;
-    private final EditSession editSession;
-    private final BukkitWorld bukkitWorld;
+    private final World world;
     private final List<Region> regions;
     private final int size;
 
     public WorldEditRegenTask(World world, Set<Region> borderRegions) {
-        bukkitWorld = new BukkitWorld(world);
-        editSession = new EditSession(bukkitWorld, 255 * Settings.island_protectionRange * Settings.island_protectionRange);
-        editSession.setFastMode(true);
-        editSession.enableQueue();
         log.log(Level.FINE, "Planning regen of borders: " + borderRegions);
+        this.world = world;
         regions = createRegions(borderRegions);
         size = regions.size();
         log.log(Level.FINE, "Planning regen of regions: " + regions);
@@ -42,14 +33,14 @@ public class WorldEditRegenTask implements IncrementalTask {
     private List<Region> createRegions(Set<Region> borderRegions) {
         List<Region> list = new ArrayList<>();
         for (Region region : borderRegions) {
-            if (region.getLength() > region.getWidth())  {
+            if (region.getLength() > region.getWidth()) {
                 // Z-axis
                 Vector min = region.getMinimumPoint();
                 Vector max = region.getMaximumPoint();
                 Vector pt = new Vector(max);
                 pt = pt.setZ(min.getBlockZ());
                 while (pt.getBlockZ() < max.getBlockZ()) {
-                    int dz = Math.min(INCREMENT, Math.abs(max.getBlockZ()-pt.getBlockZ()));
+                    int dz = Math.min(INCREMENT, Math.abs(max.getBlockZ() - pt.getBlockZ()));
                     pt = pt.add(0, 0, dz);
                     list.add(new CuboidRegion(min, pt));
                     min = min.setZ(pt.getZ());
@@ -61,7 +52,7 @@ public class WorldEditRegenTask implements IncrementalTask {
                 Vector pt = new Vector(max);
                 pt = pt.setX(min.getBlockX());
                 while (pt.getBlockX() < max.getBlockX()) {
-                    int dx = Math.min(INCREMENT, Math.abs(max.getBlockX()-pt.getBlockX()));
+                    int dx = Math.min(INCREMENT, Math.abs(max.getBlockX() - pt.getBlockX()));
                     pt = pt.add(dx, 0, 0);
                     list.add(new CuboidRegion(min, pt));
                     min = min.setX(pt.getX());
@@ -73,21 +64,17 @@ public class WorldEditRegenTask implements IncrementalTask {
 
     @Override
     public boolean execute(Plugin plugin, int offset, int length) {
-        log.log(Level.FINE, "Executing WorldEditRegen of regions " + offset + "-" + (offset+length) + " of " + regions.size() + " regions");
+        log.log(Level.FINE, "Executing WorldEditRegen of regions " + offset + "-" + (offset + length) + " of " + regions.size() + " regions");
         for (int i = 0; i < length && !regions.isEmpty(); i++) {
             Region region = regions.remove(0);
-            editSession.enableQueue();
-            /*
-            try {
-                editSession.setBlocks(region, GLASS);
-                editSession.flushQueue();
-            } catch (MaxChangedBlocksException e) {
-                plugin.getLogger().log(Level.WARNING, "Unable to clear region " + region);
+
+            for (int x = region.getMinimumPoint().getBlockX(); x <= region.getMaximumPoint().getBlockX(); ++x) {
+                for (int y = region.getMinimumPoint().getBlockY(); y <= region.getMaximumPoint().getBlockY(); ++y) {
+                    for (int z = region.getMinimumPoint().getBlockZ(); z <= region.getMaximumPoint().getBlockZ(); ++z) {
+                        world.getBlockAt(x, y, x).setTypeIdAndData(0, (byte) 0, false);
+                    }
+                }
             }
-            */
-            bukkitWorld.regenerate(region, editSession);
-            editSession.flushQueue();
-            editSession.commit();
         }
         return isComplete();
     }

--- a/src/main/java/us/talabrek/ultimateskyblock/handler/worldedit/WorldEdit558Adaptor.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/handler/worldedit/WorldEdit558Adaptor.java
@@ -21,7 +21,7 @@ public class WorldEdit558Adaptor implements WorldEditAdaptor {
         this.worldEditPlugin = worldEditPlugin;
     }
     @Override
-    public boolean loadIslandSchematic(Player player, World world, File file, Location origin) {
+    public boolean loadIslandSchematic(World world, File file, Location origin) {
         return false;
     }
 }

--- a/src/main/java/us/talabrek/ultimateskyblock/handler/worldedit/WorldEdit6Adaptor.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/handler/worldedit/WorldEdit6Adaptor.java
@@ -1,11 +1,9 @@
 package us.talabrek.ultimateskyblock.handler.worldedit;
 
 import com.sk89q.worldedit.EditSession;
-import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
-import com.sk89q.worldedit.bukkit.BukkitPlayer;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
@@ -15,12 +13,6 @@ import com.sk89q.worldedit.function.operation.Operation;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.world.registry.WorldData;
-import org.bukkit.Location;
-import org.bukkit.World;
-import org.bukkit.entity.Player;
-import us.talabrek.ultimateskyblock.Settings;
-import us.talabrek.ultimateskyblock.uSkyBlock;
-
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -28,6 +20,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.bukkit.Location;
+import org.bukkit.World;
+import us.talabrek.ultimateskyblock.Settings;
+import us.talabrek.ultimateskyblock.uSkyBlock;
 
 /**
  * The World Edit 6.0 specific adaptations
@@ -45,11 +41,9 @@ public class WorldEdit6Adaptor implements WorldEditAdaptor {
     }
 
     @Override
-    public boolean loadIslandSchematic(Player player, World world, File file, Location origin) {
-        log.finer("Trying to load schematic " + file + " for " + player);
+    public boolean loadIslandSchematic(World world, File file, Location origin) {
+        log.finer("Trying to load schematic " + file);
         WorldEdit worldEdit = worldEditPlugin.getWorldEdit();
-        BukkitPlayer wePlayer = worldEditPlugin.wrapPlayer(player);
-        LocalSession session = worldEdit.getSession(wePlayer);
         try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
             BukkitWorld bukkitWorld = new BukkitWorld(world);
             ClipboardReader reader = ClipboardFormat.SCHEMATIC.getReader(in);
@@ -57,9 +51,8 @@ public class WorldEdit6Adaptor implements WorldEditAdaptor {
             WorldData worldData = bukkitWorld.getWorldData();
             Clipboard clipboard = reader.read(worldData);
             ClipboardHolder holder = new ClipboardHolder(clipboard, worldData);
-            session.setClipboard(holder);
 
-            EditSession editSession = new EditSession(bukkitWorld, 255 * Settings.island_protectionRange * Settings.island_protectionRange);
+            EditSession editSession = worldEdit.getEditSessionFactory().getEditSession(bukkitWorld, 255 * Settings.island_protectionRange * Settings.island_protectionRange);
             editSession.enableQueue();
             editSession.setFastMode(true);
             Vector to = new Vector(origin.getBlockX(), origin.getBlockY(), origin.getBlockZ());
@@ -72,7 +65,7 @@ public class WorldEdit6Adaptor implements WorldEditAdaptor {
             editSession.flushQueue();
             editSession.commit();
             return true;
-        } catch (IOException |WorldEditException e) {
+        } catch (IOException | WorldEditException e) {
             uSkyBlock.log(Level.WARNING, "Unable to load schematic " + file, e);
         }
         return false;

--- a/src/main/java/us/talabrek/ultimateskyblock/handler/worldedit/WorldEditAdaptor.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/handler/worldedit/WorldEditAdaptor.java
@@ -25,7 +25,7 @@ public interface WorldEditAdaptor {
      * Returns <code>true</code> if successful.
      * @return <code>true</code> if successful.
      */
-    boolean loadIslandSchematic(Player player, final World world, final File file, final Location origin);
+    boolean loadIslandSchematic(World world, File file, Location origin);
 
     public static class Factory {
         private static final Logger log = Logger.getLogger(Factory.class.getName());

--- a/src/main/java/us/talabrek/ultimateskyblock/island/IslandGenerator.java
+++ b/src/main/java/us/talabrek/ultimateskyblock/island/IslandGenerator.java
@@ -1,9 +1,9 @@
 package us.talabrek.ultimateskyblock.island;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.logging.Logger;
 import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -15,6 +15,7 @@ import org.bukkit.inventory.ItemStack;
 import us.talabrek.ultimateskyblock.Settings;
 import us.talabrek.ultimateskyblock.handler.VaultHandler;
 import us.talabrek.ultimateskyblock.handler.WorldEditHandler;
+import us.talabrek.ultimateskyblock.player.PlayerInfo;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 import us.talabrek.ultimateskyblock.util.ItemStackUtil;
 
@@ -42,9 +43,77 @@ public class IslandGenerator {
         }
     }
 
-    public void createIsland(uSkyBlock plugin, Player player, Location next) {
-        log.entering(CN, "createIsland", new Object[]{plugin, player, next});
-        log.fine("creating island for " + player + " at " + next);
+    public class PlayerIslandCreationData {
+        private final PlayerInfo playerInfo;
+        private HashSet<String> allowAccessSchematics = new HashSet<String>();
+        private HashSet<String> allowedExtraItemPermissions = new HashSet<String>();
+        private HashSet<String> allowedBiomePermissions = new HashSet<String>();
+
+        public PlayerIslandCreationData(PlayerInfo playerInfo) {
+            this.playerInfo = playerInfo;
+        }
+
+        public PlayerInfo getPlayerInfo() {
+            return this.playerInfo;
+        }
+
+        protected void allowSchematicPermission(String schematic) {
+            this.allowAccessSchematics.add(schematic);
+        }
+
+        protected boolean hasSchematicPermission(String schematic) {
+            return this.allowAccessSchematics.contains(schematic);
+        }
+
+        protected void allowExtraItemPermission(String permission) {
+            this.allowedExtraItemPermissions.add(permission);
+        }
+
+        protected boolean hasExtraItemPermission(String permission) {
+            return this.allowedExtraItemPermissions.contains(permission);
+        }
+
+        protected void allowBiomePermission(String permission) {
+            this.allowedBiomePermissions.add(permission);
+        }
+
+        public boolean hasBiomePermission(String permission) {
+            return this.allowedBiomePermissions.contains(permission);
+        }
+    }
+
+    public PlayerIslandCreationData preCreateData(Player player, PlayerInfo playerInfo) {
+        PlayerIslandCreationData playerIslandCreationData = new PlayerIslandCreationData(playerInfo);
+
+        for (File schemFile : schemFiles) {
+            // First run-through - try to set the island the player has permission for.
+            String cSchem = schemFile.getName();
+            if (cSchem.lastIndexOf('.') > 0) {
+                cSchem = cSchem.substring(0, cSchem.lastIndexOf('.'));
+            }
+            if (VaultHandler.checkPerk(player.getName(), "usb.schematic." + cSchem, uSkyBlock.skyBlockWorld)) {
+                playerIslandCreationData.allowSchematicPermission(cSchem);
+            }
+        }
+
+        for (String perm : Settings.island_extraPermissions) {
+            if (VaultHandler.checkPerk(player.getName(), "usb." + perm, uSkyBlock.skyBlockWorld)) {
+                playerIslandCreationData.allowExtraItemPermission(perm);
+            }
+        }
+
+        for (String biome : uSkyBlock.getInstance().getValidBiomes().keySet()) {
+            if (VaultHandler.checkPerk(player.getName(), "usb.biome." + biome, uSkyBlock.skyBlockWorld)) {
+                playerIslandCreationData.allowBiomePermission(biome);
+            }
+        }
+
+        return playerIslandCreationData;
+    }
+
+    public void createIsland(uSkyBlock plugin, PlayerIslandCreationData playerIslandCreationData, Location next) {
+        log.entering(CN, "createIsland", new Object[]{plugin, playerIslandCreationData.getPlayerInfo().getPlayerName(), next});
+        log.fine("creating island for " + playerIslandCreationData.getPlayerInfo().getPlayerName() + " at " + next);
         boolean hasIslandNow = false;
         if (schemFiles.length > 0 && Bukkit.getServer().getPluginManager().isPluginEnabled("WorldEdit")) {
             for (File schemFile : schemFiles) {
@@ -53,9 +122,9 @@ public class IslandGenerator {
                 if (cSchem.lastIndexOf('.') > 0) {
                     cSchem = cSchem.substring(0, cSchem.lastIndexOf('.'));
                 }
-                if (VaultHandler.checkPerk(player.getName(), "usb.schematic." + cSchem, uSkyBlock.skyBlockWorld)
-                        && WorldEditHandler.loadIslandSchematic(player, uSkyBlock.skyBlockWorld, schemFile, next)) {
-                    setChest(next, player);
+                if (playerIslandCreationData.hasSchematicPermission(cSchem)
+                        && WorldEditHandler.loadIslandSchematic(uSkyBlock.skyBlockWorld, schemFile, next)) {
+                    setChest(next, playerIslandCreationData);
                     hasIslandNow = true;
                     log.fine("chose schematic " + cSchem + " due to permission.");
                     break;
@@ -69,8 +138,8 @@ public class IslandGenerator {
                         cSchem = cSchem.substring(0, cSchem.lastIndexOf('.'));
                     }
                     if (cSchem.equalsIgnoreCase(Settings.island_schematicName)
-                            && WorldEditHandler.loadIslandSchematic(player, uSkyBlock.skyBlockWorld, schemFile, next)) {
-                        setChest(next, player);
+                            && WorldEditHandler.loadIslandSchematic(uSkyBlock.skyBlockWorld, schemFile, next)) {
+                        setChest(next, playerIslandCreationData);
                         hasIslandNow = true;
                         log.fine("chose schematic " + cSchem);
                         break;
@@ -81,10 +150,10 @@ public class IslandGenerator {
         if (!hasIslandNow) {
             if (!Settings.island_useOldIslands) {
                 log.fine("generating a uSkyBlock default island");
-                generateIslandBlocks(next.getBlockX(), next.getBlockZ(), player, uSkyBlock.skyBlockWorld);
+                generateIslandBlocks(next.getBlockX(), next.getBlockZ(), playerIslandCreationData, uSkyBlock.skyBlockWorld);
             } else {
                 log.fine("generating a skySMP island");
-                oldGenerateIslandBlocks(next.getBlockX(), next.getBlockZ(), player, uSkyBlock.skyBlockWorld);
+                oldGenerateIslandBlocks(next.getBlockX(), next.getBlockZ(), playerIslandCreationData, uSkyBlock.skyBlockWorld);
             }
             hasIslandNow = true;
         }
@@ -93,18 +162,18 @@ public class IslandGenerator {
         log.exiting(CN, "createIsland");
     }
 
-    public void generateIslandBlocks(final int x, final int z, final Player player, final World world) {
+    public void generateIslandBlocks(final int x, final int z, final PlayerIslandCreationData playerIslandCreationData, final World world) {
         final int y = Settings.island_height;
         final Block blockToChange = world.getBlockAt(x, y, z);
         blockToChange.setTypeIdAndData(7, (byte) 0, false);
-        this.islandLayer1(x, z, player, world);
-        this.islandLayer2(x, z, player, world);
-        this.islandLayer3(x, z, player, world);
-        this.islandLayer4(x, z, player, world);
-        this.islandExtras(x, z, player, world);
+        this.islandLayer1(x, z, world);
+        this.islandLayer2(x, z, world);
+        this.islandLayer3(x, z, world);
+        this.islandLayer4(x, z, world);
+        this.islandExtras(x, z, playerIslandCreationData, world);
     }
 
-    public void oldGenerateIslandBlocks(final int x, final int z, final Player player, final World world) {
+    public void oldGenerateIslandBlocks(final int x, final int z, final PlayerIslandCreationData playerIslandCreationData, final World world) {
         final int y = Settings.island_height;
         for (int x_operate = x; x_operate < x + 3; ++x_operate) {
             for (int y_operate = y; y_operate < y + 3; ++y_operate) {
@@ -145,10 +214,10 @@ public class IslandGenerator {
         blockToChange3.setTypeIdAndData(12, (byte) 0, false);
         blockToChange3 = world.getBlockAt(x + 2, y + 1, z + 3);
         blockToChange3.setTypeIdAndData(12, (byte) 0, false);
-        setChest(chest.getLocation(), player);
+        setChest(chest.getLocation(), playerIslandCreationData);
     }
 
-    private void islandLayer1(final int x, final int z, final Player player, final World world) {
+    private void islandLayer1(final int x, final int z, final World world) {
         int y = Settings.island_height + 4;
         for (int x_operate = x - 3; x_operate <= x + 3; ++x_operate) {
             for (int z_operate = z - 3; z_operate <= z + 3; ++z_operate) {
@@ -166,7 +235,7 @@ public class IslandGenerator {
         blockToChange2.setTypeIdAndData(0, (byte) 0, false);
     }
 
-    private void islandLayer2(final int x, final int z, final Player player, final World world) {
+    private void islandLayer2(final int x, final int z, final World world) {
         int y = Settings.island_height + 3;
         for (int x_operate = x - 2; x_operate <= x + 2; ++x_operate) {
             for (int z_operate = z - 2; z_operate <= z + 2; ++z_operate) {
@@ -186,7 +255,7 @@ public class IslandGenerator {
         blockToChange2.setTypeIdAndData(12, (byte) 0, false);
     }
 
-    private void islandLayer3(final int x, final int z, final Player player, final World world) {
+    private void islandLayer3(final int x, final int z, final World world) {
         int y = Settings.island_height + 2;
         for (int x_operate = x - 1; x_operate <= x + 1; ++x_operate) {
             for (int z_operate = z - 1; z_operate <= z + 1; ++z_operate) {
@@ -206,7 +275,7 @@ public class IslandGenerator {
         blockToChange2.setTypeIdAndData(12, (byte) 0, false);
     }
 
-    private void islandLayer4(final int x, final int z, final Player player, final World world) {
+    private void islandLayer4(final int x, final int z, final World world) {
         int y = Settings.island_height + 1;
         Block blockToChange = world.getBlockAt(x - 1, y, z);
         blockToChange.setTypeIdAndData(3, (byte) 0, false);
@@ -220,7 +289,7 @@ public class IslandGenerator {
         blockToChange.setTypeIdAndData(12, (byte) 0, false);
     }
 
-    private void islandExtras(final int x, final int z, final Player player, final World world) {
+    private void islandExtras(final int x, final int z, final PlayerIslandCreationData playerIslandCreationData, final World world) {
         int y = Settings.island_height;
         Block blockToChange = world.getBlockAt(x, y + 5, z);
         blockToChange.setTypeIdAndData(17, (byte) 0, false);
@@ -276,19 +345,19 @@ public class IslandGenerator {
         blockToChange = world.getBlockAt(x, y + 1, z);
         blockToChange.setTypeIdAndData(18, (byte) 0, false);
         blockToChange = world.getBlockAt(x, Settings.island_height + 5, z + 1);
-        blockToChange.setTypeIdAndData(54, (byte)3, false);
+        blockToChange.setTypeIdAndData(54, (byte) 3, false);
         final Chest chest = (Chest) blockToChange.getState();
-        setChest(chest.getLocation(), player);
+        setChest(chest.getLocation(), playerIslandCreationData);
     }
 
-    public void setChest(final Location loc, final Player player) {
+    public void setChest(final Location loc, final PlayerIslandCreationData playerIslandCreationData) {
         World world = loc.getWorld();
         for (int dx = 1; dx <= 30; dx++) {
             for (int dy = 1; dy <= 30; dy++) {
                 for (int dz = 1; dz <= 30; dz++) {
-                    int x = ((dx % 2) == 0) ? dx/2 : -dx/2;
-                    int y = ((dy % 2) == 0) ? dy/2 : -dy/2;
-                    int z = ((dz % 2) == 0) ? dz/2 : -dz/2;
+                    int x = ((dx % 2) == 0) ? dx / 2 : -dx / 2;
+                    int y = ((dy % 2) == 0) ? dy / 2 : -dy / 2;
+                    int z = ((dz % 2) == 0) ? dz / 2 : -dz / 2;
                     if (world.getBlockAt(loc.getBlockX() + x, loc.getBlockY() + y, loc.getBlockZ() + z).getTypeId() == 54) {
                         final Block blockToChange = world.getBlockAt(loc.getBlockX() + x, loc.getBlockY() + y, loc.getBlockZ() + z);
                         final Chest chest = (Chest) blockToChange.getState();
@@ -297,7 +366,7 @@ public class IslandGenerator {
                         inventory.setContents(Settings.island_chestItems);
                         if (Settings.island_addExtraItems) {
                             for (String perm : Settings.island_extraPermissions) {
-                                if (VaultHandler.checkPerk(player.getName(), "usb." + perm, world)) {
+                                if (playerIslandCreationData.hasExtraItemPermission(perm)) {
                                     String itemString = config.getString("options.island.extraPermissions." + perm);
                                     if (itemString == null || itemString.isEmpty()) {
                                         continue;


### PR DESCRIPTION
- Denies teleporting to the island home if the island is in the process
of generating/restarting.
- Denies teleporting to another island if the players island is
restarting.
- Optimizes the WorldEditRegenTask by manually setting the blocks.
- Removes a redundant list creation every time the chunk generator gets
the default populators.
- * MAJOR * Re-writes the island restart code to no longer require the
player to be online once the island has generated for the postRestart()
call, fixes all exceptions caused by the player logging out mid-island
restart. Also fixes an exploit due to the player logging out mid-restart
and their inventory not being cleared.
- Improves biome lookup/setting to check if it is a valid biome first.