### PR TITLE
Add MenuType to UltimateHolder

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/MenuEvents.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/MenuEvents.java
@@ -22,9 +22,13 @@ public class MenuEvents implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void guiClick(final InventoryClickEvent event) {
-        String prefix = stripFormatting(tr("Config:"));
-        if (!prefix.isEmpty() && event.getInventory().getHolder() instanceof UltimateHolder &&
-                stripFormatting(((UltimateHolder) event.getInventory().getHolder()).getTitle()).startsWith(prefix)) {
+        if (!(event.getInventory().getHolder() instanceof UltimateHolder)) {
+            // Not our menu.
+            return;
+        }
+
+        UltimateHolder holder = (UltimateHolder) event.getInventory().getHolder();
+        if (holder.getMenuType() == UltimateHolder.MenuType.CONFIG) {
             plugin.getConfigMenu().onClick(event);
         } else {
             plugin.getMenu().onClick(event);

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/menu/IntegerEditMenu.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/menu/IntegerEditMenu.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import us.talabrek.ultimateskyblock.player.UltimateHolder;
+import us.talabrek.ultimateskyblock.player.UltimateHolder.MenuType;
 
 import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
 import static dk.lockfuglsang.minecraft.util.FormatUtil.stripFormatting;
@@ -51,7 +52,7 @@ public class IntegerEditMenu extends AbstractConfigMenu implements EditMenu {
 
     @Override
     public boolean onClick(InventoryClickEvent event) {
-        if (event.getInventory() == null || !(event.getInventory().getHolder() instanceof UltimateHolder) ||
+        if (!(event.getInventory().getHolder() instanceof UltimateHolder) ||
                 ((UltimateHolder) event.getInventory().getHolder()).getTitle() == null ||
                 !stripFormatting(((UltimateHolder) event.getInventory().getHolder()).getTitle()).contains(stripFormatting(getTitle()))) {
             return false;
@@ -125,7 +126,7 @@ public class IntegerEditMenu extends AbstractConfigMenu implements EditMenu {
             return null;
         }
         int value = config.getInt(path, 0);
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(null, getTitle()), 6 * 9, getTitle());
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(null, getTitle(), MenuType.CONFIG), 6 * 9, getTitle());
         menu.setMaxStackSize(MenuItemFactory.MAX_INT_VALUE);
         ItemStack frame = createItem(Material.BLACK_STAINED_GLASS_PANE, 0, null, null);
         for (int i = 0; i < 27; i++) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/menu/MainConfigMenu.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/menu/MainConfigMenu.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import us.talabrek.ultimateskyblock.player.UltimateHolder;
+import us.talabrek.ultimateskyblock.player.UltimateHolder.MenuType;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 
 import java.io.File;
@@ -171,7 +172,7 @@ public class MainConfigMenu extends AbstractConfigMenu implements EditMenu {
             page = maxPages;
         }
         String title = tr("Config:") + " " + pre("{0} ({1}/{2})", filename, page, maxPages);
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(null, title), 6 * 9, title);
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(null, title, MenuType.CONFIG), 6 * 9, title);
         menu.setMaxStackSize(MenuItemFactory.MAX_INT_VALUE);
         int startOffset = (page-1)*54;
         // Add section markers on top line

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/menu/SkyBlockMenu.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/menu/SkyBlockMenu.java
@@ -18,6 +18,7 @@ import us.talabrek.ultimateskyblock.island.IslandInfo;
 import us.talabrek.ultimateskyblock.player.IslandPerk;
 import us.talabrek.ultimateskyblock.player.PlayerInfo;
 import us.talabrek.ultimateskyblock.player.UltimateHolder;
+import us.talabrek.ultimateskyblock.player.UltimateHolder.MenuType;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 import us.talabrek.ultimateskyblock.util.PlayerUtil;
 
@@ -155,7 +156,7 @@ public class SkyBlockMenu {
         List<String> lores = new ArrayList<>();
         String emptyTitle = tr("{0} <{1}>", "", tr("Permissions"));
         String title = tr("{0} <{1}>", pname.substring(0, Math.min(32-emptyTitle.length(), pname.length())), tr("Permissions"));
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title), 9, title);
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title, MenuType.DEFAULT), 9, title);
         final ItemStack pHead = new ItemStack(Material.PLAYER_HEAD, 1);
         final SkullMeta meta3 = (SkullMeta) pHead.getItemMeta();
         ItemMeta meta2 = sign.getItemMeta();
@@ -212,7 +213,7 @@ public class SkyBlockMenu {
     public Inventory displayPartyGUI(final Player player) {
         List<String> lores = new ArrayList<>();
         String title = "\u00a79" + tr("Island Group Members");
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title), 18, title);
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title, MenuType.DEFAULT), 18, title);
         IslandInfo islandInfo = plugin.getIslandInfo(player);
         final Set<String> memberList = islandInfo.getMembers();
         final ItemMeta meta2 = sign.getItemMeta();
@@ -260,7 +261,7 @@ public class SkyBlockMenu {
     public Inventory displayLogGUI(final Player player) {
         List<String> lores = new ArrayList<>();
         String title = "\u00a79" + tr("Island Log");
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title), 9, title);
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title, MenuType.DEFAULT), 9, title);
         ItemMeta meta4 = sign.getItemMeta();
         meta4.setDisplayName("\u00a79\u00a7l" + tr("Island Log"));
         addLore(lores, tr("\u00a7eClick here to return to\n\u00a7ethe main island screen."));
@@ -284,7 +285,7 @@ public class SkyBlockMenu {
     public Inventory displayBiomeGUI(final Player player) {
         List<String> lores = new ArrayList<>();
         String title = "\u00a79" + tr("Island Biome");
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title), 27, title);
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title, MenuType.DEFAULT), 27, title);
         ItemMeta meta4 = sign.getItemMeta();
         meta4.setDisplayName("\u00a7h" + tr("Island Biome"));
         addLore(lores, tr("\u00a7eClick here to return to\n\u00a7ethe main island screen."));
@@ -467,7 +468,7 @@ public class SkyBlockMenu {
     public Inventory displayChallengeGUI(final Player player, int page, String playerName) {
         int total = challengeLogic.getTotalPages();
         String title = "\u00a79" + pre("{0} ({1}/{2})", tr("Challenge Menu"), page, total);
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title), CHALLENGE_PAGESIZE+COLS_PER_ROW, title);
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title, MenuType.DEFAULT), CHALLENGE_PAGESIZE+COLS_PER_ROW, title);
         final PlayerInfo pi = playerName == null ? plugin.getPlayerInfo(player) : plugin.getPlayerInfo(playerName);
         challengeLogic.populateChallengeRank(menu, pi, page, playerName != null && player.hasPermission("usb.mod.bypassrestriction"));
         int[] pages = new int[9];
@@ -519,7 +520,7 @@ public class SkyBlockMenu {
         List<String> schemeNames = plugin.getIslandGenerator().getSchemeNames();
         int menuSize = (int) Math.ceil(getMaxSchemeIndex(schemeNames) / 9d)*9;
         String title = "\u00a79" + tr("Island Create Menu");
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title), menuSize, title);
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title, MenuType.DEFAULT), menuSize, title);
         List<String> lores = new ArrayList<>();
         ItemStack menuItem = new ItemStack(Material.OAK_SAPLING, 1);
         ItemMeta meta = menuItem.getItemMeta();
@@ -591,7 +592,7 @@ public class SkyBlockMenu {
 
     private Inventory createMainMenu(Player player) {
 		String title = "\u00a79" + tr("Island Menu");
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title), 18, title);
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title, MenuType.DEFAULT), 18, title);
         List<String> lores = new ArrayList<>();
         ItemStack menuItem = new ItemStack(Material.OAK_DOOR, 1);
         ItemMeta meta4 = menuItem.getItemMeta();
@@ -775,8 +776,7 @@ public class SkyBlockMenu {
 
     public void onClick(InventoryClickEvent event) {
         ItemStack currentItem = event != null ? event.getCurrentItem() : null;
-        //if (event == null || currentItem == null || event.getWhoClicked() == null || event.getSlotType() != InventoryType.SlotType.CONTAINER) {
-        if (event == null || currentItem == null || event.getWhoClicked() == null) {
+        if (event == null || currentItem == null) {
             return; // Bail out, nothing we can do anyway
         }
         Player p = (Player) event.getWhoClicked();
@@ -968,7 +968,7 @@ public class SkyBlockMenu {
         List<String> schemeNames = plugin.getIslandGenerator().getSchemeNames();
         int menuSize = (int) Math.ceil(getMaxSchemeIndex(schemeNames) / 9d)*9;
         String title = "\u00a79" + tr("Island Restart Menu");
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title), menuSize, title);
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(player, title, MenuType.DEFAULT), menuSize, title);
         List<String> lores = new ArrayList<>();
         ItemStack menuItem = new ItemStack(SIGN_MATERIAL, 1);
         ItemMeta meta = menuItem.getItemMeta();

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/menu/StringEditMenu.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/menu/StringEditMenu.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import us.talabrek.ultimateskyblock.player.UltimateHolder;
+import us.talabrek.ultimateskyblock.player.UltimateHolder.MenuType;
 
 import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
 import static dk.lockfuglsang.minecraft.util.FormatUtil.stripFormatting;
@@ -132,7 +133,7 @@ public class StringEditMenu extends AbstractConfigMenu implements EditMenu {
             return null;
         }
         String value = config.getString(path, "");
-        Inventory menu = Bukkit.createInventory(new UltimateHolder(null, getTitle()), 9 * 6, getTitle());
+        Inventory menu = Bukkit.createInventory(new UltimateHolder(null, getTitle(), MenuType.DEFAULT), 9 * 6, getTitle());
         setCharacters(menu, value, keyboard);
         if (isCaps) {
             setCharacters(menu, value, capslockOverlay);

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/player/UltimateHolder.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/player/UltimateHolder.java
@@ -4,15 +4,18 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class UltimateHolder implements InventoryHolder {
 
 	private Player player;
 	private String title;
+	private MenuType menuType;
 
-	public UltimateHolder(Player player, String title) {
+	public UltimateHolder(@Nullable Player player, @NotNull String title, @NotNull MenuType menuType) {
 		this.player = player;
 		this.title = title;
+		this.menuType = menuType;
 	}
 
 	@NotNull
@@ -21,12 +24,23 @@ public class UltimateHolder implements InventoryHolder {
 		return player.getInventory();
 	}
 
+	@Nullable
 	public Player getPlayer() {
 		return player;
 	}
 
+	@NotNull
 	public String getTitle() {
 		return title;
 	}
 
+	@NotNull
+	public MenuType getMenuType() {
+		return menuType;
+	}
+
+	public enum MenuType {
+		CONFIG,
+		DEFAULT
+	}
 }

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/MenuEventsTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/MenuEventsTest.java
@@ -8,12 +8,12 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.InventoryView;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import us.talabrek.ultimateskyblock.menu.ConfigMenu;
 import us.talabrek.ultimateskyblock.menu.SkyBlockMenu;
 import us.talabrek.ultimateskyblock.player.UltimateHolder;
+import us.talabrek.ultimateskyblock.player.UltimateHolder.MenuType;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 
 import java.util.UUID;
@@ -21,7 +21,6 @@ import java.util.UUID;
 import static org.mockito.Mockito.*;
 
 public class MenuEventsTest {
-    private uSkyBlock fakePlugin;
     private ConfigMenu fakeConfigMenu;
     private SkyBlockMenu fakeMenu;
 
@@ -29,7 +28,7 @@ public class MenuEventsTest {
 
     @Before
     public void setUp() {
-        fakePlugin = mock(uSkyBlock.class);
+        uSkyBlock fakePlugin = mock(uSkyBlock.class);
         fakeConfigMenu = spy(mock(ConfigMenu.class));
         fakeMenu = spy(mock(SkyBlockMenu.class));
 
@@ -44,7 +43,7 @@ public class MenuEventsTest {
 
     @Test
     public void testOnGuiClick_configMenu() {
-        UltimateHolder holder = new UltimateHolder(getFakePlayer(), "Config: config.yml (1/2)");
+        UltimateHolder holder = new UltimateHolder(getFakePlayer(), "Config: config.yml (1/2)", MenuType.CONFIG);
         InventoryClickEvent event = getEvent(holder);
 
         menuEvents.guiClick(event);
@@ -54,7 +53,7 @@ public class MenuEventsTest {
 
     @Test
     public void testOnGuiClick_regularMenu() {
-        UltimateHolder holder = new UltimateHolder(getFakePlayer(), "Island GUI menu");
+        UltimateHolder holder = new UltimateHolder(getFakePlayer(), "Island GUI menu", MenuType.DEFAULT);
         InventoryClickEvent event = getEvent(holder);
 
         menuEvents.guiClick(event);
@@ -69,7 +68,7 @@ public class MenuEventsTest {
 
         menuEvents.guiClick(event);
         verify(fakeConfigMenu, times(0)).onClick(any());
-        verify(fakeMenu).onClick(event);
+        verify(fakeMenu, times(0)).onClick(event);
     }
 
     private Player getFakePlayer() {


### PR DESCRIPTION
Adds a MenuType enum to UltimateHolder and chooses the right menu type based on that value, instead of matching parts of the title.

Should also fix #1102 as far as I can see, but I'm unable to test with the mentioned permission plugin because it's a paid resource.