### PR TITLE
Fix "top chef" challenge

### DIFF
--- a/uSkyBlock-Core/src/main/resources/challenges.yml
+++ b/uSkyBlock-Core/src/main/resources/challenges.yml
@@ -1095,14 +1095,14 @@ ranks:
           text: 2 diamond, 1 mooshroom
           items:
           - '264:2'
-          - '383:1 {EntityTag:{id:"Mooshroom"}}'
+          - '383:1 {EntityTag:{id:"MushroomCow"}}'
           currency: 80
           xp: 80
         repeatReward:
           text: 1 diamond, 1 mooshroom
           items:
           - '264:1'
-          - '383:1 {EntityTag:{id:"Mooshroom"}}'
+          - '383:1 {EntityTag:{id:"MushroomCow"}}'
           currency: 40
           xp: 40
 


### PR DESCRIPTION
This fixes this challenge. MushroomCow is the correct name.
It's 1.10 compatible, not sure about 1.8/.19