### PR TITLE
Add island ban-related events to API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <groupId>uSkyBlock</groupId>
     <artifactId>uSkyBlock</artifactId>
     <packaging>pom</packaging>
-    <version>2.7.9-SNAPSHOT</version>
+    <version>2.7.10-SNAPSHOT</version>
     <name>Ultimate SkyBlock</name>
 
     <properties>
-        <api.version>2.7.7</api.version>
+        <api.version>2.7.8</api.version>
         <bukkit-utils.version>1.23-SNAPSHOT</bukkit-utils.version>
         <po-utils.version>1.2</po-utils.version>
         <deluxechat.version>1.6</deluxechat.version>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,13 +6,13 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ "$TRAVIS_BRANCH" == "master" ]]
   cd $HOME
 
   rsync -r --quiet $HOME/build/uskyblock/uSkyBlock/uSkyBlock-API/target/mvn-repo/ \
-  dool1@shell.xs4all.nl:WWW/maven/master/uSkyBlock-API/
+  dool1@shell.xs4all.nl:WWW/maven/master/
 
   rsync -r --quiet $HOME/build/uskyblock/uSkyBlock/uSkyBlock-Core/target/mvn-repo/ \
-  dool1@shell.xs4all.nl:WWW/maven/master/uSkyBlock-Core/
+  dool1@shell.xs4all.nl:WWW/maven/master/
 
   rsync -r --quiet $HOME/build/uskyblock/uSkyBlock/uSkyBlock-FAWE/target/mvn-repo/ \
-  dool1@shell.xs4all.nl:WWW/maven/master/uSkyBlock-FAWE/
+  dool1@shell.xs4all.nl:WWW/maven/master/
 
   echo -e "Publishing javadocs...\n"
 
@@ -38,13 +38,13 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ "$TRAVIS_BRANCH" == "release" ]
   cd $HOME
 
   rsync -r --quiet $HOME/build/uskyblock/uSkyBlock/uSkyBlock-API/target/mvn-repo/ \
-  dool1@shell.xs4all.nl:WWW/maven/release/uSkyBlock-API/
+  dool1@shell.xs4all.nl:WWW/maven/release/
 
   rsync -r --quiet $HOME/build/uskyblock/uSkyBlock/uSkyBlock-Core/target/mvn-repo/ \
-  dool1@shell.xs4all.nl:WWW/maven/release/uSkyBlock-Core/
+  dool1@shell.xs4all.nl:WWW/maven/release/
 
   rsync -r --quiet $HOME/build/uskyblock/uSkyBlock/uSkyBlock-FAWE/target/mvn-repo/ \
-  dool1@shell.xs4all.nl:WWW/maven/release/uSkyBlock-FAWE/
+  dool1@shell.xs4all.nl:WWW/maven/release/
 
   echo -e "Publishing javadocs...\n"
 

--- a/uSkyBlock-API/pom.xml
+++ b/uSkyBlock-API/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.rlf</groupId>
     <artifactId>uSkyBlock-API</artifactId>
-    <version>2.7.7</version>
+    <version>2.7.8</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <travis.buildNumber>dev</travis.buildNumber>

--- a/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/IslandInfo.java
+++ b/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/IslandInfo.java
@@ -152,7 +152,8 @@ public interface IslandInfo {
     boolean unbanPlayer(@NotNull OfflinePlayer target, @Nullable OfflinePlayer initializer);
 
     /**
-     * Checks if the given player is trusted on this island.
+     * Checks if the given player is banned on this island.
+     *
      * @param target The {@link OfflinePlayer} to query for.
      * @return True if the player is banned on this island, false otherwise.
      * @since 2.7.8

--- a/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/IslandInfo.java
+++ b/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/IslandInfo.java
@@ -99,6 +99,7 @@ public interface IslandInfo {
      * True if the player has been banned from this island.
      * @param player The player to query for
      * @return True if the player has been banned from this island.
+     * @deprecated Use {@link IslandInfo#isBanned(OfflinePlayer)}
      */
     boolean isBanned(Player player);
 
@@ -109,6 +110,56 @@ public interface IslandInfo {
     List<String> getBans();
 
     /**
+     * Bans a player from this island.
+     * Plugins using this function should check if the initializer is authorized to ban a player.
+     *
+     * @param target The {@link OfflinePlayer} to ban.
+     * @return True if the player was banned, false otherwise. Returns false if the player is banned already.
+     * @since 2.7.8
+     */
+    boolean banPlayer(@NotNull OfflinePlayer target);
+
+    /**
+     * Bans a player from this island.
+     * Plugins using this function should check if the initializer is authorized to ban a player.
+     *
+     * @param target The {@link OfflinePlayer} to ban.
+     * @param initializer The {@link OfflinePlayer} initializing this request.
+     * @return True if the player was banned, false otherwise. Returns false if the player is banned already.
+     * @since 2.7.8
+     */
+    boolean banPlayer(@NotNull OfflinePlayer target, @Nullable OfflinePlayer initializer);
+
+    /**
+     * Unbans a player from this island.
+     * Plugins using this function should check if the initializer is authorized to unban a player.
+     *
+     * @param target The {@link OfflinePlayer} to unban.
+     * @return True if the player was unbanned, false otherwise. Returns false if the player is unbanned already.
+     * @since 2.7.8
+     */
+    boolean unbanPlayer(@NotNull OfflinePlayer target);
+
+    /**
+     * Unbans a player from this island.
+     * Plugins using this function should check if the initializer is authorized to unban a player.
+     *
+     * @param target The {@link OfflinePlayer} to unban.
+     * @param initializer the {@link OfflinePlayer} initializing this request.
+     * @return True if the player was unbanned, false otherwise. Returns false if the player is unbanned already.
+     * @since 2.7.8
+     */
+    boolean unbanPlayer(@NotNull OfflinePlayer target, @Nullable OfflinePlayer initializer);
+
+    /**
+     * Checks if the given player is trusted on this island.
+     * @param target The {@link OfflinePlayer} to query for.
+     * @return True if the player is banned on this island, false otherwise.
+     * @since 2.7.8
+     */
+    boolean isBanned(@NotNull OfflinePlayer target);
+
+    /**
      * List of players trusted on this island.
      * @return List of players trusted on this island.
      * @deprecated Use #getTrusteeUUIDs instead
@@ -117,6 +168,8 @@ public interface IslandInfo {
 
     /**
      * Trusts a player on this island.
+     * Plugins using this function should check if the initializer is authorized to trust a player.
+     *
      * @param target The {@link OfflinePlayer} to trust.
      * @return True if the player was trusted, false otherwise.
      * @since 2.7.7
@@ -125,6 +178,8 @@ public interface IslandInfo {
 
     /**
      * Trusts a player on this island.
+     * Plugins using this function should check if the initializer is authorized to trust a player.
+     *
      * @param target The {@link OfflinePlayer} to trust.
      * @param initializer The {@link OfflinePlayer} initializing this request.
      * @return True if the player was trusted, false otherwise.
@@ -134,24 +189,28 @@ public interface IslandInfo {
 
     /**
      * Untrusts a player on this island.
+     * Plugins using this function should check if the initializer is authorized to untrust a player.
+     *
      * @param target The {@link OfflinePlayer} to untrust.
-     * @return True if the player was trusted, false otherwise.
+     * @return True if the player was untrusted, false otherwise.
      * @since 2.7.7
      */
     boolean untrustPlayer(@NotNull OfflinePlayer target);
 
     /**
      * Untrusts a player on this island.
+     * Plugins using this function should check if the initializer is authorized to untrust a player.
+     *
      * @param target The {@link OfflinePlayer} to untrust.
      * @param initializer The {@link OfflinePlayer} initializing this request.
-     * @return True if the player was trusted, false otherwise.
+     * @return True if the player was untrusted, false otherwise.
      * @since 2.7.7
      */
     boolean untrustPlayer(@NotNull OfflinePlayer target, @Nullable OfflinePlayer initializer);
 
     /**
      * Checks if the given player is trusted on this island.
-     * @param target The player to query for.
+     * @param target The {@link OfflinePlayer} to query for.
      * @return True if the player is trusted on this island, false otherwise.
      * @since 2.7.7
      */

--- a/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/event/island/IslandBanPlayerEvent.java
+++ b/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/event/island/IslandBanPlayerEvent.java
@@ -1,0 +1,57 @@
+package us.talabrek.ultimateskyblock.api.event.island;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import us.talabrek.ultimateskyblock.api.IslandInfo;
+
+/**
+ * Thrown when a player is banned from an island.
+ * @implNote Until more fundamental changes to uSkyBlock are made, the user gets *NO* feedback that the ban event is
+ * cancelled from us! The cancelling plugin should send a message to the initializer if feedback is expected.
+ * @since 2.7.8
+ */
+public class IslandBanPlayerEvent extends CancellableIslandEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private final OfflinePlayer target;
+    private final OfflinePlayer initializer;
+
+    public IslandBanPlayerEvent(@NotNull final IslandInfo islandInfo,
+                                  @NotNull final OfflinePlayer target,
+                                  @Nullable final OfflinePlayer initializer)
+    {
+        super(islandInfo);
+        this.target = target;
+        this.initializer = initializer;
+    }
+
+    /**
+     * Gets the {@link OfflinePlayer} representing the banned player.
+     * @return The {@link OfflinePlayer} representing the banned player.
+     */
+    @NotNull
+    public OfflinePlayer getTarget() {
+        return target;
+    }
+
+    /**
+     * Gets the {@link OfflinePlayer} initializing the ban event, if available.
+     * @return The {@link OfflinePlayer} initializing the ban event, or null if the initializer is unknown.
+     */
+    @Nullable
+    public OfflinePlayer getInitializer() {
+        return initializer;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/event/island/IslandUnbanPlayerEvent.java
+++ b/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/event/island/IslandUnbanPlayerEvent.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 import us.talabrek.ultimateskyblock.api.IslandInfo;
 
 /**
- * Thrown when a player is banned from an island.
+ * Thrown when a player is unbanned from an island.
  * @implNote Until more fundamental changes to uSkyBlock are made, the user gets *NO* feedback that the unban event is
  * cancelled from us! The cancelling plugin should send a message to the initializer if feedback is expected.
  * @since 2.7.8
@@ -36,8 +36,8 @@ public class IslandUnbanPlayerEvent extends CancellableIslandEvent {
     }
 
     /**
-     * Gets the {@link OfflinePlayer} initializing the ban event, if available.
-     * @return The {@link OfflinePlayer} initializing the ban event, or null if the initializer is unknown.
+     * Gets the {@link OfflinePlayer} initializing the unban event, if available.
+     * @return The {@link OfflinePlayer} initializing the unban event, or null if the initializer is unknown.
      */
     @Nullable
     public OfflinePlayer getInitializer() {

--- a/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/event/island/IslandUnbanPlayerEvent.java
+++ b/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/event/island/IslandUnbanPlayerEvent.java
@@ -1,0 +1,57 @@
+package us.talabrek.ultimateskyblock.api.event.island;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import us.talabrek.ultimateskyblock.api.IslandInfo;
+
+/**
+ * Thrown when a player is banned from an island.
+ * @implNote Until more fundamental changes to uSkyBlock are made, the user gets *NO* feedback that the unban event is
+ * cancelled from us! The cancelling plugin should send a message to the initializer if feedback is expected.
+ * @since 2.7.8
+ */
+public class IslandUnbanPlayerEvent extends CancellableIslandEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private final OfflinePlayer target;
+    private final OfflinePlayer initializer;
+
+    public IslandUnbanPlayerEvent(@NotNull final IslandInfo islandInfo,
+                                @NotNull final OfflinePlayer target,
+                                @Nullable final OfflinePlayer initializer)
+    {
+        super(islandInfo);
+        this.target = target;
+        this.initializer = initializer;
+    }
+
+    /**
+     * Gets the {@link OfflinePlayer} representing the unbanned player.
+     * @return The {@link OfflinePlayer} representing the unbanned player.
+     */
+    @NotNull
+    public OfflinePlayer getTarget() {
+        return target;
+    }
+
+    /**
+     * Gets the {@link OfflinePlayer} initializing the ban event, if available.
+     * @return The {@link OfflinePlayer} initializing the ban event, or null if the initializer is unknown.
+     */
+    @Nullable
+    public OfflinePlayer getInitializer() {
+        return initializer;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>uSkyBlock</artifactId>
         <groupId>uSkyBlock</groupId>
-        <version>2.7.9-SNAPSHOT</version>
+        <version>2.7.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/BanCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/BanCommand.java
@@ -39,7 +39,7 @@ public class BanCommand extends RequireIslandCommand {
             if (!island.isBanned(name)) {
                 //noinspection deprecation
                 OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(name);
-                if (!offlinePlayer.hasPlayedBefore()) {
+                if (!offlinePlayer.hasPlayedBefore() && !offlinePlayer.isOnline()) {
                     player.sendMessage(tr("\u00a7eUnable to ban unknown player {0}", name));
                     return true;
                 }
@@ -48,7 +48,7 @@ public class BanCommand extends RequireIslandCommand {
                     player.sendMessage(tr("\u00a74{0} is exempt from being banned.", name));
                     return true;
                 }
-                island.banPlayer(offlinePlayer.getUniqueId());
+                island.banPlayer(offlinePlayer, player);
                 player.sendMessage(tr("\u00a7eYou have banned \u00a74{0}\u00a7e from warping to your island.", name));
                 if (offlinePlayer.isOnline()) {
                     offlinePlayer.getPlayer().sendMessage(tr("\u00a7eYou have been \u00a7cBANNED\u00a7e from {0}\u00a7e''s island.", player.getDisplayName()));
@@ -59,11 +59,11 @@ public class BanCommand extends RequireIslandCommand {
             } else {
                 //noinspection deprecation
                 OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(name);
-                if (!offlinePlayer.hasPlayedBefore()) {
+                if (!offlinePlayer.hasPlayedBefore() && !offlinePlayer.isOnline()) {
                     player.sendMessage(tr("\u00a7eUnable to ban unknown player {0}", name));
                     return true;
                 }
-                island.unbanPlayer(offlinePlayer.getUniqueId());
+                island.unbanPlayer(offlinePlayer, player);
                 player.sendMessage(tr("\u00a7eYou have unbanned \u00a7a{0}\u00a7e from warping to your island.", name));
                 if (offlinePlayer.isOnline()) {
                     offlinePlayer.getPlayer().sendMessage(tr("\u00a7eYou have been \u00a7aUNBANNED\u00a7e from {0}\u00a7e''s island.", player.getDisplayName()));

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/TrustCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/TrustCommand.java
@@ -37,7 +37,7 @@ public class TrustCommand extends RequireIslandCommand {
             }
             //noinspection deprecation
             OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(name);
-            if (!offlinePlayer.hasPlayedBefore()) {
+            if (!offlinePlayer.hasPlayedBefore() && !offlinePlayer.isOnline()) {
                 player.sendMessage(tr("\u00a74Unknown player {0}", name));
                 return true;
             }

--- a/uSkyBlock-FAWE/pom.xml
+++ b/uSkyBlock-FAWE/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>uSkyBlock</artifactId>
         <groupId>uSkyBlock</groupId>
-        <version>2.7.9-SNAPSHOT</version>
+        <version>2.7.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>uSkyBlock-FAWE</artifactId>

--- a/uSkyBlock-Plugin/pom.xml
+++ b/uSkyBlock-Plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>uSkyBlock</artifactId>
         <groupId>uSkyBlock</groupId>
-        <version>2.7.9-SNAPSHOT</version>
+        <version>2.7.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
@@ -13,7 +13,7 @@
 
     <properties>
         <github.global.server>github</github.global.server>
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
 
     <build>
@@ -40,7 +40,7 @@
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <classesDirectory>${project.build.directory}/uSkyBlock-Plugin</classesDirectory>
+                    <classesDirectory>${project.build.directory}/uSkyBlock-${pom.version}-Plugin</classesDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/uSkyBlock-Plugin/pom.xml
+++ b/uSkyBlock-Plugin/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <github.global.server>github</github.global.server>
-        <maven.deploy.skip>false</maven.deploy.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <build>


### PR DESCRIPTION
Removing the api-function IslandInfo#isBanned(Player player) can be done in the next change, because IslandInfo#isBanned(OfflinePlayer target) should cover it (Player implements OfflinePlayer).

See PR #1187 for the reasoning behind using OfflinePlayer instead of using UUID objects.

Made these changes while on the road, so there are a few things to take into consideration when following-up on this:

1) Save the API-version we're implementing in USB-Core somewhere, so we can report the actual version we're implementing to other plugins calling for the API;
2) Deprecate all API functions in uSkyBlock's main class except for a new/improved getApi() method.

These new events and methods aren't _really_ useful for external plugins at the moment, but they should work as described (tested locally) and can be extended in the future to be more useful. The used parameters make the methods flexible enough to change the implementation or extend use without having to deprecate the current ones.