### PR TITLE
 Fix french translation

### DIFF
--- a/uSkyBlock-Core/src/main/po/fr.po
+++ b/uSkyBlock-Core/src/main/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2.4\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2016-07-16 14:05+0100\n"
+"PO-Revision-Date: 2019-02-18 11:50+0100\n"
 "Last-Translator: Wura <wura59@gmail.com>\n"
 "Language-Team: Wura <wura59@gmail.com>\n"
 "Language: fr\n"
@@ -12,13 +12,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Loco-Source-Locale: fr_FR\n"
-"X-Generator: Poedit 1.8.8\n"
+"X-Generator: Poedit 2.2.1\n"
 "X-Loco-Parser: loco_parse_po\n"
 "X-Loco-Target-Locale: fr_FR\n"
 
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
-msgstr ""
+msgstr "§eVous n''y avez pas accès (§4{0}§e)"
 
 #, java-format
 msgid "§eInvalid command: {0}"
@@ -82,7 +82,7 @@ msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
 
 #, java-format
 msgid " §f{0}x §7{1}"
-msgstr ""
+msgstr " §f{0}x §7{1}"
 
 #, java-format
 msgid "§eStill the following blocks short: {0}"
@@ -181,11 +181,11 @@ msgstr "§4{0}"
 #, java-format
 msgid "§4You must be standing within {0} blocks of all required items."
 msgstr ""
-"§4Vous devez êtres dans les alentours de {0} blocks de tout les items requis"
+"§4Vous devez êtres dans les alentours de {0} blocks de tout les items requis."
 
 #, java-format
 msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4Votre ile doit être niveau {0} pour compléter ce challenge"
+msgstr "§4Votre ile doit être niveau {0} pour compléter ce challenge !"
 
 #, java-format
 msgid "§4Unknown type of challenge: {0}"
@@ -231,7 +231,7 @@ msgid "§eYour inventory is §4full§e. Items dropped on the ground."
 msgstr "§eVotre invetaire est §4complet§e. Les items ont étés droppés au sol."
 
 msgid "§e§lClick to complete this challenge."
-msgstr "§e§lClique ici pour compléter le challenge."
+msgstr "§e§lCliquez ici pour compléter le challenge."
 
 msgid "§4§lYou can't repeat this challenge."
 msgstr "§4§lVous ne pouvez refaire le challenge."
@@ -247,10 +247,10 @@ msgid "§fthis rank to unlock the next rank."
 msgstr "§fce rang pour débloquer le rang suivant."
 
 msgid "§eClick here to show previous page"
-msgstr "§eClique ici pour voir la page précédente"
+msgstr "§eCliquez ici pour voir la page précédente"
 
 msgid "§eClick here to show next page"
-msgstr "§eClique ici pour voir la page suivante"
+msgstr "§eCliquez ici pour voir la page suivante"
 
 msgid "§4§lLocked Challenge"
 msgstr "§4§4Challenge vérouillé"
@@ -283,8 +283,7 @@ msgid "§cSorry! {0}"
 msgstr "§cDésolé ! {0}"
 
 msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr ""
-"Envoyez directement un message à votre groupe, ou désactiver/activer le."
+msgstr "Envoyez directement un message à votre groupe, ou désactiver/activer le."
 
 msgid "party"
 msgstr "groupe"
@@ -298,7 +297,7 @@ msgstr "§cChat activé pour {0}"
 
 #, java-format
 msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§cRépète §9{0}§c pour le désactiver"
+msgstr "§cRépétez §9{0}§c pour le désactiver"
 
 #, java-format
 msgid "§aToggled chat §cOFF§a for {0}"
@@ -342,7 +341,7 @@ msgid "§e{0} has had all challenges reset."
 msgstr "§e{0} a eu tous les challenges réinitialisés."
 
 msgid "complete all challenges in the rank"
-msgstr "Compléte tout les challenges dans le rang"
+msgstr "compléte tout les challenges dans le rang"
 
 #, java-format
 msgid "§4No player named {0} was found!"
@@ -398,9 +397,8 @@ msgid "§4No player named {0} found!"
 msgstr "§4Aucun joueur nommé {0} trouvé !"
 
 msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr "§4Aucune île fournie , essayez de fournir un nom d'île."
+"§4No valid island provided, either stand within one, or provide an island name"
+msgstr "§4Aucune île fournie , essayez de fournir un nom d'île"
 
 msgid "print out info about the island"
 msgstr "afficher les informations à propos de l'île"
@@ -409,7 +407,7 @@ msgid "sets the biome of the island"
 msgstr "définir le biome de l'île"
 
 msgid "§4That player has no island."
-msgstr "§4Ce joueur n'a pas d'île"
+msgstr "§4Ce joueur n'a pas d'île."
 
 msgid "§4No valid island at your location"
 msgstr "§4Ile invalide à votre position"
@@ -418,14 +416,14 @@ msgid "purges the island"
 msgstr "nettoyer l'île"
 
 msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Erreur ! §9Ile invalide à nettoyer"
+msgstr "§4Erreur ! §9Aucune île valide à nettoyer."
 
 #, java-format
 msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cNettoyé : §9Ile nettoyé à {0}"
+msgstr "§cNettoyage : §9Ile nettoyé à {0}"
 
 msgid "toggles the islands ignore status"
-msgstr "activer "
+msgstr "activer"
 
 #, java-format
 msgid "§cSet {0}s island to be ignored on top-ten and purge."
@@ -433,11 +431,10 @@ msgstr "§cMettre l''île de {0} à ignorer sur le top dix et la nettoyer."
 
 #, java-format
 msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and purge."
 msgstr ""
-"§cRetirer le flag ignoré de l''île de {0}, elle apparaitra maintenant sur le "
-"top dix et le nettoyage"
+"§cRetirer le flag ignoré de l''île de {0}, elle apparaitra maintenant sur le top "
+"dix et le nettoyage."
 
 msgid "§4No valid player-name supplied."
 msgstr "§4Aucun pseudo valide fourni."
@@ -456,8 +453,7 @@ msgstr "§eLe biome de l''île de {0} a été changé en OCEAN."
 
 msgid "§aYou may need to go to spawn, or relog, to see the changes."
 msgstr ""
-"§aVous avez besoin d'aller au spawn, ou se reconnecter, pour voir les "
-"changements."
+"§aVous avez besoin d'aller au spawn, ou se reconnecter, pour voir les changements."
 
 #, java-format
 msgid "§e{0} has had their biome changed to {1}."
@@ -469,10 +465,10 @@ msgstr "§e{0} a eu son biome changé en OCEAN."
 
 #, java-format
 msgid "§eRemoving {0}''s island."
-msgstr "§eL''île de {0} a été retiré"
+msgstr "§eL''île de {0} a été retiré."
 
 msgid "Error: That player does not have an island!"
-msgstr "Erreur : Ce joueur n'a pas d'île"
+msgstr "Erreur : Ce joueur n'a pas d'île !"
 
 #, java-format
 msgid "§e{0}s island at {1} has been protected"
@@ -610,7 +606,7 @@ msgid "flush current content of the logger to file."
 msgstr "contenu actuel dans le fichier logger."
 
 msgid "§eLog-file has been flushed."
-msgstr "§eLe fichier log a été néttoyé"
+msgstr "§eLe fichier log a été néttoyé."
 
 msgid "§4Logging is not enabled, use §d/usb debug enable"
 msgstr "§4Le logging est désactivé, utilise §d/usb debug enable"
@@ -619,7 +615,7 @@ msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
 msgstr "§4Argument invalide , essayez INFO,FINE,FINER,FINEST"
 
 msgid "§eLogging disabled!"
-msgstr "§eLogging désactivé"
+msgstr "§eLogging désactivé !"
 
 msgid "tries to fix the the area of flatland."
 msgstr "tenter de fixer le domaine de la plaine."
@@ -635,18 +631,17 @@ msgid "flushes all caches to files"
 msgstr "débusquer tout les fichiers cachés"
 
 #, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgid "§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
 msgstr "§eDébusqué §a{0} îles§e, §b{1} joueurs et §6{2} challenges complétés."
 
 msgid "manually update the top 10 list"
-msgstr "rafraishir manuellement le top 10 !"
+msgstr "rafraishir manuellement le top 10"
 
 msgid "§eGenerating the Top Ten list"
 msgstr "§eGénération de la top liste"
 
 msgid "§eFinished generation of the Top Ten list"
-msgstr "§eGénération de la top liste terminée !"
+msgstr "§eGénération du top 10 terminée"
 
 msgid "advanced command for getting island-data"
 msgstr "commandes avancées pour obtenir les données de l'île"
@@ -739,11 +734,11 @@ msgstr "§4Le joueur {0} n'a pas d'île à transférer !"
 
 #, java-format
 msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e to "
+"remove him first."
 msgstr ""
-"§eLe joueur §d{0}§e a déjà une île.§e Utilise §d/usb island remove <nom>§e "
-"pour là supprimer en premier."
+"§eLe joueur §d{0}§e a déjà une île.§e Utilise §d/usb island remove <nom>§e pour là "
+"supprimer en premier."
 
 #, java-format
 msgid "§bLeadership transferred by {0}§b to {1}"
@@ -795,7 +790,7 @@ msgstr "compter les orphans"
 
 #, java-format
 msgid "§e{0} old island locations will be used before new ones."
-msgstr "§eL'ancien emplacement de l'île {0} seront utilisés avec les nouveaux"
+msgstr "§eLes anciens emplacements de l''île {0} seront utilisés avant les nouveaux."
 
 msgid "clear orphans"
 msgstr "supprimer des orphans"
@@ -830,16 +825,15 @@ msgid "§cTrying to abort protect-all task."
 msgstr "§cEssayer d'annuler toutes les tâches de protection."
 
 msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use §9usb "
+"protectall §cstop"
 msgstr ""
-"§4Désolé !§e Une protection total est déjà en cours. Laissez le se terminer, "
-"ou utilisez §9usb protectall §cstop"
+"§4Désolé !§e Une protection total est déjà en cours. Laissez le se terminer, ou "
+"utilisez §9usb protectall §cstop"
 
 msgid "§eStarting a protect-all task. It will take a while."
 msgstr ""
-"§eDémarrage d'une protection complète. Cela risque de prendre un certain "
-"temps."
+"§eDémarrage d'une protection complète. Cela risque de prendre un certain temps."
 
 msgid "purges all abandoned islands"
 msgstr "nettoyer toutes les îles abandonnés"
@@ -852,8 +846,8 @@ msgstr ""
 
 #, java-format
 msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
+"§eFinding all islands that have been abandoned for more than {0} days below level "
+"{1}"
 msgstr ""
 
 #, java-format
@@ -944,8 +938,7 @@ msgstr "§cImpossible de modifier le champs {0} en \"{1}\""
 
 #, java-format
 msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr ""
-"§cImpossible de modifier le champs {0} en \"{1}\", un nombre est attendu"
+msgstr "§cImpossible de modifier le champs {0} en \"{1}\", un nombre est attendu"
 
 #, java-format
 msgid "§cInvalid field {0}"
@@ -956,11 +949,9 @@ msgstr "activer/désactiver le mode maintenance"
 
 msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
 msgstr ""
-"§cMAINTENANCE: §aActivée§e Toutes les fonctionnalités du skyblock sont "
-"désactivés."
+"§cMAINTENANCE: §aActivée§e Toutes les fonctionnalités du skyblock sont désactivés."
 
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgid "§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
 msgstr ""
 "§cMAINTENANCE: §4Désactivée§e Toutes les fonctionnalités du skyblock sont de "
 "retour."
@@ -973,15 +964,14 @@ msgstr "§cINTERROMPU:§e La protection totale a été interrompu !"
 
 #, java-format
 msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr ""
-"§cProtection totale complété dans {0}, {1} nouvelles regions ont été crées. "
+msgstr "§cProtection totale complété dans {0}, {1} nouvelles régions ont été crées !"
 
 #, java-format
 msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
 msgstr "§7- Scan: {0,number,##}% ({1}/{2} échoués: {3}) ~ {4}"
 
 msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4PURGE:§9 Scan interrompu. "
+msgstr "§4PURGE :§9 Scan interrompu."
 
 #, java-format
 msgid ""
@@ -990,15 +980,14 @@ msgid ""
 msgstr ""
 
 #, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgid "- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
 msgstr ""
 
 msgid "§4PURGE:§9 Finished purging abandoned islands."
 msgstr "§4 NETTOYAGE: Finit , îles abandonnés nétoyés."
 
 msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4PURGE:§9 Purge annulée des îles abandonnées. "
+msgstr "§4PURGE :§9 Purge annulée des îles abandonnées."
 
 msgid "displays version information"
 msgstr "afficher les informations sur la version"
@@ -1052,19 +1041,17 @@ msgid "show information about the challenge"
 msgstr "voir les informations à propos du challenge"
 
 msgid "§eRank: "
-msgstr "§eRang :"
+msgstr "§eRang : "
 
 msgid "§4This Challenge is not repeatable!"
 msgstr "§4Ce challenge ne peut être refait !"
 
 msgid "§4You will lose all required items when you complete this challenge!"
 msgstr ""
-"§eVous perdrez tous les éléments nécessaires lorsque vous remplirez ce "
-"challenge !"
+"§eVous perdrez tous les éléments nécessaires lorsque vous remplirez ce challenge !"
 
 #, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
+msgid "§4All required items must be placed on your island, within {0} blocks of you."
 msgstr ""
 "§4Tous les élements requis doivent être placés sur votre île, dans {0} blocs "
 "autour de vous."
@@ -1083,19 +1070,17 @@ msgid "§eChallenges has been disabled. Contact an administrator."
 msgstr "§eChallenge désactivé. Contacte un administrateur."
 
 msgid "§4You can only submit challenges in the skyblock world!"
-msgstr ""
-"§4Vous pouvez compléter les challenges uniquement dans le mode du skyblock !"
+msgstr "§4Vous pouvez compléter les challenges uniquement dans le mode du skyblock !"
 
 msgid "§4You can only submit challenges when you have an island!"
-msgstr ""
-"§4Vous pouvez compléter les challenges uniquement quand vous avez une île !"
+msgstr "§4Vous pouvez compléter les challenges uniquement quand vous avez une île !"
 
 msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
+"§4Your island is full, or you have too many pending invites. You can't invite "
+"anyone else."
 msgstr ""
-"§4Votre île est pleine, ou vous avez trop d'invitations en attente. Vous ne "
-"pouvez pas inviter quelqu'un d'autre."
+"§4Votre île est pleine, ou vous avez trop d'invitations en attente. Vous ne pouvez "
+"pas inviter quelqu'un d'autre."
 
 msgid "§4That player is already leader on another island."
 msgstr "§4Ce joueur est déjà le chef d'une autre île."
@@ -1110,7 +1095,7 @@ msgstr ""
 
 #, java-format
 msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e vous invite à rejoindre son île"
+msgstr "{0}§e vous invite à rejoindre son île !"
 
 msgid "§f/island [accept/reject]§e to accept or reject the invite."
 msgstr "§f/island [accept/reject]§e pour accepter ou rejeter l'invitation."
@@ -1128,14 +1113,12 @@ msgstr "{0}§e a rejeté l'invitation."
 
 msgid "§4You can't use that command right now. Leave your current party first."
 msgstr ""
-"§4Vous ne pouvez pas utiliser cette commande en ce moment. Quittez votre "
-"premier groupe actuel."
+"§4Vous ne pouvez pas utiliser cette commande en ce moment. Quittez votre premier "
+"groupe actuel."
 
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
+msgid "§aYou have joined an island! Use /island party to see the other members."
 msgstr ""
-"§aVous avez rejoint une îe ! Utiliser /island party pour voir les autres "
-"membres."
+"§aVous avez rejoint une îe ! Utiliser /island party pour voir les autres membres."
 
 #, java-format
 msgid "§eInvitation for {0}§e has timedout or been cancelled."
@@ -1184,7 +1167,7 @@ msgstr "§eImpossible de ban ce joueur (joueur inconnu) {0}"
 
 #, java-format
 msgid "§4{0} tried to ban you from their island!"
-msgstr "§4{0} a essayé de vous bannir de leur île"
+msgstr "§4{0} a essayé de vous bannir de leur île !"
 
 #, java-format
 msgid "§4{0} is exempt from being banned."
@@ -1216,10 +1199,8 @@ msgstr ""
 msgid "Let the player change their islands biome to {0}"
 msgstr ""
 
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr ""
-"§cVous n'avez pas la permission pour changer le biome de l'île actuelle."
+msgid "§cYou do not have permission to change the biome of your current island."
+msgstr "§cVous n'avez pas la permission pour changer le biome de l'île actuelle."
 
 msgid "§4You do not have permission to change the biome of this island!"
 msgstr "§4Vous n'avez pas la permission pour changer le biome de l'île !"
@@ -1230,8 +1211,7 @@ msgstr "§eVous devez être sur votre île pour changer le biome !"
 #, java-format
 msgid "§cYou have misspelled the biome name. Must be one of {0}"
 msgstr ""
-"§cVous avez mal orthographié le nom du biome. Doit faire parti de cette "
-"liste : {0}"
+"§cVous avez mal orthographié le nom du biome. Doit faire parti de cette liste : {0}"
 
 #, java-format
 msgid "§eYou can change your biome again in {0,number,#} minutes."
@@ -1241,20 +1221,18 @@ msgid "§cYou do not have permission to change your biome to that type."
 msgstr "§cVous n'êtes pas autorisé à changer votre biome à ce type."
 
 #, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgid "§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
 msgstr ""
 
 #, java-format
 msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, be "
 "patient."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be patient."
 msgstr ""
 "§7Les pixels sont occupés à changer le biome de votre île en §9{0}§7, soyez "
 "patient."
@@ -1286,11 +1264,11 @@ msgid "exempt player from create-cooldown"
 msgstr ""
 
 msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
+"§4Island found!§e You already have an island. If you want a fresh island, type§b /"
+"is restart§e to get one"
 msgstr ""
-"§4Ile trouvé !§e Vous avez déjà une île. Si vous voulez une nouvelle île, "
-"tape§b /is restart§e pour en avoir une nouvelle"
+"§4Ile trouvé !§e Vous avez déjà une île. Si vous voulez une nouvelle île, tape§b /"
+"is restart§e pour en avoir une nouvelle"
 
 msgid ""
 "§4Island found!§e You are already a member of an island. To start your own, "
@@ -1305,8 +1283,7 @@ msgid "teleport to the island home"
 msgstr "téléporter au home de l'île"
 
 msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
+"§cYour island is in the process of generating, you cannot teleport home right now."
 msgstr "§cVotre île génére, vous ne pouvez vous téléporter maintenant."
 
 msgid "check your or another''s island info"
@@ -1328,7 +1305,7 @@ msgid "§4You do not have an island!"
 msgstr "§4Vous n'avez pas d'île !"
 
 msgid "§4You do not have access to that command!"
-msgstr "§4Vous n'avez pas accés à cette commande :"
+msgstr "§4Vous n'avez pas accès à cette commande !"
 
 msgid "§4That player is invalid or does not have an island!"
 msgstr "§4Joueur invalide ou le joueur n'a pas d'île !"
@@ -1351,8 +1328,7 @@ msgstr "§aLe niveau de votre île est {0,number,###.##}"
 msgid "invite a player to your island"
 msgstr "inviter un joueur sur votre île"
 
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgid "§eUse§f /island invite <playername>§e to invite a player to your island."
 msgstr ""
 "§eUtiliser§f /island invite <pseudo> §e pour inviter un joueur sur votre île."
 
@@ -1367,8 +1343,7 @@ msgid "§4You can't invite any more players."
 msgstr "§4Vous ne pouvez pas inviter plus de joueurs."
 
 msgid "§4You do not have permission to invite others to this island!"
-msgstr ""
-"§4Vous n'avez pas la permission pour inviter d'autres joueur sur l'île !"
+msgstr "§4Vous n'avez pas la permission pour inviter d'autres joueur sur l'île !"
 
 msgid "§4That player is offline or doesn't exist."
 msgstr "§4Ce joueur est hors-ligne ou n'éxiste pas."
@@ -1401,7 +1376,7 @@ msgstr "§4{0} a été retiré de l'île."
 
 #, java-format
 msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0} a essayé de vous kick de leur île."
+msgstr "§4{0} a essayé de vous kick de leur île !"
 
 #, java-format
 msgid "§4{0} is exempt from being kicked."
@@ -1425,13 +1400,12 @@ msgid ""
 "§4You can't leave your island if you are the only person. Try using /island "
 "restart if you want a new one!"
 msgstr ""
-"§4Vous ne pouvez pas quitter votre île quand vous êtes tout seul. Essayez /"
-"island restart si vous en voulez une nouvelle !"
+"§4Vous ne pouvez pas quitter votre île quand vous êtes tout seul. Essayez /island "
+"restart si vous en voulez une nouvelle !"
 
 msgid "§eYou own this island, use /island remove <player> instead."
 msgstr ""
-"§eVous êtes le propriétaire de l'île, utiliser /island remove <joueur> à la "
-"place."
+"§eVous êtes le propriétaire de l'île, utiliser /island remove <joueur> à la place."
 
 msgid "§eYou have left the island and returned to the player spawn."
 msgstr "§eVos avez quitté l'île et vous êtes retourné au spawn des joueurs."
@@ -1462,7 +1436,7 @@ msgid "§4Could not locate rank of {0}"
 msgstr ""
 
 msgid "lock your island to non-party members."
-msgstr "vérrouillé votre île aux non-membres de votre île"
+msgstr "vérrouiller votre île aux non-membres de votre île."
 
 msgid "§4You do not have permission to lock your island!"
 msgstr "§4Vous n'avez pas la permission pour vérrouillé votre île !"
@@ -1480,19 +1454,18 @@ msgid "transfer leadership to another member"
 msgstr "transférer le chef à un autre membre"
 
 msgid "§4You can only transfer ownership to party-members!"
-msgstr ""
-"§4Vous ne pouvez uniquement transférer le chef aux membres de votre île"
+msgstr "§4Vous ne pouvez uniquement transférer le chef aux membres de votre île !"
 
 #, java-format
 msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e est déjà le chef de l'île"
+msgstr "{0}§e est déjà le chef de l'île !"
 
 msgid "§4Only leader can transfer leadership!"
 msgstr "§4Seul le chef peut transférer le rang de chef !"
 
 #, java-format
 msgid "{0} tried to take over the island!"
-msgstr "{0} a essayé de prendre sur l'île"
+msgstr "{0} a essayé de reprendre l'île !"
 
 msgid "show the islands limits"
 msgstr ""
@@ -1557,32 +1530,29 @@ msgid "exempt player from restart-cooldown"
 msgstr ""
 
 msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
+"§4Only the owner may restart this island. Leave this island in order to start your "
+"own (/island leave)."
 msgstr ""
-"§4Uniquement le chef de l'île peut remettre à zéro l'île. Quitter l'île pour "
-"créer la votre (/island leave)."
+"§4Uniquement le chef de l'île peut remettre à zéro l'île. Quitter l'île pour créer "
+"la votre (/island leave)."
 
 msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
+"§eYou must remove all players from your island before you can restart it (/island "
+"kick <player>). See a list of players currently part of your island using /island "
+"party."
 msgstr ""
-"§eVous devez enlever tout les joueurs de votre île avant de le remettre à "
-"zéro (/island kick <joueur>. Pour voir les membres de votre île faites /"
-"island party."
+"§eVous devez enlever tout les joueurs de votre île avant de le remettre à zéro (/"
+"island kick <joueur>. Pour voir les membres de votre île faites /island party."
 
 #, java-format
 msgid "§cYou can restart your island in {0} seconds."
 msgstr "§cVous pouvez remettre à zéro votre île dans {0} secondes."
 
 msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr ""
-"§cVotre île est en génération, vous ne pouvez la remettre à zéro maintenant."
+msgstr "§cVotre île est en génération, vous ne pouvez la remettre à zéro maintenant."
 
 msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr ""
-"§eRAPPEL: La totalité de votre île et tous vos biens seront remis à zéro !"
+msgstr "§eRAPPEL: La totalité de votre île et tous vos biens seront remis à zéro !"
 
 msgid "set the island-home"
 msgstr "modifier le home de l'île"
@@ -1604,26 +1574,25 @@ msgid "teleports you to the skyblock spawn"
 msgstr "téléporter au spawn du skyblock"
 
 msgid "enable/disable warping to your island."
-msgstr "activer/désactiver le warp à votre île"
+msgstr "activer/désactiver le warp à votre île."
 
 msgid "§4Your island is locked. You must unlock it before enabling your warp."
 msgstr ""
-"§4Votre île est vérrouillé. Vous devez la dévérouilleé pour activer votre "
-"warp."
+"§4Votre île est vérrouillé. Vous devez la dévérouilleé pour activer votre warp."
 
 #, java-format
 msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d a activé le warp de l'île"
+msgstr "§b{0}§d a activé le warp de l'île."
 
 #, java-format
 msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d a désactivé le warp de l'île"
+msgstr "§b{0}§d a désactivé le warp de l'île."
 
 msgid "§cYou do not have permission to enable/disable your island''s warp!"
 msgstr ""
 
 msgid "display the top10 of islands"
-msgstr "afficher le top 10 des îles."
+msgstr "Afficher le top 10 des îles."
 
 msgid "enables user to all-ways generate top-ten (no caching)"
 msgstr ""
@@ -1638,8 +1607,7 @@ msgid "§eThe following leaders trusts you:"
 msgstr "§eLes chefs auxquels vous faites confiance:"
 
 msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr ""
-"§ePour ajouter/retirer des membres de confiances, /island trust <joueur>"
+msgstr "§ePour ajouter/retirer des membres de confiances, /island trust <joueur>"
 
 msgid "§4Members are already trusted!"
 msgstr "§4Membre déjà ajouté !"
@@ -1689,11 +1657,10 @@ msgid "§4You do not have permission to warp to other islands!"
 msgstr "§4You n'avez pas la permission utiliser le warp de d'autres îles !"
 
 msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
+"§cYour island is in the process of generating, you cannot warp to other players "
+"islands right now."
 msgstr ""
-"§cVotre île est en géneration, vous ne pouvez vous téléporter sur d'autres "
-"îles."
+"§cVotre île est en géneration, vous ne pouvez vous téléporter sur d'autres îles."
 
 msgid "§4That player does not exist!"
 msgstr "§4Ce joueur n'éxiste pas !"
@@ -1702,8 +1669,8 @@ msgid "§4That player does not have an active warp."
 msgstr "§4Ce joueur n'a pas de warp actif."
 
 msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
+"§cThat players island is in the process of generating, you cannot warp to it right "
+"now."
 msgstr "§cL'île du joueur se genère, vous ne pouvez pas vous y téléporter."
 
 #, java-format
@@ -1747,7 +1714,7 @@ msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
 
 msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr "§cWither retiré ! Il partirait trop loing de votre île"
+msgstr "§cWither retiré ! Il partirait trop loin de votre île."
 
 #, java-format
 msgid "{0}''s Wither"
@@ -1769,15 +1736,14 @@ msgid "Config:"
 msgstr "Config:"
 
 msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
+"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, that is "
+"not allowed."
 msgstr ""
 "§cAccés interdit !§e Vous avez essayé de vous téléporter sur le toît du "
 "§cNETHER§c, ce n'est pas autorisé."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
-msgstr ""
-"§4Vous ne pouvez convertir l'obsidienne, qu'une fois toutes les 10 secondes."
+msgstr "§4Vous ne pouvez convertir l'obsidienne, qu'une fois toutes les 10 secondes."
 
 msgid "§eChanging your obsidian back into lava. Be careful!"
 msgstr "§eObsidienne changé en lave ! Soyez prudent !"
@@ -1799,8 +1765,8 @@ msgstr "§4Cette île est §cvérrouillé.§e Impossible de s'y téléporter."
 
 #, java-format
 msgid ""
-"§4{0} is limited. §eScanning your island to see if you are allowed to place "
-"more, please be patient"
+"§4{0} is limited. §eScanning your island to see if you are allowed to place more, "
+"please be patient"
 msgstr ""
 
 msgid "§e... Scanning complete, you can try again"
@@ -1808,15 +1774,15 @@ msgstr ""
 
 #, java-format
 msgid ""
-"§4You''ve hit the {0} limit!§e You can''t have more of that type on your "
-"island!§9 Max: {1,number}"
+"§4You''ve hit the {0} limit!§e You can''t have more of that type on your island!§9 "
+"Max: {1,number}"
 msgstr ""
 
 msgid "§eYou can only use spawn-eggs on your own island."
 msgstr "§eVous pouvez uniquement utiliser les oeufs de spawn sur votre île."
 
 msgid "§cYou have reached your spawn-limit for your island."
-msgstr "§cVous avez atteint la limite de spawn de votre île"
+msgstr "§cVous avez atteint la limite de spawn de votre île."
 
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cBanni:§e Vous êtes banni de cette île."
@@ -1838,11 +1804,10 @@ msgstr "§9{0}§7 timed out"
 
 #, java-format
 msgid ""
-"§eDoing §9{0}§e is §cRISKY§e. Repeat the command within §a{1}§e seconds to "
-"accept!"
+"§eDoing §9{0}§e is §cRISKY§e. Repeat the command within §a{1}§e seconds to accept!"
 msgstr ""
-"§eFaire ceci §9{0}§e est §cDANGEREUX§e. Répeter la commande avant §a{1}§e "
-"secondes pour confirmer !"
+"§eFaire ceci §9{0}§e est §cDANGEREUX§e. Répeter la commande avant §a{1}§e secondes "
+"pour confirmer !"
 
 msgid "N/A"
 msgstr "N/A"
@@ -1862,18 +1827,17 @@ msgid "§d** You are leaving §b{0}''s §disland."
 msgstr "§d** Vous quittez l''île de §b{0}."
 
 msgid "§eYour island is now locked. Only your party members may enter."
-msgstr ""
-"§eVotre île est maintenant vérrouillé. Seuls vos membres peuvent y entrer."
+msgstr "§eVotre île est maintenant vérrouillé. Seuls vos membres peuvent y entrer."
 
 msgid "§4You must be the party leader to lock your island!"
 msgstr "§4Tu dois être le chef de l'île pour pouvoir la verrouiller !"
 
 msgid ""
-"§eYour island is unlocked and anyone may enter, however only you and your "
-"party members may build or remove blocks."
+"§eYour island is unlocked and anyone may enter, however only you and your party "
+"members may build or remove blocks."
 msgstr ""
-"§eVotre île est dévérrouillé et n'importe qui peut y entrer , mais seulement "
-"les membres peuvent construire ou casser des blocs."
+"§eVotre île est dévérrouillé et n'importe qui peut y entrer , mais seulement les "
+"membres peuvent construire ou casser des blocs."
 
 msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4Vous devez être le chef de l'île pour là dévérouillé !"
@@ -1892,11 +1856,9 @@ msgstr "§7PlayerDB: Filtré {0} noms"
 
 #, java-format
 msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), {6}"
 msgstr ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, échoués:{3} ~ {5,number,##}%), "
-"{6}"
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, échoués:{3} ~ {5,number,##}%), {6}"
 
 #, java-format
 msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
@@ -1918,11 +1880,10 @@ msgstr "§7 - MojangAPI:§cERREUR: {0}"
 
 #, java-format
 msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) ~ {6}"
 msgstr ""
-"§eProgression: {0,number,##}% ({1}/{2} - réussis:{3}, échoués:{4}, passés:"
-"{5}) ~ {6}"
+"§eProgression: {0,number,##}% ({1}/{2} - réussis:{3}, échoués:{4}, passés:{5}) ~ "
+"{6}"
 
 #, java-format
 msgid "§4No importer named §e{0}§4 found"
@@ -1944,7 +1905,7 @@ msgstr "§4Comme votre île est vérrouillé, la warp a été désactivé."
 
 #, java-format
 msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d a déverrouillé l'île"
+msgstr "§b{0}§d a déverrouillé l'île."
 
 #, java-format
 msgid "§cSKY §f> §7 {0}"
@@ -1966,12 +1927,11 @@ msgid "§9Creating an island §7{0}§9 of you"
 msgstr "§9Créer une île §7{0}§9 pour vous"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
+"§cThe island owning this piece of nether is being deleted! Sending you to spawn."
 msgstr "§cL'île a été supprimé. Téléportation au spawn."
 
 msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§cL'île sur laquelle vous êtes a été supprimé ! "
+msgstr "§cL'île sur laquelle vous êtes a été supprimé ! Retour au spawn."
 
 #, java-format
 msgid "§eWALL OF FAME (page {0} of {1}):"
@@ -1980,8 +1940,8 @@ msgstr "§eTableau des meilleurs joueurs (page {0} de {1}):"
 #, java-format
 msgid "§4Top ten list is empty! Only islands above level {0} is considered."
 msgstr ""
-"§4La top liste est vide ! Seulement les îles au dessus du niveau {0} est "
-"pris en compte."
+"§4La top liste est vide ! Seulement les îles au dessus du niveau {0} est pris en "
+"compte."
 
 msgid "§a#%2d §7(%5.2f): §e%s §7%s"
 msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
@@ -2018,7 +1978,7 @@ msgid "Unable to locate schematic {0}, contact a server-admin"
 msgstr "Impossible de localiser la schematic {0}, contactez un administrateur"
 
 msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aFécilicitation ! §eVotre île est apparu"
+msgstr "§aFélicitation ! §eVotre île est apparu."
 
 msgid "§cNote:§e Construction might still be ongoing."
 msgstr "§cNote:§e La création peut être encore en cours."
@@ -2100,19 +2060,19 @@ msgid "Change Biome"
 msgstr ""
 
 msgid "change the island''s biome."
-msgstr "changer le biome de l'île"
+msgstr "changer le biome de l'île."
 
 msgid "Toggle Island Lock"
 msgstr ""
 
 msgid "toggle the island''s lock."
-msgstr "activer le vérrouillage de l'île"
+msgstr "activer le vérrouillage de l'île."
 
 msgid "Set Island Warp"
 msgstr ""
 
 msgid "set the island''s warp."
-msgstr "définir le warp de l'île"
+msgstr "définir le warp de l'île."
 
 msgid ""
 "set the island''s warp,\n"
@@ -2125,7 +2085,7 @@ msgid "Toggle Island Warp"
 msgstr ""
 
 msgid "toggle the island''s warp."
-msgstr "activer le warp de l'île"
+msgstr "activer le warp de l'île."
 
 msgid ""
 "toggle the island''s warp,\n"
@@ -2138,7 +2098,7 @@ msgid "Invite Players"
 msgstr ""
 
 msgid "invite others to the island."
-msgstr "inviter d'autres joueurs sur l'île"
+msgstr "inviter d'autres joueurs sur l'île."
 
 msgid ""
 "invite\n"
@@ -2155,7 +2115,7 @@ msgid "Kick Players"
 msgstr ""
 
 msgid "kick others from the island."
-msgstr "kick d'autres joueurs de l'île"
+msgstr "kick d'autres joueurs de l'île."
 
 msgid ""
 "kick\n"
@@ -2163,10 +2123,8 @@ msgid ""
 "but they are unable to kick\n"
 "the island leader."
 msgstr ""
-"kick\n"
-"d'autre joueurs depuis l'île,\n"
-"mais ne peuvent pas kick\n"
-"le chef de l'île"
+"kick d'autre joueurs depuis l'île, mais\n"
+"ne peuvent pas kick le chef de l'île."
 
 msgid "Ocean"
 msgstr "Ocean"
@@ -2265,9 +2223,8 @@ msgid ""
 "No other passive or\n"
 "hostile mobs will spawn."
 msgstr ""
-"Biome champignon\n"
-"Spawn uniquement\n"
-"de vache champignon"
+"Le biome champignon ne spawne\n"
+"que des vache champignon."
 
 msgid "Hell"
 msgstr "Enfer"
@@ -2346,10 +2303,10 @@ msgid ""
 "(including Guardians) will\n"
 "spawn normally."
 msgstr ""
-"Le biome océan monument est un biome avancé\n"
+"Le biome océan profond est un biome avancé.\n"
 "Les mobs passifs comme les animaux\n"
 "ne spawnent pas. Les mobs hostiles\n"
-"(incluant les Guardians) spawn\n"
+"(incluant les Guardians) spawnent\n"
 "normalement."
 
 msgid "Ice Plains"
@@ -2369,7 +2326,7 @@ msgid "{0} <{1}>"
 msgstr "{0} <{1}>"
 
 msgid "§9Player Permissions"
-msgstr "§9Permissions Joueurs"
+msgstr "§9Permissions du joueur"
 
 msgid ""
 "§eClick here to return to\n"
@@ -2378,41 +2335,41 @@ msgstr ""
 
 #, java-format
 msgid "§e{0}''§9s Permissions"
-msgstr ""
+msgstr "§9Permissions de {0}"
 
 msgid ""
 "§eHover over an icon to view\n"
 "§ea permission. Change the\n"
 "§epermission by clicking it."
 msgstr ""
-"§eSurvoez une icone pour voir\n"
-"§ela permission. Changer la\n"
+"§eSurvolez une icone pour voir\n"
+"§ela permission. Changez la\n"
 "§epermissions en cliquant ici."
 
 msgid "§fThis player §acan"
 msgstr "§fCe joueur §apeut"
 
 msgid "Click here to remove this permission."
-msgstr "Clique ici pour retirer des permissions"
+msgstr "Cliquez ici pour retirer des permissions."
 
 msgid "§fThis player §ccannot"
 msgstr "§fCe joueur §cne peut"
 
 msgid "Click here to grant this permission."
-msgstr "Clique ici pour ajouter des permissions."
+msgstr "Cliquez ici pour ajouter des permissions."
 
 msgid "Island Group Members"
-msgstr "Membre du groupe de l'île"
+msgstr "Membres du groupe de l'île"
 
 #, java-format
 msgid "Group Members: §2{0}§7/§e{1}"
 msgstr "Membres du groupe: §2{0}§7/§e{1}"
 
 msgid "§aMore players can be invited to this island."
-msgstr "§aD'autre joueurs peuvent être inviter sur cette île"
+msgstr "§aD'autres joueurs peuvent être invité sur cette île."
 
 msgid "§cThis island is full."
-msgstr "§cCette île est pleine"
+msgstr "§cCette île est pleine."
 
 msgid ""
 "§eHover over a player''s icon to\n"
@@ -2440,7 +2397,7 @@ msgid "Cannot {0}"
 msgstr "Vous ne pouvez pas {0}"
 
 msgid "§e<Click to change this player''s permissions>"
-msgstr "§e<Clique ici pour changer les permissions du joueur>"
+msgstr "§e<Cliquez ici pour changer les permissions du joueur>"
 
 msgid "Island Log"
 msgstr "Log de l'île"
@@ -2448,7 +2405,7 @@ msgstr "Log de l'île"
 msgid ""
 "§eClick here to return to\n"
 "§ethe main island screen."
-msgstr "§eClique ici pour retourner à§e la première page."
+msgstr "§eCliquez ici pour retourner à§e la première page."
 
 msgid "§e§lIsland Log"
 msgstr "§e§lLog de l'île"
@@ -2464,10 +2421,10 @@ msgid "§2§lThis is your current biome."
 msgstr "§2§lBiome actuel."
 
 msgid "§e§lClick to change to this biome."
-msgstr "§e§lClique ici pour changer le biome"
+msgstr "§e§lCliquez ici pour changer le biome."
 
 msgid "You cannot use this biome."
-msgstr "Vous ne pouvez pas utiliser ce biome"
+msgstr "Vous ne pouvez pas utiliser ce biome."
 
 msgid "§2chunk"
 msgstr ""
@@ -2505,7 +2462,7 @@ msgid "§7Last Page"
 msgstr "§7Dernière page"
 
 msgid "Island Create Menu"
-msgstr "Menu - Creer une île "
+msgstr "Menu - Créer une île"
 
 msgid "§a§lStart an Island"
 msgstr "§a§lCréer une île"
@@ -2520,16 +2477,16 @@ msgid ""
 "building your island empire!\n"
 "§e§lClick here to start!"
 msgstr ""
-"Commencer votre journée de skyblock\n"
+"Commencez votre voyage de skyblock\n"
 "en créant votre île.\n"
 "Complétez les challenges pour \n"
 "gagner de l'argent et des objets.\n"
 "Vous pouvez inviter d'autres\n"
 "joueurs à rejoindre votre empire !\n"
-"§e§lClique ici pour commencer l'aventure !"
+"§e§lCliquez ici pour commencer l'aventure !"
 
 msgid "§aClick to create!"
-msgstr "§aClique pour créer !"
+msgstr "§aCliquez pour créer !"
 
 #, java-format
 msgid ""
@@ -2585,10 +2542,10 @@ msgstr ""
 "Voir la lite des §9challenges\n"
 "Vous pouvez les completer sur\n"
 "votre ile pour gagner de l'argent\n"
-"des objets, objets, titres etc.."
+"des objets, titres etc.."
 
 msgid "§e§lClick here to view challenges."
-msgstr "§e§lClique ici pour voir les challenges."
+msgstr "§e§lCliquez ici pour voir les challenges."
 
 msgid "§4§lChallenges disabled."
 msgstr "§4§lChallenges désactivé."
@@ -2610,10 +2567,10 @@ msgid ""
 msgstr ""
 "Gagner des niveaux en\n"
 "agrandissant votre île\n"
-"et compléter certains challenges\n"
-"Les blocks rares ajoutentn plus\n"
+"et en complétant certains challenges\n"
+"Les blocks rares ajoutent plus\n"
 "de niveau.\n"
-"§e§lClique ici pour rafraichir.\n"
+"§e§lCliquez ici pour mettre à jour.\n"
 "§e§l(Vous devez être sur l'île)"
 
 msgid "Island Group"
@@ -2634,7 +2591,7 @@ msgstr ""
 "et leurs permissions. Si vous \n"
 "êtes le chef, vous pouvez changer\n"
 "les permissions des membres.\n"
-"§e§lClique ici pour les voir ou changer."
+"§e§lCliquez ici pour les voir ou changer."
 
 msgid "Change Island Biome"
 msgstr "Changer le biome de l'île"
@@ -2648,18 +2605,18 @@ msgid ""
 "like grass color and spawning\n"
 "of both animals and monsters."
 msgstr ""
-"Les biomes affectent\n"
-"la couleur de l'herbe et le spawn\n"
-"des monstres et animaux."
+"Les biomes affectent des choses\n"
+"comme la couleur de l'herbe et le\n"
+"spawn des monstres et des animaux."
 
 msgid "§e§lClick here to change biomes."
-msgstr "§e§lClique ici pour changer le biome"
+msgstr "§e§lCliquez ici pour changer le biome."
 
 msgid "§c§lYou can't change the biome."
-msgstr "§c§lVous ne pouvez pas changer le biome"
+msgstr "§c§lVous ne pouvez pas changer le biome."
 
 msgid "§a§lIsland Lock"
-msgstr "§a§lIle vérouillé"
+msgstr "§a§lÎle vérouillée"
 
 msgid ""
 "§eLock Status: §aActive\n"
@@ -2667,13 +2624,13 @@ msgid ""
 "§fPlayers outside of your group\n"
 "§fare unable to enter your island."
 msgstr ""
-"§eStatus: §aActif\n"
-"§fVotre île est acutellement §cvérrouillé.\n"
-"§fJoueurs en dehors de votre groupe\n"
-"§fne peuvent rentrer sur votre île."
+"§eStatus du vérouillage: §aActif\n"
+"§fVotre île est actuellement §cverrouillé.\n"
+"§fLes joueurs en dehors de votre groupe\n"
+"§fne peuvent pas rentrer sur votre île."
 
 msgid "§e§lClick here to unlock your island."
-msgstr "§e§lClique ici pour dévérrouillé votre île."
+msgstr "§e§lCliquez ici pour déverrouiller votre île."
 
 msgid "§c§lYou can't change the lock."
 msgstr "§c§lVous ne pouvez pas modifier le vérrouillage."
@@ -2685,17 +2642,17 @@ msgid ""
 "§fisland, but only you and your group\n"
 "§fmembers may build there."
 msgstr ""
-"§eStatut: §8Inactif\n"
-"§fVotre île est actuellement §adévérrouillé.\n"
-"§fTous les joueurs sont capable de\n"
-"§frentrer sur votre île mais seul\n"
-"§fles membres de votre groupe peuvent construire."
+"§eStatut du vérouillage: §8Inactif\n"
+"§fVotre île est actuellement §adéverrouillé.\n"
+"§fTous les joueurs peuvent rentrer sur\n"
+"§fvotre île mais seul les membres de\n"
+"§fvotre groupe peuvent construire."
 
 msgid "§e§lClick here to lock your island."
-msgstr "§e§lClique ici pour vérouiller votre île."
+msgstr "§e§lCliquez ici pour vérouiller votre île."
 
 msgid "§a§lIsland Warp"
-msgstr "§a§lIsland Warp"
+msgstr "§a§lWarp de l'île"
 
 msgid ""
 "§eWarp Status: §aActive\n"
@@ -2703,16 +2660,16 @@ msgid ""
 "§fisland at anytime to the point\n"
 "§fyou set using §d/island setwarp."
 msgstr ""
-"§eStatut: §aActif\n"
-"§fD'autres joueurs peuvent à\n"
-"§fmoment s'y téléporter\n"
-"§fpour le changer §d/island setwarp."
+"§eStatut du warp: §aActif\n"
+"§fD'autres joueurs peuvent s'y téléporter\n"
+"§fà tout moment.\n"
+"§fPour le déplacer : §d/island setwarp."
 
 msgid "§e§lClick here to deactivate."
-msgstr "§e§lClique ici pour désactiver."
+msgstr "§e§lCliquez ici pour désactiver."
 
 msgid "§c§lYou can't change the warp."
-msgstr "§c§lVous ne pouvez pas changer le warp"
+msgstr "§c§lVous ne pouvez pas changer le warp."
 
 msgid ""
 "§eWarp Status: §8Inactive\n"
@@ -2720,16 +2677,16 @@ msgid ""
 "§fisland. Set a warp point using\n"
 "§d/island setwarp §fbefore activating."
 msgstr ""
-"§eStatut: §8Inactif\n"
-"§fLes autres joueurs ne peuvent\n"
-"§fle warp de l'île. Utilise§d /island setwarp\n"
-"§f pour le définir et l'activer."
+"§eStatut du warp: §8Inactif\n"
+"§fLes autres joueurs ne peuvent pas se téléporter\n"
+"§fsur le warp de l'île. Utilisez§d /island setwarp\n"
+"§fpour le définir et l'activer."
 
 msgid "§e§lClick here to activate."
-msgstr "§e§lClique ici pour activer"
+msgstr "§e§lCliquez ici pour activer."
 
 msgid "§a§lIsland Log"
-msgstr "§a§lLog de l'île"
+msgstr "§a§lHistorique de l'île"
 
 msgid ""
 "View a log of events from\n"
@@ -2737,10 +2694,10 @@ msgid ""
 "biome, and warp changes.\n"
 "§e§lClick to view the log."
 msgstr ""
-"Voir les logs de l'île\n"
+"Voir l'historique de l'île\n"
 "(changement de membres,\n"
 "biome et warp).\n"
-"§e§lClique ici pour voir les logs."
+"§e§lCliquez ici pour voir l'historique."
 
 msgid "§a§lChange Home Location"
 msgstr "§a§lChanger la position du home"
@@ -2751,10 +2708,10 @@ msgid ""
 "this location.\n"
 "§e§lClick here to change."
 msgstr ""
-"Lorsque vous vous téléporter à \n"
+"Lorsque vous vous téléportez à\n"
 "votre île, vous serez amené à\n"
 "cet endroit.\n"
-"§e§lClique ici pour le changer."
+"§e§lCliquez ici pour le changer."
 
 msgid "§a§lChange Warp Location"
 msgstr "§a§lChanger la position du Warp"
@@ -2770,14 +2727,14 @@ msgid "§e§lClick here to change."
 msgstr ""
 
 msgid "§c§lRestart Island"
-msgstr "§c§lRédémarrer l'île"
+msgstr "§c§lRedémarrer l'île"
 
 msgid ""
 "Restarts your island.\n"
 "§4WARNING! §cwill remove your items and island!"
 msgstr ""
-"Redémarres votre île.\n"
-"§4ATTENTION§ !ccela va supprimer tout vos items et votre île !"
+"Redémarre votre île.\n"
+"§4ATTENTION ! §ccela va supprimer tout vos items et votre île !"
 
 msgid "§c§lLeave Island"
 msgstr "§c§lQuitter l'île"
@@ -2786,11 +2743,11 @@ msgid ""
 "Leaves your island.\n"
 "§4WARNING! §cwill remove all your items!"
 msgstr ""
-"Quittes votre île.\n"
-"§4ATTENTION§ !ccela va supprimer tout vos items !"
+"Quitte votre île.\n"
+"§4ATTENTION !§ccela va supprimer tout vos items !"
 
 msgid "§cClick to leave"
-msgstr "§cClique pour quitter"
+msgstr "§cCliquez pour quitter"
 
 msgid "Island Restart Menu"
 msgstr "Menu de redémarrage de l'île"
@@ -2800,45 +2757,45 @@ msgstr "§eVous n'avez pas accès à ce type d'île !"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
-msgstr "§cClique dans §9{0}§c pour quitter !"
+msgstr "§cCliquez dans §9{0}§c pour quitter !"
 
 msgid "§a§lReturn to the main menu"
 msgstr "§a§lRetour au menu principal"
 
 #, java-format
 msgid "§cClick within §9{0}§c to restart!"
-msgstr "§cClique dans §9{0}§c pour redémarrer !"
+msgstr "§cCliquez dans §9{0}§c pour redémarrer !"
 
 msgid "§aClick to restart!"
-msgstr "§aClique pour redémarrer !"
+msgstr "§aCliquez pour redémarrer !"
 
 msgid "Caps On"
 msgstr "Majuscule activé"
 
 msgid "§9Text Editor"
-msgstr "§9Editeur de texte"
+msgstr "§9Éditeur de texte"
 
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
-msgstr "Trop de requêtes pour Mojang API ({0} within {1}), sleeping {2}"
+msgstr "Trop de requêtes pour l''API Mojang ({0} within {1}), sleeping {2}"
 
 msgid "§9Hold your horses! You have to be patient..."
 msgstr ""
 
 msgid "§9Not really patient, are you?"
-msgstr ""
+msgstr "§9Vous n'êtes pas vraiment patient, n'est-ce pas ?"
 
 msgid "§9Be patient, young padawan"
-msgstr ""
+msgstr "§9Soyez patient, jeune padawan"
 
 msgid "§9Patience you MUST have, young padawan"
-msgstr ""
+msgstr "§9Jeune padawan, avoir la patience tu DOIS"
 
 msgid "§9The two most powerful warriors are patience and time."
 msgstr ""
 
 msgid "§eSending you to spawn."
-msgstr "§aTéléportation au spawn"
+msgstr "§aTéléportation au spawn."
 
 msgid "§eThe island has been §cLOCKED§e."
 msgstr "§eL'île a été §cVÉRROUILLÉ§e."
@@ -2853,28 +2810,25 @@ msgstr "§7Téléportation annulée"
 msgid "READY"
 msgstr "PRÊT"
 
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
+msgid "§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
-"§cATTENTION:§e Impossible de transférer tout les items nécessaires dans "
-"votre inventaire !"
+"§cATTENTION :§e Impossible de transférer tout les items nécessaires dansvotre "
+"inventaire !"
 
 msgid "§cNot enough items in chest to complete challenge!"
 msgstr "§cPas assez d'items dans le coffre pour compléter le challenge !"
 
 msgid "Something went wrong saving the island and/or party data!"
-msgstr ""
-"Quelque chose a mal sauvegardé les données de l'île et / ou de la partie!"
+msgstr "Quelque chose a mal sauvegardé les données de l'île et/ou de la partie !"
 
 msgid "Converting data to UUID, this make take a while!"
 msgstr "Conversion des données en UUID, cela peut prendre un certain temps !"
 
 msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§cMAINTENANCE:§e uSkyBlock est actuellement en mode maintenance"
+msgstr "§cMAINTENANCE :§e uSkyBlock est actuellement en mode maintenance"
 
 #, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
 msgstr ""
 "§buSkyBlock§e dépend de §9{0}§e >= §av{1}§e mais seulement §cv{2}§e a été "
 "trouvé !\n"
@@ -2887,13 +2841,13 @@ msgid "§4Player is already assigned to this island!"
 msgstr "§4Ce joueur est déjà assigné à une île !"
 
 msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4Impossible de trouver un endroit sécuriser sur votre île !"
+msgstr "§4Impossible de trouver un endroit sécurisé sur votre île !"
 
 msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§cATTENTION: §eTéléportation en plein air."
+msgstr "§cATTENTION : §eTéléportation en plein air."
 
 msgid "§aTeleporting you to your island."
-msgstr "§aTéléportation à votre île"
+msgstr "§aTéléportation à votre île."
 
 msgid "§4Unable to warp you to that player''s island!"
 msgstr "§4Impossible d'utiliser le warp de cette île !"
@@ -2912,29 +2866,29 @@ msgid "§4Your current location is not a safe home-location."
 msgstr "§4Votre position acutelle n'est pas un home protégé."
 
 msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cVotre île génére , vous ne pouvez pas créer maintenant."
+msgstr "§cVotre île est en cours de génération, vous ne pouvez pas créer maintenant."
 
 msgid "Could not create your Island. Please contact a server moderator."
 msgstr "Vous ne pouvez pas créer d'île. Contactez un administrateur."
 
 msgid "§eGetting your island ready, please be patient, it can take a while."
 msgstr ""
-"§eVotre île est prête, soyez patient cela peut prendre un certain temps.."
+"§eVotre île est bientôt prête, soyez patient cela peut prendre un certain temps..."
 
 msgid "§cCommand is currently disabled!"
-msgstr "§cLa commande est actuellement désactivé !"
+msgstr "§cLa commande est actuellement désactivée !"
 
 msgid "North"
-msgstr "North"
+msgstr "Nord"
 
 msgid "North-East"
-msgstr "North-Est"
+msgstr "Nord-Est"
 
 msgid "East"
 msgstr "Est"
 
 msgid "South-East"
-msgstr "Sud-Esr"
+msgstr "Sud-Est"
 
 msgid "South"
 msgstr "Sud"

--- a/uSkyBlock-Core/src/main/po/fr.po
+++ b/uSkyBlock-Core/src/main/po/fr.po
@@ -341,7 +341,7 @@ msgid "§e{0} has had all challenges reset."
 msgstr "§e{0} a eu tous les challenges réinitialisés."
 
 msgid "complete all challenges in the rank"
-msgstr "compléte tout les challenges dans le rang"
+msgstr "complète tout les challenges dans le rang"
 
 #, java-format
 msgid "§4No player named {0} was found!"
@@ -398,7 +398,7 @@ msgstr "§4Aucun joueur nommé {0} trouvé !"
 
 msgid ""
 "§4No valid island provided, either stand within one, or provide an island name"
-msgstr "§4Aucune île fournie , essayez de fournir un nom d'île"
+msgstr "§4Aucune île indiquée. Essayez de fournir un nom d'île"
 
 msgid "print out info about the island"
 msgstr "afficher les informations à propos de l'île"
@@ -420,7 +420,7 @@ msgstr "§4Erreur ! §9Aucune île valide à nettoyer."
 
 #, java-format
 msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cNettoyage : §9Ile nettoyé à {0}"
+msgstr "§cNETTOYAGE : §9Ile nettoyé à {0}"
 
 msgid "toggles the islands ignore status"
 msgstr "activer"
@@ -971,7 +971,7 @@ msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
 msgstr "§7- Scan: {0,number,##}% ({1}/{2} échoués: {3}) ~ {4}"
 
 msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4PURGE :§9 Scan interrompu."
+msgstr "§4NETTOYAGE :§9 Scan interrompu."
 
 #, java-format
 msgid ""
@@ -984,10 +984,10 @@ msgid "- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{
 msgstr ""
 
 msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4 NETTOYAGE: Finit , îles abandonnés nétoyés."
+msgstr "§4NETTOYAGE : Finit , îles abandonnés nétoyés."
 
 msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4PURGE :§9 Purge annulée des îles abandonnées."
+msgstr "§4NETTOYAGE :§9 Purge annulée des îles abandonnées."
 
 msgid "displays version information"
 msgstr "afficher les informations sur la version"
@@ -1067,13 +1067,13 @@ msgid "complete and list challenges"
 msgstr "liste des challenges"
 
 msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eChallenge désactivé. Contacte un administrateur."
+msgstr "§eChallenge désactivé. Contactez un administrateur."
 
 msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4Vous pouvez compléter les challenges uniquement dans le mode du skyblock !"
+msgstr "§4Vous devez être dans le monde Skyblock pour compléter les challenges !"
 
 msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4Vous pouvez compléter les challenges uniquement quand vous avez une île !"
+msgstr "§4Vous devez avoir une île pour compléter les challenges !"
 
 msgid ""
 "§4Your island is full, or you have too many pending invites. You can't invite "
@@ -1200,10 +1200,10 @@ msgid "Let the player change their islands biome to {0}"
 msgstr ""
 
 msgid "§cYou do not have permission to change the biome of your current island."
-msgstr "§cVous n'avez pas la permission pour changer le biome de l'île actuelle."
+msgstr "§cVous n'avez pas la permission de changer le biome de l'île actuelle."
 
 msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4Vous n'avez pas la permission pour changer le biome de l'île !"
+msgstr "§4Vous n'avez pas la permission de changer le biome de l'île !"
 
 msgid "§eYou must be on your island to change the biome!"
 msgstr "§eVous devez être sur votre île pour changer le biome !"
@@ -1218,7 +1218,7 @@ msgid "§eYou can change your biome again in {0,number,#} minutes."
 msgstr "§eVous ne pouvez pas changer le biome avant {0,number,#} minutes."
 
 msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cVous n'êtes pas autorisé à changer votre biome à ce type."
+msgstr "§cVous n'êtes pas autorisé à changer votre biome vers ce type."
 
 #, java-format
 msgid "§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
@@ -1376,7 +1376,7 @@ msgstr "§4{0} a été retiré de l'île."
 
 #, java-format
 msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0} a essayé de vous kick de leur île !"
+msgstr "§4{0} a essayé de vous kick de son île !"
 
 #, java-format
 msgid "§4{0} is exempt from being kicked."
@@ -1384,7 +1384,7 @@ msgstr "§4{0} est excepté du kick de l'île."
 
 #, java-format
 msgid "§4{0} has kicked you from their island!"
-msgstr "§4{0} vous a kické de leur île !"
+msgstr "§4{0} vous a kické de son île !"
 
 #, java-format
 msgid "§4{0} has been kicked from the island."
@@ -1415,7 +1415,7 @@ msgid "§4{0} has left your island!"
 msgstr "§4{0} a quitté votre île !"
 
 msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4Vous devez être dans le monde du skyblock pour quitter l'île !"
+msgstr "§4Vous devez être dans le monde skyblock pour quitter l'île !"
 
 msgid "check your or anothers island level"
 msgstr "vérifier le niveau des autres îles"
@@ -1454,7 +1454,7 @@ msgid "transfer leadership to another member"
 msgstr "transférer le chef à un autre membre"
 
 msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4Vous ne pouvez uniquement transférer le chef aux membres de votre île !"
+msgstr "§4Seul un membre de votre île peut devenir chef !"
 
 #, java-format
 msgid "{0}§e is already leader of your island!"
@@ -1533,7 +1533,7 @@ msgid ""
 "§4Only the owner may restart this island. Leave this island in order to start your "
 "own (/island leave)."
 msgstr ""
-"§4Uniquement le chef de l'île peut remettre à zéro l'île. Quitter l'île pour créer "
+"§4Uniquement le chef de l'île peut remettre à zéro l'île. Quittez l'île pour créer "
 "la votre (/island leave)."
 
 msgid ""
@@ -1592,7 +1592,7 @@ msgid "§cYou do not have permission to enable/disable your island''s warp!"
 msgstr ""
 
 msgid "display the top10 of islands"
-msgstr "Afficher le top 10 des îles."
+msgstr "afficher le top 10 des îles"
 
 msgid "enables user to all-ways generate top-ten (no caching)"
 msgstr ""
@@ -1660,7 +1660,7 @@ msgid ""
 "§cYour island is in the process of generating, you cannot warp to other players "
 "islands right now."
 msgstr ""
-"§cVotre île est en géneration, vous ne pouvez vous téléporter sur d'autres îles."
+"§cVotre île est en géneration, vous ne pouvez pas vous téléporter sur d'autres îles."
 
 msgid "§4That player does not exist!"
 msgstr "§4Ce joueur n'éxiste pas !"
@@ -1743,7 +1743,7 @@ msgstr ""
 "§cNETHER§c, ce n'est pas autorisé."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
-msgstr "§4Vous ne pouvez convertir l'obsidienne, qu'une fois toutes les 10 secondes."
+msgstr "§4Vous ne pouvez convertir l'obsidienne qu'une fois toutes les 10 secondes."
 
 msgid "§eChanging your obsidian back into lava. Be careful!"
 msgstr "§eObsidienne changé en lave ! Soyez prudent !"
@@ -1940,7 +1940,7 @@ msgstr "§eTableau des meilleurs joueurs (page {0} de {1}):"
 #, java-format
 msgid "§4Top ten list is empty! Only islands above level {0} is considered."
 msgstr ""
-"§4La top liste est vide ! Seulement les îles au dessus du niveau {0} est pris en "
+"§4Le top 10 est vide ! Seulement les îles au dessus du niveau {0} est pris en "
 "compte."
 
 msgid "§a#%2d §7(%5.2f): §e%s §7%s"
@@ -2477,7 +2477,7 @@ msgid ""
 "building your island empire!\n"
 "§e§lClick here to start!"
 msgstr ""
-"Commencez votre voyage de skyblock\n"
+"Commencez votre aventure skyblock\n"
 "en créant votre île.\n"
 "Complétez les challenges pour \n"
 "gagner de l'argent et des objets.\n"
@@ -2744,7 +2744,7 @@ msgid ""
 "§4WARNING! §cwill remove all your items!"
 msgstr ""
 "Quitte votre île.\n"
-"§4ATTENTION !§ccela va supprimer tout vos items !"
+"§4ATTENTION ! §ccela va supprimer tout vos items !"
 
 msgid "§cClick to leave"
 msgstr "§cCliquez pour quitter"
@@ -2789,7 +2789,7 @@ msgid "§9Be patient, young padawan"
 msgstr "§9Soyez patient, jeune padawan"
 
 msgid "§9Patience you MUST have, young padawan"
-msgstr "§9Jeune padawan, avoir la patience tu DOIS"
+msgstr "§9Jeune padawan, la patience tu DOIS avoir"
 
 msgid "§9The two most powerful warriors are patience and time."
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr "PRÊT"
 
 msgid "§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
-"§cATTENTION :§e Impossible de transférer tout les items nécessaires dansvotre "
+"§cATTENTION :§e Impossible de transférer tout les items nécessaires dans votre"
 "inventaire !"
 
 msgid "§cNot enough items in chest to complete challenge!"
@@ -2863,7 +2863,7 @@ msgid "§aYour skyblock home has been set to your current location."
 msgstr "§aVotre home a été modifié à votre position acutelle."
 
 msgid "§4Your current location is not a safe home-location."
-msgstr "§4Votre position acutelle n'est pas un home protégé."
+msgstr "§4Votre position actuelle n'est pas un home protégé."
 
 msgid "§cYour island is in the process of generating, you cannot create now."
 msgstr "§cVotre île est en cours de génération, vous ne pouvez pas créer maintenant."


### PR DESCRIPTION
- Fix inconsistency of usage of T-V distinction in french (see https://en.wikipedia.org/wiki/T%E2%80%93V_distinction#French_2 ).
- Fix some mistranslated sentences and words.
- Added more translation