### PR TITLE
Small POM updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,19 +81,13 @@
             <id>sk89q-repo</id>
             <url>http://maven.sk89q.com/repo/</url>
         </repository>
-        <!--
-        <repository>
-            <id>sk89q-mvn2</id>
-            <url>http://mvn2.sk89q.com/repo</url>
-        </repository>
-        -->
         <repository>
             <id>onarandombox</id>
             <url>http://repo.onarandombox.com/content/groups/public</url>
         </repository>
         <repository>
-            <id>bstats-repo</id>
-            <url>http://repo.bstats.org/content/repositories/releases/</url>
+            <id>CodeMC</id>
+            <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
         <repository>
             <id>rlf-mvn-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -102,79 +102,6 @@
     </pluginRepositories>
     <profiles>
         <profile>
-            <id>wg5</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sk89q</groupId>
-                    <artifactId>worldguard</artifactId>
-                    <version>5.9</version>
-                    <scope>compile</scope>
-                    <type>jar</type>
-                    <optional>true</optional>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>wg6</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sk89q</groupId>
-                    <artifactId>worldguard</artifactId>
-                    <version>6.0.0-SNAPSHOT</version>
-                    <scope>compile</scope>
-                    <type>jar</type>
-                    <optional>true</optional>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>wg611</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sk89q</groupId>
-                    <artifactId>worldguard</artifactId>
-                    <version>6.1.1-SNAPSHOT</version>
-                    <scope>compile</scope>
-                    <type>jar</type>
-                    <optional>true</optional>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.sk89q</groupId>
-                            <artifactId>worldedit</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>wg62</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sk89q.worldguard</groupId>
-                    <artifactId>worldguard-legacy</artifactId>
-                    <version>6.2</version>
-                    <scope>compile</scope>
-                    <type>jar</type>
-                    <optional>true</optional>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.sk89q</groupId>
-                            <artifactId>worldedit</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>wg700</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
@@ -193,22 +120,6 @@
                             <artifactId>worldedit</artifactId>
                         </exclusion>
                     </exclusions>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>we613</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sk89q.worldedit</groupId>
-                    <artifactId>worldedit-bukkit</artifactId>
-                    <version>6.1.3-SNAPSHOT</version>
-                    <scope>compile</scope>
-                    <type>jar</type>
-                    <optional>true</optional>
                 </dependency>
             </dependencies>
         </profile>

--- a/uSkyBlock-API/pom.xml
+++ b/uSkyBlock-API/pom.xml
@@ -84,20 +84,5 @@
                 </dependency>
             </dependencies>
         </profile>
-        <profile>
-            <id>1.12</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <dependencies>
-                <dependency> <!-- Bukkit implementation -->
-                    <groupId>org.bukkit</groupId>
-                    <artifactId>bukkit</artifactId>
-                    <version>1.12.2-R0.1-SNAPSHOT</version>
-                    <optional>true</optional>
-                    <scope>compile</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -438,7 +438,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.2</version>
+            <version>1.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -279,21 +279,6 @@
             </dependencies>
         </profile>
         <profile>
-            <id>1.12</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <dependencies>
-                <dependency> <!-- Bukkit implementation -->
-                    <groupId>org.bukkit</groupId>
-                    <artifactId>bukkit</artifactId>
-                    <version>1.12.2-R0.1-SNAPSHOT</version>
-                    <optional>true</optional>
-                    <scope>compile</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>i18n</id>
             <activation>
                 <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
Updating bStats (+repository URL) and removing some old WE5/6 and Bukkit 1.12 profiles from the POM files. The AWE repository URL is also outdated but re-adding or removing AWE support is another subject.