### PR TITLE
Add IslandLeaderChangedEvent, move event firing to seperate class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>Ultimate SkyBlock</name>
 
     <properties>
-        <api.version>2.7.4</api.version>
+        <api.version>2.7.5</api.version>
         <bukkit-utils.version>1.23-SNAPSHOT</bukkit-utils.version>
         <po-utils.version>1.2</po-utils.version>
         <deluxechat.version>1.6</deluxechat.version>

--- a/uSkyBlock-API/pom.xml
+++ b/uSkyBlock-API/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.rlf</groupId>
     <artifactId>uSkyBlock-API</artifactId>
-    <version>2.7.4</version>
+    <version>2.7.5</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <travis.buildNumber>dev</travis.buildNumber>

--- a/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/event/IslandLeaderChangedEvent.java
+++ b/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/event/IslandLeaderChangedEvent.java
@@ -1,0 +1,45 @@
+package us.talabrek.ultimateskyblock.api.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import us.talabrek.ultimateskyblock.api.IslandInfo;
+import us.talabrek.ultimateskyblock.api.PlayerInfo;
+
+/**
+ * Fired on island leader change (e.g. when a leader uses /island makeleader). Async, not cancellable.
+ * @since 2.7.5
+ */
+public class IslandLeaderChangedEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+    private final IslandInfo islandInfo;
+    private final PlayerInfo originalLeaderInfo;
+    private final PlayerInfo newLeaderInfo;
+
+    public IslandLeaderChangedEvent(IslandInfo islandInfo, PlayerInfo originalLeaderInfo, PlayerInfo newLeaderInfo) {
+        super(true);
+        this.islandInfo = islandInfo;
+        this.originalLeaderInfo = originalLeaderInfo;
+        this.newLeaderInfo = newLeaderInfo;
+    }
+
+    public IslandInfo getIslandInfo() {
+        return islandInfo;
+    }
+
+    public PlayerInfo getOriginalLeaderInfo() {
+        return originalLeaderInfo;
+    }
+
+    public PlayerInfo getNewLeaderInfo() {
+        return newLeaderInfo;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/api/event/EventLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/api/event/EventLogic.java
@@ -1,0 +1,50 @@
+package us.talabrek.ultimateskyblock.api.event;
+
+import us.talabrek.ultimateskyblock.island.IslandInfo;
+import us.talabrek.ultimateskyblock.player.PlayerInfo;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+
+public class EventLogic {
+    private final uSkyBlock plugin;
+
+    public EventLogic(uSkyBlock plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Fires a new async {@link IslandLeaderChangedEvent}.
+     *
+     * @param islandInfo {@link IslandInfo} for the island in the scope of this event.
+     * @param originalLeaderInfo {@link PlayerInfo} for the original island leader.
+     * @param newLeaderInfo {@link PlayerInfo} for the new island leader.
+     */
+    public void fireIslandLeaderChangedEvent(us.talabrek.ultimateskyblock.api.IslandInfo islandInfo,
+                                             us.talabrek.ultimateskyblock.api.PlayerInfo originalLeaderInfo,
+                                             us.talabrek.ultimateskyblock.api.PlayerInfo newLeaderInfo) {
+        plugin.async(() -> plugin.getServer().getPluginManager().callEvent(new IslandLeaderChangedEvent(islandInfo, originalLeaderInfo, newLeaderInfo)));
+    }
+
+    /**
+     * Fires a new async {@link MemberJoinedEvent}.
+     *
+     * @param islandInfo {@link IslandInfo} for the island that the member joined.
+     * @param playerInfo {@link PlayerInfo} for the joined member.
+     */
+    public void fireMemberJoinedEvent(us.talabrek.ultimateskyblock.island.IslandInfo islandInfo, us.talabrek.ultimateskyblock.player.PlayerInfo playerInfo) {
+        plugin.async(() -> plugin.getServer().getPluginManager().callEvent(new MemberJoinedEvent(islandInfo, playerInfo)));
+    }
+
+    /**
+     * Fires a new async {@link MemberLeftEvent}.
+     *
+     * @param islandInfo {@link IslandInfo} for the island that the member left.
+     * @param member {@link PlayerInfo} for the left member.
+     */
+    public void fireMemberLeftEvent(IslandInfo islandInfo, PlayerInfo member) {
+        plugin.async(() -> plugin.getServer().getPluginManager().callEvent(new MemberLeftEvent(islandInfo, member)));
+    }
+
+    public void shutdown() {
+        // Placeholder for now.
+    }
+}

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/MakeLeaderCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/MakeLeaderCommand.java
@@ -32,31 +32,32 @@ public class MakeLeaderCommand extends AbstractCommand {
                 public void run() {
                     String islandPlayerName = args[0];
                     String playerName = args[1];
-                    PlayerInfo islandPlayer = plugin.getPlayerInfo(islandPlayerName);
-                    PlayerInfo playerInfo = plugin.getPlayerInfo(playerName);
+                    PlayerInfo currentLeader = plugin.getPlayerInfo(islandPlayerName);
+                    PlayerInfo newLeader = plugin.getPlayerInfo(playerName);
 
-                    if (islandPlayer == null || !islandPlayer.getHasIsland()) {
+                    if (currentLeader == null || !currentLeader.getHasIsland()) {
                         sender.sendMessage(I18nUtil.tr("\u00a74Player {0} has no island to transfer!", islandPlayerName));
                         return;
                     }
-                    IslandInfo islandInfo = plugin.getIslandInfo(islandPlayer);
+                    IslandInfo islandInfo = plugin.getIslandInfo(currentLeader);
                     if (islandInfo == null) {
                         sender.sendMessage(I18nUtil.tr("\u00a74Player {0} has no island to transfer!", islandPlayerName));
                         return;
                     }
-                    if (playerInfo != null && playerInfo.getHasIsland() && !playerInfo.locationForParty().equals(islandInfo.getName())) {
+                    if (newLeader != null && newLeader.getHasIsland() && !newLeader.locationForParty().equals(islandInfo.getName())) {
                         sender.sendMessage(I18nUtil.tr("\u00a7ePlayer \u00a7d{0}\u00a7e already has an island.\u00a7eUse \u00a7d/usb island remove <name>\u00a7e to remove him first.", playerName));
                         return;
                     }
-                    playerInfo.setJoinParty(islandInfo.getIslandLocation());
-                    Location homeLocation = islandPlayer.getHomeLocation();
-                    islandInfo.removeMember(islandPlayer); // Remove leader
-                    islandInfo.setupPartyLeader(playerInfo.getPlayerName()); // Promote member
-                    islandInfo.addMember(islandPlayer);
-                    playerInfo.setHomeLocation(homeLocation);
-                    islandPlayer.save();
-                    playerInfo.save();
+                    newLeader.setJoinParty(islandInfo.getIslandLocation());
+                    Location homeLocation = currentLeader.getHomeLocation();
+                    islandInfo.removeMember(currentLeader); // Remove leader
+                    islandInfo.setupPartyLeader(newLeader.getPlayerName()); // Promote member
+                    islandInfo.addMember(currentLeader);
+                    newLeader.setHomeLocation(homeLocation);
+                    currentLeader.save();
+                    newLeader.save();
                     WorldGuardHandler.updateRegion(islandInfo);
+                    plugin.getEventLogic().fireIslandLeaderChangedEvent(islandInfo, currentLeader, newLeader);
                     islandInfo.sendMessageToIslandGroup(true, marktr("\u00a7bLeadership transferred by {0}\u00a7b to {1}"), sender.getName(), playerName);
                 }
             });

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/MakeLeaderCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/MakeLeaderCommand.java
@@ -17,26 +17,28 @@ public class MakeLeaderCommand extends RequireIslandCommand {
     }
 
     @Override
-    protected boolean doExecute(String alias, Player player, PlayerInfo pi, IslandInfo island, Map<String, Object> data, String... args) {
+    protected boolean doExecute(String alias, Player player, PlayerInfo currentLeader, IslandInfo island, Map<String, Object> data, String... args) {
         if (args.length == 1) {
-            String member = args[0];
-            if (!island.getMembers().contains(member)) {
+            String newLeader = args[0];
+            if (!island.getMembers().contains(newLeader)) {
                 player.sendMessage(tr("\u00a74You can only transfer ownership to party-members!"));
                 return true;
             }
-            if (island.getLeader().equals(member)) {
-                player.sendMessage(tr("{0}\u00a7e is already leader of your island!", member));
+            if (island.getLeader().equals(newLeader)) {
+                player.sendMessage(tr("{0}\u00a7e is already leader of your island!", newLeader));
                 return true;
             }
             if (!island.isLeader(player)) {
                 player.sendMessage(tr("\u00a74Only leader can transfer leadership!"));
-                island.sendMessageToIslandGroup(true, marktr("{0} tried to take over the island!"), member);
+                island.sendMessageToIslandGroup(true, marktr("{0} tried to take over the island!"), newLeader);
                 return true;
             }
-            island.setupPartyLeader(member); // Promote member
-            island.setupPartyMember(pi); // Demote leader
+            island.setupPartyLeader(newLeader); // Promote member
+            island.setupPartyMember(currentLeader); // Demote leader
             WorldGuardHandler.updateRegion(island);
-            island.sendMessageToIslandGroup(true, tr("\u00a7bLeadership transferred by {0}\u00a7b to {1}", player.getDisplayName(), member));
+            PlayerInfo newLeaderInfo = uSkyBlock.getInstance().getPlayerInfo(newLeader);
+            uSkyBlock.getInstance().getEventLogic().fireIslandLeaderChangedEvent(island, currentLeader, newLeaderInfo);
+            island.sendMessageToIslandGroup(true, tr("\u00a7bLeadership transferred by {0}\u00a7b to {1}", player.getDisplayName(), newLeader));
             return true;
         }
         return false;

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/IslandInfo.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/IslandInfo.java
@@ -145,7 +145,7 @@ public class IslandInfo implements us.talabrek.ultimateskyblock.api.IslandInfo {
     public void addMember(final PlayerInfo playerInfo) {
         playerInfo.setJoinParty(getIslandLocation());
         setupPartyMember(playerInfo);
-        uSkyBlock.getInstance().fireMemberJoinedEvent(this, playerInfo);
+        uSkyBlock.getInstance().getEventLogic().fireMemberJoinedEvent(this, playerInfo);
     }
 
     public void setupPartyMember(final PlayerInfo member) {
@@ -653,7 +653,7 @@ public class IslandInfo implements us.talabrek.ultimateskyblock.api.IslandInfo {
 
         sendMessageToIslandGroup(true, marktr("\u00a7b{0}\u00a7d has been removed from the island group."), member.getPlayerName());
         WorldGuardHandler.updateRegion(this);
-        uSkyBlock.getInstance().fireMemberLeftEvent(this, member);
+        uSkyBlock.getInstance().getEventLogic().fireMemberLeftEvent(this, member);
         save();
     }
 

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
@@ -38,6 +38,7 @@ import org.bukkit.scheduler.BukkitTask;
 import us.talabrek.ultimateskyblock.api.IslandLevel;
 import us.talabrek.ultimateskyblock.api.IslandRank;
 import us.talabrek.ultimateskyblock.api.async.Callback;
+import us.talabrek.ultimateskyblock.api.event.EventLogic;
 import us.talabrek.ultimateskyblock.api.event.MemberJoinedEvent;
 import us.talabrek.ultimateskyblock.api.event.MemberLeftEvent;
 import us.talabrek.ultimateskyblock.api.event.uSkyBlockEvent;
@@ -139,6 +140,7 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
     private SkyBlockMenu menu;
     private ConfigMenu configMenu;
     private ChallengeLogic challengeLogic;
+    private EventLogic eventLogic;
     private LevelLogic levelLogic;
     private IslandLogic islandLogic;
     private OrphanLogic orphanLogic;
@@ -195,6 +197,7 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
             animationHandler.stop();
         }
         challengeLogic.shutdown();
+        eventLogic.shutdown();
         playerLogic.shutdown();
         islandLogic.shutdown();
         playerDB.shutdown(); // Must be before playerNameChangeManager!!
@@ -1001,6 +1004,7 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
         }
 
         getServer().getPluginManager().registerEvents(playerDB, this);
+        eventLogic = new EventLogic(this);
         teleportLogic = new TeleportLogic(this);
         PlayerUtil.loadConfig(playerDB, getConfig());
         islandGenerator = new IslandGenerator(getDataFolder(), getConfig());
@@ -1309,6 +1313,10 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
         return cooldownHandler;
     }
 
+    public EventLogic getEventLogic() {
+        return eventLogic;
+    }
+
     public PlayerLogic getPlayerLogic() {
         return playerLogic;
     }
@@ -1389,17 +1397,5 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
         for (String cmd : cmdList) {
             execCommand(player, cmd, false);
         }
-    }
-
-    public void fireMemberJoinedEvent(IslandInfo islandInfo, PlayerInfo playerInfo) {
-        async(() -> {
-            getServer().getPluginManager().callEvent(new MemberJoinedEvent(islandInfo, playerInfo));
-        });
-    }
-
-    public void fireMemberLeftEvent(IslandInfo islandInfo, PlayerInfo member) {
-        async(() -> {
-            getServer().getPluginManager().callEvent(new MemberLeftEvent(islandInfo, member));
-        });
     }
 }


### PR DESCRIPTION
Closes #1088. Bumps the API version to 2.7.5 to introduce a new event.

Adds the requested event for now, I'm thinking of some other refactoring around this code, but that's a todo for later, just like the rest of refactoring. Should at least satisfy the user requesting this feature. 

When trying to build, see: https://github.com/rlf/uSkyBlock/issues/1131
Simple plugin to test this event: https://github.com/Muspah/USBTestListener

Trying to prevent getting lots of logic-classes in main class, but that's something to refactor later, as mentioned.