### PR TITLE
Break out for loop in ChunkGenerator when chunkList is empty (#1217)

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/world/ChunkRegenerator.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/world/ChunkRegenerator.java
@@ -1,5 +1,6 @@
 package us.talabrek.ultimateskyblock.world;
 
+import io.papermc.lib.PaperLib;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Chunk;
 import org.bukkit.World;
@@ -39,7 +40,8 @@ public class ChunkRegenerator {
     }
 
     /**
-     * Regenerates the given list of {@link Chunk}s at a 5 chunks/tick speed.
+     * Regenerates the given list of {@link Chunk}s at a 4 chunks/tick speed (can be overwritten with hidden
+     * configuration value).
      * @param chunkList List of chunks to regenerate.
      * @param onCompletion Runnable to schedule on completion, or null to call no runnable.
      */
@@ -51,13 +53,14 @@ public class ChunkRegenerator {
         task = scheduler.runTaskTimer(plugin, () -> {
             for (int i = 0; i < CHUNKS_PER_TICK; i++) {
                 if (!chunkList.isEmpty()) {
-                    final Chunk chunk = chunkList.remove(0);
+                    Chunk chunk = chunkList.remove(0);
                     regenerateChunk(chunk);
                 } else {
                     if (onCompletion != null) {
                         scheduler.runTaskLater(plugin, onCompletion, 1L);
                     }
                     task.cancel();
+                    break;
                 }
             }
         }, 0L, 1L);
@@ -67,7 +70,7 @@ public class ChunkRegenerator {
      * Regenerates the given {@link Chunk}, removing all it's entities except players and setting the default biome.
      * @param chunk Chunk to regenerate.
      */
-    public void regenerateChunk(@NotNull Chunk chunk) {
+    private void regenerateChunk(@NotNull Chunk chunk) {
         Validate.notNull(chunk, "Chunk cannot be null");
 
         spawnTeleportPlayers(chunk);

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/world/ChunkRegenerator.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/world/ChunkRegenerator.java
@@ -1,6 +1,5 @@
 package us.talabrek.ultimateskyblock.world;
 
-import io.papermc.lib.PaperLib;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Chunk;
 import org.bukkit.World;
@@ -40,18 +39,17 @@ public class ChunkRegenerator {
     }
 
     /**
-     * Regenerates the given list of {@link Chunk}s at a 4 chunks/tick speed (can be overwritten with hidden
-     * configuration value).
+     * Regenerates the given list of {@link Chunk}s at the configured chunks/tick speed (default: 4).
      * @param chunkList List of chunks to regenerate.
      * @param onCompletion Runnable to schedule on completion, or null to call no runnable.
      */
     public void regenerateChunks(@NotNull List<Chunk> chunkList, @Nullable Runnable onCompletion) {
         Validate.notNull(chunkList, "ChunkList cannot be empty");
 
-        final int CHUNKS_PER_TICK = 5;
+        final int CHUNKS_PER_TICK = plugin.getConfig().getInt("options.advanced.chunkRegenSpeed", 4);
         BukkitScheduler scheduler = plugin.getServer().getScheduler();
         task = scheduler.runTaskTimer(plugin, () -> {
-            for (int i = 0; i < CHUNKS_PER_TICK; i++) {
+            for (int i = 0; i <= CHUNKS_PER_TICK; i++) {
                 if (!chunkList.isEmpty()) {
                     Chunk chunk = chunkList.remove(0);
                     regenerateChunk(chunk);
@@ -117,7 +115,7 @@ public class ChunkRegenerator {
     /**
      * Default BiomeGrid used by uSkyBlock when regenerating chunks.
      */
-    class DefaultBiomeGrid implements BiomeGrid {
+    static class DefaultBiomeGrid implements BiomeGrid {
         private Biome defaultBiome;
 
         DefaultBiomeGrid(Environment env) {

--- a/uSkyBlock-Core/src/main/resources/config.yml
+++ b/uSkyBlock-Core/src/main/resources/config.yml
@@ -214,6 +214,10 @@ options:
     # re-executing it (/is leave, /is restart).
     confirmTimeout: 10
 
+    # [number] The number of chunks to regenerate per server tick. Might be decreased or increased based on available
+    # server resources. Default value: 4.
+    chunkRegenSpeed: 4
+
     # Controls advanced behaviour reg. the internal playerdb
     playerdb:
 
@@ -435,7 +439,7 @@ placeholder:
   servercommandplaceholder: false
 
 # DO NOT TOUCH THE FIELDS BELOW
-version: 103
+version: 104
 force-replace:
   options.party.invite-timeout: 100
   options.island.islandTeleportDelay: 5


### PR DESCRIPTION
Fixes #1217 

Added a config option to change the chunk regenerator speed.

Should also fix an issue reported on the SpigotMC forums where the starter chest gets filled up with the items multiple times.