### PR TITLE
Make nether island region heights configurable

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
@@ -126,8 +126,8 @@ public class WorldGuardHandler {
         BlockVector3 minPoint = getProtectionVectorRight(islandLocation);
         BlockVector3 maxPoint = getProtectionVectorLeft(islandLocation);
         if (regionName != null && regionName.endsWith("nether")) {
-            minPoint = minPoint.withY(6);
-            maxPoint = maxPoint.withY(120);
+            minPoint = minPoint.withY(uSkyBlock.getInstance().getConfig().getInt("worldguard.nether.minY", 6));
+            maxPoint = maxPoint.withY(uSkyBlock.getInstance().getConfig().getInt("worldguard.nether.maxY", 120));
         }
         ProtectedCuboidRegion region = new ProtectedCuboidRegion(regionName, minPoint, maxPoint);
         final DefaultDomain owners = new DefaultDomain();

--- a/uSkyBlock-Core/src/main/resources/config.yml
+++ b/uSkyBlock-Core/src/main/resources/config.yml
@@ -349,6 +349,9 @@ asyncworldedit:
 worldguard:
   entry-message: true
   exit-message: true
+  nether:
+    minY: 6
+    minX: 120
 nether:
   enabled: true
   height: 75


### PR DESCRIPTION
As discussed in #1172, the nether region height was inadvertently adjusted a while ago. And although it's now fixed in master, I thought it would be good to have this configurable.

Server owners can now set `minY` and `maxY` for the island regions created in the nether.

The default values in config (and code) are now:
```
worldguard:
  nether:
    minY: 6
    minX: 120
```