### PR TITLE
Re-add po-utils to USB

### DIFF
--- a/po-utils/pom.xml
+++ b/po-utils/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>uSkyBlock</artifactId>
+        <groupId>uSkyBlock</groupId>
+        <version>2.8.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <artifactId>po-utils</artifactId>
+
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>internal.repo</id>
+            <name>Temporary Staging Repository</name>
+            <url>file://${project.build.directory}/mvn-repo</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>17.0.0</version>
+        </dependency>
+        <!-- TESTING -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit-vintage-engine.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>utf-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <show>public</show>
+                    <failOnError>false</failOnError>
+                    <doclint>none</doclint>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/po-utils/src/main/java/dk/lockfuglsang/minecraft/po/I18nUtil.java
+++ b/po-utils/src/main/java/dk/lockfuglsang/minecraft/po/I18nUtil.java
@@ -1,0 +1,235 @@
+package dk.lockfuglsang.minecraft.po;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.logging.Logger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Convenience util for supporting static imports.
+ */
+public enum I18nUtil {
+    ;
+    private static final Logger log = Logger.getLogger(I18nUtil.class.getName());
+    private static I18n i18n;
+    private static Locale locale;
+    private static File dataFolder = new File(".");
+
+    /**
+     * Translates the given {@link String} to the configured language. Returns the given String if no translation is
+     * available. Returns an empty String if the given key is null or empty.
+     * @param s String to translate.
+     * @return Translated String.
+     */
+    @NotNull
+    public static String tr(@Nullable String s) {
+        return getI18n().tr(s);
+    }
+
+    /**
+     * Translates the given {@link String} to the configured language. Formats with the given {@link Object}. Returns
+     * the given String if no translation is available. Returns an empty String if the given key is null or empty.
+     * @param s String to translate.
+     * @param args Arguments to format.
+     * @return Translated String.
+     */
+    @NotNull
+    public static String tr(@Nullable String s, @Nullable Object... args) {
+        return getI18n().tr(s, args);
+    }
+
+    /**
+     * Marks the given {@link String} for translation for the .po files.
+     * @param key String to mark.
+     * @return Input String.
+     */
+    @Contract("null -> null")
+    public static String marktr(@Nullable String key) {
+        return key;
+    }
+
+    /**
+     * Formats the given {@link String} without translating. Returns an empty String if the given String is
+     * null or empty.
+     * @param s String to format.
+     * @param args Arguments for formatting.
+     * @return Formatted String.
+     */
+    @NotNull
+    public static String pre(@Nullable String s, @Nullable Object... args) {
+        if (s != null && !s.isEmpty()) {
+            new MessageFormat(s, getLocale());
+            return MessageFormat.format(s, args);
+        }
+        return "";
+    }
+
+    /**
+     * Gets the {@link I18n} instance representing the configured {@link Locale}. Lazy-loads if necessary.
+     * @return I18n instance for the configured locale.
+     */
+    public static I18n getI18n() {
+        if (i18n == null) {
+            i18n = new I18n(getLocale());
+        }
+        return i18n;
+    }
+
+    /**
+     * Returns the configured {@link Locale} or the default if unset.
+     * @return Configured Locale.
+     */
+    @NotNull
+    public static Locale getLocale() {
+        return locale != null ? locale : Locale.ENGLISH;
+    }
+
+    /**
+     * Sets the {@link Locale}. Resets to the default locale if NULL is given.
+     * @param locale Locale to set.
+     */
+    public static void setLocale(@Nullable Locale locale) {
+        I18nUtil.locale = locale;
+        clearCache();
+    }
+
+    /**
+     * Sets the datafolder that is used to look for .po files.
+     * @param folder Location of the datafolder.
+     */
+    public static void setDataFolder(@NotNull File folder) {
+        dataFolder = folder;
+        clearCache();
+    }
+
+    /**
+     * Clears the I18n cache, forces a reload of the .po files the next time that {@link I18nUtil#getLocale()} is
+     * accessed.
+     */
+    public static void clearCache() {
+        i18n = null;
+    }
+
+    /**
+     * Converts the given {@link String} to a {@link Locale}.
+     * @param lang Language code..
+     * @return Locale based on the given string.
+     */
+    @Contract("null -> null")
+    public static Locale getLocale(@Nullable String lang) {
+        if (lang != null) {
+            String[] parts = lang.split("[_\\-]");
+            if (parts.length >= 3) {
+                return new Locale(parts[0], parts[1], parts[2]);
+            } else if (parts.length == 2) {
+                return new Locale(parts[0], parts[1]);
+            } else {
+                return new Locale(parts[0]);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Proxy between uSkyBlock and org.xnap.commons.i18n.I18n
+     */
+    public static class I18n {
+        private final Locale locale;
+        private List<Properties> props;
+
+        I18n(Locale locale) {
+            this.locale = locale;
+            props = new ArrayList<>();
+            addPropsFromPluginFolder();
+            addPropsFromJar();
+            addPropsFromZipInJar();
+        }
+
+        private void addPropsFromJar() {
+            try (InputStream in = getClass().getClassLoader().getResourceAsStream("po/" + locale + ".po")) {
+                if (in == null) {
+                    return;
+                }
+                Properties i18nProps = POParser.asProperties(in);
+                if (i18nProps != null && !i18nProps.isEmpty()) {
+                    props.add(i18nProps);
+                }
+            } catch (IOException e) {
+                log.info("Unable to read translations from po/" + locale + ".po: " + e);
+            }
+        }
+
+        private void addPropsFromZipInJar() {
+            // We zip the .po files, since they are currently half the footprint of the jar.
+            try (
+                    InputStream in = getClass().getClassLoader().getResourceAsStream("i18n.zip");
+                    ZipInputStream zin = in != null ? new ZipInputStream(in, StandardCharsets.UTF_8) : null
+            ) {
+                ZipEntry nextEntry;
+                do {
+                    nextEntry = zin != null ? zin.getNextEntry() : null;
+                    if (nextEntry != null && nextEntry.getName().equalsIgnoreCase(locale + ".po")) {
+                        Properties i18nProps = POParser.asProperties(zin);
+                        if (i18nProps != null && !i18nProps.isEmpty()) {
+                            props.add(i18nProps);
+                        }
+                    }
+                } while (nextEntry != null);
+            } catch (IOException e) {
+                log.info("Unable to load translations from i18n.zip!" + locale + ".po: " + e);
+            }
+        }
+
+        private void addPropsFromPluginFolder() {
+            File poFile = new File(dataFolder, "i18n" + File.separator + locale + ".po");
+            if (poFile.exists()) {
+                try (InputStream in = new FileInputStream(poFile)) {
+                    Properties i18nProps = POParser.asProperties(in);
+                    if (i18nProps != null && !i18nProps.isEmpty()) {
+                        props.add(i18nProps);
+                    }
+                } catch (IOException e) {
+                    log.info("Unable to load translations from i18n" + File.separator + locale + ".po: " + e);
+                }
+            }
+        }
+
+        public String tr(String key, Object... args) {
+            if (key == null || key.trim().isEmpty()) {
+                return "";
+            }
+            for (Properties prop : props) {
+                String propKey = prop.getProperty(key);
+                if (propKey != null && prop.containsKey(key) && !propKey.trim().isEmpty()) {
+                    return format(propKey, args);
+                }
+            }
+            return format(key, args);
+        }
+
+        private String format(String propKey, Object[] args) {
+            try {
+                return new MessageFormat(propKey, getLocale()).format(args);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Problem with: '" + propKey + "'", e);
+            }
+        }
+
+        public Locale getLocale() {
+            return locale;
+        }
+    }
+}

--- a/po-utils/src/main/java/dk/lockfuglsang/minecraft/po/POParser.java
+++ b/po-utils/src/main/java/dk/lockfuglsang/minecraft/po/POParser.java
@@ -1,0 +1,72 @@
+package dk.lockfuglsang.minecraft.po;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+/**
+ * Parses a simple PO file, and returns the result as a Properties object.
+ */
+@SuppressWarnings("WeakerAccess")
+public class POParser {
+    public static Properties asProperties(InputStream in) throws IOException {
+        return new POParser().readPOAsProperties(in);
+    }
+
+    public Properties readPOAsProperties(InputStream in) throws IOException {
+        if (in == null) {
+            return null;
+        }
+        Properties props = new Properties();
+        BufferedReader rdr = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+        String line = null;
+        String key = null;
+        String value = null;
+        int lineNo = 0;
+        while ((line = rdr.readLine()) != null) {
+            line = line.trim();
+            lineNo++;
+            if (line.startsWith("#")) {
+                // skip - comment
+                continue;
+            }
+            if (line.startsWith("msgid \"") && line.endsWith("\"")) {
+                if (key != null && value == null) {
+                    throw new IOException("Malformed po, msgid without msgstr! at line " + lineNo);
+                }
+                addTranslation(props, key, value);
+                value = null;
+                key = line.substring(7, line.length() - 1);
+            } else if (line.startsWith("msgstr \"") && line.endsWith("\"")) {
+                if (key == null) {
+                    throw new IOException("Malformed po, msgstr wihtout msgid! at line " + lineNo);
+                }
+                if (value != null) {
+                    throw new IOException("Malformed po, msgstr before msgid! at line " + lineNo);
+                }
+                value = line.substring(8, line.length() - 1);
+            } else if (value != null && line.startsWith("\"") && line.endsWith("\"")) {
+                value += line.substring(1, line.length() - 1);
+            } else if (key != null && line.startsWith("\"") && line.endsWith("\"")) {
+                key += line.substring(1, line.length() - 1);
+            } else if (!line.isEmpty()) {
+                throw new IOException("Malformed po, did not expect '" + line + "' at line " + lineNo);
+            }
+        }
+        addTranslation(props, key, value);
+        return props;
+    }
+
+    private void addTranslation(Properties props, String key, String value) {
+        if (key != null && value != null) {
+            props.put(normalize(key), normalize(value));
+        }
+    }
+
+    private String normalize(String key) {
+        return key.replaceAll("\\\\n", "\n");
+    }
+}

--- a/po-utils/src/test/java/dk/lockfuglsang/minecraft/po/I18nUtilTest.java
+++ b/po-utils/src/test/java/dk/lockfuglsang/minecraft/po/I18nUtilTest.java
@@ -1,0 +1,132 @@
+package dk.lockfuglsang.minecraft.po;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Locale;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class I18nUtilTest {
+    @Before
+    public void setUp() throws Exception {
+        URL dataFolderUrl = getClass().getClassLoader().getResource("");
+        I18nUtil.setDataFolder(new File(dataFolderUrl.getFile()));
+    }
+
+    @Test
+    public void testTr_nullKey() {
+        assertThat(I18nUtil.tr(null), is(""));
+    }
+
+    @Test
+    public void testTr_emptyKey() {
+        assertThat(I18nUtil.tr(""), is(""));
+    }
+
+    @Test
+    public void testTr_existingKey() {
+        String TEST_STRING = "\u00a7eYou do not have access to that island-schematic!";
+        String TEST_RESULT = "\u00a7eYou have no azzess to the schemz";
+
+        assertThat(I18nUtil.tr(TEST_STRING), is(TEST_RESULT));
+    }
+
+    @Test
+    public void testTr_nonExistingKey() {
+        String TEST_STRING = "\u00a7eYou have no access to that island-schematic!";
+
+        assertThat(I18nUtil.tr(TEST_STRING), is(TEST_STRING));
+    }
+
+    @Test
+    public void testTr_existingKeyWithFormatting() {
+        String TEST_STRING = "\u00a7eNo active cooldowns for \u00a79{0}\u00a7e found.";
+        String TEST_ARG = "linksssofrechts";
+        String TEST_RESULT = "\u00a74* \u00a77No expired coolupz for \u00a76" + TEST_ARG + "\u00a77 found.";
+
+        assertThat(I18nUtil.tr(TEST_STRING, TEST_ARG), is(TEST_RESULT));
+    }
+
+    @Test
+    public void testTr_nonExistingKeyWithFormatting() {
+        String TEST_STRING = "\u00a7eThis key is unknown to {0}.";
+        String TEST_ARG = "Bukkit";
+        String TEST_RESULT = "\u00a7eThis key is unknown to " + TEST_ARG + ".";
+
+        assertThat(I18nUtil.tr(TEST_STRING, TEST_ARG), is(TEST_RESULT));
+    }
+
+    @Test
+    public void testTr_existingKeyNullArgs() {
+        String TEST_STRING = "\u00a7eNo active cooldowns for \u00a79{0}\u00a7e found.";
+        String TEST_RESULT = "\u00a74* \u00a77No expired coolupz for \u00a76{0}\u00a77 found.";
+
+        assertThat(I18nUtil.tr(TEST_STRING, (Object[]) null), is(TEST_RESULT));
+    }
+
+    @Test
+    public void testMarktr_nullKey() {
+        assertNull(I18nUtil.marktr(null));
+    }
+
+    @Test
+    public void testMarktr_emptyKey() {
+        assertThat(I18nUtil.marktr(""), is(""));
+    }
+
+    @Test
+    public void testMarktr_withString() {
+        String TEST_STRING = "This is a test message for {0}.";
+
+        assertThat(I18nUtil.marktr(TEST_STRING), is(TEST_STRING));
+    }
+
+    @Test
+    public void testPre_nullString() {
+        assertThat(I18nUtil.pre(null), is(""));
+    }
+
+    @Test
+    public void testPre_emptyString() {
+        assertThat(I18nUtil.pre(""), is(""));
+    }
+
+    @Test
+    public void testPre_withNonFormattedString() {
+        String TEST_STRING = "\u00a7eThis is a test string";
+
+        assertThat(I18nUtil.pre(TEST_STRING), is(TEST_STRING));
+    }
+    
+    @Test
+    public void testPre_withFormattedString() {
+        String TEST_STRING = "\u00a7bThis is a test for {0} regarding {1}.";
+        Object[] TEST_ARGS = new String[]{"Jinxert", "Ultimate Skyblock"};
+        String TEST_RESULT = "\u00a7bThis is a test for Jinxert regarding Ultimate Skyblock.";
+
+        assertThat(I18nUtil.pre(TEST_STRING, TEST_ARGS), is(TEST_RESULT));
+    }
+
+    @Test
+    public void testGetLocale_unset() {
+        assertThat(I18nUtil.getLocale(), is(Locale.ENGLISH));
+    }
+
+    @Test
+    public void testGetLocale_setToChina() {
+        I18nUtil.setLocale(Locale.CHINA);
+
+        assertThat(I18nUtil.getLocale(), is(Locale.CHINA));
+    }
+
+    @Test
+    public void testSetLocale_setToNull() {
+        I18nUtil.setLocale(null);
+
+        assertThat(I18nUtil.getLocale(), is(Locale.ENGLISH));
+    }
+}

--- a/po-utils/src/test/java/dk/lockfuglsang/minecraft/po/POParserTest.java
+++ b/po-utils/src/test/java/dk/lockfuglsang/minecraft/po/POParserTest.java
@@ -1,0 +1,78 @@
+package dk.lockfuglsang.minecraft.po;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class POParserTest {
+
+    @Test
+    public void testReadPOAsProperties() throws Exception {
+        verifyProps("valid_da.po");
+    }
+
+    @Test
+    public void testReadPOAsPropertiesNullInput() throws Exception {
+        assertThat(POParser.asProperties(null), nullValue());
+    }
+
+    @Test(expected = IOException.class)
+    public void testPOWithMissingMsgid() throws Exception {
+        POParser.asProperties(getClass().getClassLoader().getResourceAsStream("invalid_missing_msgid.po"));
+    }
+
+    @Test(expected = IOException.class)
+    public void testPOWithMissingMsgstr() throws Exception {
+        POParser.asProperties(getClass().getClassLoader().getResourceAsStream("invalid_missing_msgstr.po"));
+    }
+
+    @Test(expected = IOException.class)
+    public void testPOWithMissingContent() throws Exception {
+        POParser.asProperties(getClass().getClassLoader().getResourceAsStream("invalid_mixed_content.po"));
+    }
+
+    @Test
+    public void testPOWithEmptyLinesInId() throws Exception {
+        verifyProps("valid_emptylines_id.po");
+    }
+
+    @Test
+    public void testPOWithEmptyLinesInStr() throws Exception {
+        verifyProps("valid_emptylines_str.po");
+    }
+
+    @Test
+    public void testNotClosingIn() throws Exception {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream("valid_da.po")) {
+            Properties properties = POParser.asProperties(in);
+            in.close(); // asserts that we can close the stream
+        }
+    }
+
+    private void verifyProps(String name) throws IOException {
+        POParser parser = new POParser();
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(name)) {
+            Properties properties = parser.readPOAsProperties(in);
+            assertThat(properties, notNullValue());
+            assertThat(properties.size(), is(5));
+
+            String key = "\u00a74Requirements will reset in {0} days.";
+            String value = "\u00a74Kravene vil nulstilles om {0} dage.";
+            assertThat(properties.getProperty(key), is(value));
+
+            key = "\u00a7eThis challenge\n requires the following:";
+            value = "\u00a7eDenne udfordring\n kræver følgende:";
+            assertThat(properties.getProperty(key), is(value));
+
+            key = "\u00a74Requirements = will reset in {0} minutes.";
+            value = "\u00a74Kravene vil = nulstilles om {0} minutter.";
+            assertThat(properties.getProperty(key), is(value));
+        }
+    }
+
+}

--- a/po-utils/src/test/resources/invalid_missing_msgid.po
+++ b/po-utils/src/test/resources/invalid_missing_msgid.po
@@ -1,0 +1,32 @@
+# uSkyBlock Localization for Danish.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uSkyBlock package.
+# Rasmus Lock Fuglsang <steam@lockfuglsang.dk>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: v2.2\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2015-10-30 23:22+0100\n"
+"Last-Translator: R4zorax\n"
+"Language-Team: da <LL@li.org>\n"
+"Language: da_DK\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#, java-format
+msgstr "§4Kravene vil nulstilles om {0} dage."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Kravene vil nulstilles om {0} timer."
+
+#, java-format
+msgid "§4Requirements = will reset in {0} minutes."
+msgstr "§4Kravene vil = nulstilles om {0} minutter."
+
+msgid "§eThis challenge\n requires the following:"
+msgstr "§eDenne udfordring\n kræver følgende:"

--- a/po-utils/src/test/resources/invalid_missing_msgstr.po
+++ b/po-utils/src/test/resources/invalid_missing_msgstr.po
@@ -1,0 +1,32 @@
+# uSkyBlock Localization for Danish.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uSkyBlock package.
+# Rasmus Lock Fuglsang <steam@lockfuglsang.dk>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: v2.2\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2015-10-30 23:22+0100\n"
+"Last-Translator: R4zorax\n"
+"Language-Team: da <LL@li.org>\n"
+"Language: da_DK\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Kravene vil nulstilles om {0} timer."
+
+#, java-format
+msgid "§4Requirements = will reset in {0} minutes."
+msgstr "§4Kravene vil = nulstilles om {0} minutter."
+
+msgid "§eThis challenge\n requires the following:"
+msgstr "§eDenne udfordring\n kræver følgende:"

--- a/po-utils/src/test/resources/invalid_mixed_content.po
+++ b/po-utils/src/test/resources/invalid_mixed_content.po
@@ -1,0 +1,35 @@
+# uSkyBlock Localization for Danish.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uSkyBlock package.
+# Rasmus Lock Fuglsang <steam@lockfuglsang.dk>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: v2.2\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2015-10-30 23:22+0100\n"
+"Last-Translator: R4zorax\n"
+"Language-Team: da <LL@li.org>\n"
+"Language: da_DK\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Kravene vil nulstilles om {0} dage."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Kravene vil nulstilles om {0} timer."
+
+#, java-format
+msgid "§4Requirements = will reset in {0} minutes."
+msgstr "§4Kravene vil = nulstilles om {0} minutter."
+
+hej mor
+
+msgid "§eThis challenge requires the following:"
+msgstr "§eDenne udfordring kræver følgende:"

--- a/po-utils/src/test/resources/po/en.po
+++ b/po-utils/src/test/resources/po/en.po
@@ -1,0 +1,21 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2017-03-12 22:29+0000\n"
+"Last-Translator: dutchy1001\n"
+"Language-Team: uSkyblock-dev team\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.11\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#, java-format
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§eYou have no azzess to the schemz"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§4* §7No expired coolupz for §6{0}§7 found."

--- a/po-utils/src/test/resources/valid_da.po
+++ b/po-utils/src/test/resources/valid_da.po
@@ -1,0 +1,38 @@
+# uSkyBlock Localization for Danish.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uSkyBlock package.
+# Rasmus Lock Fuglsang <steam@lockfuglsang.dk>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: v2.2\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2015-10-30 23:22+0100\n"
+"Last-Translator: R4zorax\n"
+"Language-Team: da <LL@li.org>\n"
+"Language: da_DK\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Kravene vil nulstilles om {0} dage."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Kravene vil "
+"nulstilles om {0} timer."
+
+#, java-format
+msgid "§4Requirements = "
+"will reset in "
+"{0} minutes."
+msgstr "§4Kravene vil = "
+"nulstilles om "
+"{0} minutter."
+
+msgid "§eThis challenge\n requires the following:"
+msgstr "§eDenne udfordring\n kræver følgende:"

--- a/po-utils/src/test/resources/valid_emptylines_id.po
+++ b/po-utils/src/test/resources/valid_emptylines_id.po
@@ -1,0 +1,35 @@
+# uSkyBlock Localization for Danish.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uSkyBlock package.
+# Rasmus Lock Fuglsang <steam@lockfuglsang.dk>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: v2.2\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2015-10-30 23:22+0100\n"
+"Last-Translator: R4zorax\n"
+"Language-Team: da <LL@li.org>\n"
+"Language: da_DK\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Kravene vil nulstilles om {0} dage."
+
+#, java-format
+msgid "§4Requirements will"
+
+" reset in {0} hours."
+msgstr "§4Kravene vil nulstilles om {0} timer."
+
+#, java-format
+msgid "§4Requirements = will reset in {0} minutes."
+msgstr "§4Kravene vil = nulstilles om {0} minutter."
+
+msgid "§eThis challenge\n requires the following:"
+msgstr "§eDenne udfordring\n kræver følgende:"

--- a/po-utils/src/test/resources/valid_emptylines_str.po
+++ b/po-utils/src/test/resources/valid_emptylines_str.po
@@ -1,0 +1,36 @@
+# uSkyBlock Localization for Danish.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uSkyBlock package.
+# Rasmus Lock Fuglsang <steam@lockfuglsang.dk>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: v2.2\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2015-10-30 23:22+0100\n"
+"Last-Translator: R4zorax\n"
+"Language-Team: da <LL@li.org>\n"
+"Language: da_DK\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Kravene vil nulstilles om {0} dage."
+
+#, java-format
+msgid "§4Requirements will"
+" reset in {0} hours."
+msgstr "§4Kravene vil"
+
+" nulstilles om {0} timer."
+
+#, java-format
+msgid "§4Requirements = will reset in {0} minutes."
+msgstr "§4Kravene vil = nulstilles om {0} minutter."
+
+msgid "§eThis challenge\n requires the following:"
+msgstr "§eDenne udfordring\n kræver følgende:"

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     </properties>
 
     <modules>
+        <module>po-utils</module>
         <module>uSkyBlock-API</module>
         <module>uSkyBlock-Core</module>
         <module>uSkyBlock-Plugin</module>
@@ -198,6 +199,11 @@
             <dependency>
                 <groupId>uSkyBlock</groupId>
                 <artifactId>uSkyBlock-FAWE</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>uSkyBlock</groupId>
+                <artifactId>po-utils</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -6,6 +6,9 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
   echo -e "Publishing javadocs and artifacts...\n"
   cd $HOME
 
+  rsync -r --quiet $HOME/build/uskyblock/uSkyBlock/po-utils/target/mvn-repo/ \
+  dool1@shell.xs4all.nl:WWW/maven/uskyblock/
+
   rsync -r --quiet $HOME/build/uskyblock/uSkyBlock/uSkyBlock-API/target/mvn-repo/ \
   dool1@shell.xs4all.nl:WWW/maven/uskyblock/
 
@@ -16,6 +19,9 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
   dool1@shell.xs4all.nl:WWW/maven/uskyblock/
 
   echo -e "Publishing javadocs...\n"
+
+  rsync -r --delete --quiet $HOME/build/uskyblock/uSkyBlock/po-utils/target/site/apidocs/ \
+  dool1@shell.xs4all.nl:WWW/javadocs/release/po-utils/
 
   rsync -r --delete --quiet $HOME/build/uskyblock/uSkyBlock/uSkyBlock-API/target/site/apidocs/ \
   dool1@shell.xs4all.nl:WWW/javadocs/release/uSkyBlock-API/

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -3,8 +3,11 @@
 if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
 
     echo -e "Running staging script...\n"
-    echo -e "Publishing artifacts...\n"
+    echo -e "Publishing javadocs and artifacts...\n"
     cd $HOME
+
+    rsync -r --quiet $HOME/build/uskyblock/uSkyBlock/po-utils/target/mvn-repo/ \
+    dool1@shell.xs4all.nl:WWW/maven/uskyblock/
 
     rsync -r --quiet $HOME/build/uskyblock/uSkyBlock/uSkyBlock-API/target/mvn-repo/ \
     dool1@shell.xs4all.nl:WWW/maven/uskyblock/
@@ -16,6 +19,9 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     dool1@shell.xs4all.nl:WWW/maven/uskyblock/
 
     echo -e "Publishing javadocs...\n"
+
+    rsync -r --delete --quiet $HOME/build/uskyblock/uSkyBlock/po-utils/target/site/apidocs/ \
+    dool1@shell.xs4all.nl:WWW/javadocs/master/po-utils/
 
     rsync -r --delete --quiet $HOME/build/uskyblock/uSkyBlock/uSkyBlock-API/target/site/apidocs/ \
     dool1@shell.xs4all.nl:WWW/javadocs/master/uSkyBlock-API/

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -339,7 +339,7 @@
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>dk.lockfuglsang.minecraft</groupId>
+            <groupId>uSkyBlock</groupId>
             <artifactId>po-utils</artifactId>
         </dependency>
         <dependency>

--- a/uSkyBlock-Core/src/main/po/cs.po
+++ b/uSkyBlock-Core/src/main/po/cs.po
@@ -11,12 +11,45 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.9\n"
 
+msgid "d"
+msgstr "d"
+
+msgid "h"
+msgstr "h"
+
+msgid "m"
+msgstr "m"
+
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr ""
 
 #, java-format
 msgid "§eInvalid command: {0}"
+msgstr ""
+
+msgid "Command"
+msgstr ""
+
+msgid "Permission"
+msgstr ""
+
+msgid "Description"
 msgstr ""
 
 #, java-format
@@ -42,1677 +75,11 @@ msgstr ""
 msgid "§4Error writing documentation: {0}"
 msgstr ""
 
-msgid "Command"
+msgid "§cWither Despawned!§e It wandered too far from your island."
 msgstr ""
 
-msgid "Permission"
-msgstr ""
-
-msgid "Description"
-msgstr ""
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-msgid "d"
-msgstr "d"
-
-msgid "h"
-msgstr "h"
-
-msgid "m"
-msgstr "m"
-
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eJeste tyto bloky: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4Za  {0} dni se obnovi zadani ukolu."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4Za {0} hodin se obnovi zadani ukolu."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4Za  {0} minut se obnovi zadani ukolu."
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr ""
-
-msgid "§7and more..."
-msgstr "§7a vice..."
-
-msgid "§eItems will be traded for reward."
-msgstr ""
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr ""
-
-msgid "§6Item Reward: §a"
-msgstr "§6Odmeny: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Odmena financni: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Odmena v XP: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dCelkem splneno: §f{0} §dx"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4Ukol s timto nazvem {0} nebyl nalezen"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4Musis byt na svem ostrove!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§4Tento ukol {0} neni zatim k dispozici!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4Tento ukol {0} nejde opakovat!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§ePokusil ses ukoncit ukol: §a{0}"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr "§4Pro splneni ukolu musis byt max {0} bloku od umistenych predmetu."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4Pro dokonceni tohoto ukolu je potreba mit level ostrova: {0} !"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Neznamy typ ukolu: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§eJeste tyto entity:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§ePro tento ukol potrebujes:{0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aUkol: {0} jsi uspesne splnil!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9{0}§f uspesne splnil ukol: §9{1}§f!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§eOdmeny: §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eXP odmena: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eFinancni odmena: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§ePozor! §4Mas plny inventar!§e. Odmeny budes mit vedle sebe na zemi."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lKlikni pro dokonceni ukolu."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lNemuzes opakovat tento ukol."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Sekce: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fKompletni splneni ukolu v teto sekci"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fodemkne nasledujici sekci."
-
-msgid "§eClick here to show previous page"
-msgstr "§eKlikni pro predchozi stranku"
-
-msgid "§eClick here to show next page"
-msgstr "§eKlikni pro nasledujici stranku"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lUkol je uzamcen."
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "§7Chybi ti {0} jeste {1} §7ukoly"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7pro kompletni {0}"
-
-msgid "to unlock this rank"
-msgstr "k odemknuti teto sekce"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr ""
-
-msgid "But you are Yelling in the wind!"
-msgstr ""
-
-msgid "But your fantasy friends are gone!"
-msgstr ""
-
-msgid "But you are Talking to your self!"
-msgstr ""
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cPromin! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr ""
-
-msgid "party"
-msgstr ""
-
-msgid "island"
-msgstr ""
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr ""
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr ""
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr ""
-
-msgid "§cCommand only available to players"
-msgstr ""
-
-msgid "talk to players on your island"
-msgstr "mluv k hracum na svem ostrove "
-
-msgid "talk to your island party"
-msgstr "mluv ke sve parte"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§eTento hrac {0} nema zadny ostrov!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eNeplatny hrac {0} doplnen."
-
-msgid "Manage challenges for a player"
-msgstr "Sprava ukolu pro hrace"
-
-msgid "resets the challenge for the player"
-msgstr "resetovat ukoly pro hrace"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4Ukol nebyl nikdy dokoncen"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§eUkol: {0} byl resetovan na {1}"
-
-msgid "resets all challenges for the player"
-msgstr "Reset vsech ukolu pro hrace"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0} ma vsechny ukoly zresetovat."
-
-msgid "complete all challenges in the rank"
-msgstr "dokoncil vsechny ukoly v sekci"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4Zadny hrac s timto jmenem {0} nebyl nalezen!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4Ukol {0} byl jiz dokoncen."
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§eUkol {0} byl dokoncen: {1}"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4Zadny ukol s timto nazvem {0} nebyl nalezen!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4Zadna sekce s timto nazvem{0} nebyla nalezena!"
-
-msgid "manage islands"
-msgstr "Uprava ostrova"
-
-msgid "protects the island"
-msgstr "Ochrana ostrova"
-
-msgid "delete the island (removes the blocks)"
-msgstr "Smazat ostrov ( odstrani bloky)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Smaze zapomenuty ostrov na tve soucasne pozici"
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4Ostrov na této pozici ma cleny!\n"
-"§ePouzij §9/usb island delete <name>§e pro smazani."
-
-msgid "removes the player from the island"
-msgstr "Odstrani hrace z ostrova"
-
-msgid "adds the player to the island"
-msgstr "Prida hrace na ostrov."
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d se pridal na tvuj ostrov."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4Zadny hrac jmenem {0} nebyl nalezen!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-"§4Zadny platny ostrov nenalezen, ani zadni osamoceny ostrov nebo ostrov "
-"ktery jiz ma jmeno."
-
-msgid "print out info about the island"
-msgstr "Zobrazit informace o ostrovu."
-
-msgid "sets the biome of the island"
-msgstr "Nastavit biom ostrova."
-
-msgid "§4That player has no island."
-msgstr "§4Tento hrac nema ostrov."
-
-msgid "§4No valid island at your location"
-msgstr "§4Zadny ostrov na tomto miste."
-
-msgid "purges the island"
-msgstr "Ocistit ostrov."
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Chyba! §9Zadny ostrov na ocisteni nebyl nazelen."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cPURGE: §9Cistim ostrov na {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "Prepinani ignorovani na ostrove"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cSet {0}s Ostrov ktery ma byt ignorovan v TOP-10 a ma byt ocisteny"
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§cOdstraneno ignorovani  {0}s ostrova, nyni bude viditelny v TOP-10 a "
-"ocisten."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Jmeno hrace neni podporovane."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Odstranuji {0} z ostrova."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eZmena podnebi z {0} na ostrove  na:  {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eZmena podnebi z {0} na ostrove  na  OCEAN."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr "§aMozna budes muset jit na spawn a zpet, aby se zmeny projevily."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} bylo podnebi zmeneno na:  {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} bylo podnebi zmeneno na OCEAN."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eOdstranuji {0}''s ostrov."
-
-msgid "Error: That player does not have an island!"
-msgstr "Chyba: Tento hrac nema ostrov!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "e{0}s Ostrov  {1} je nyní chranen."
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4{0}s Ostrov at {1} uz je chranen."
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "Otevri GUI pro nastaveni"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§Neplatne konfiguracni jmeno"
-
-msgid "Controls player-cooldowns"
-msgstr "Kontrola cooldownu hrace."
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "Vymaze cooldown na prikaz (* = all)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eHrac uz není online."
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Cooldown smazan na {0} pro {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Zadny aktivni cooldown na{0} pro {1} nebyl nalezen."
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Neplatny prikaz, pouze restartovani a biom povolen!"
-
-msgid "restarts the cooldown on the command"
-msgstr "Restaruje cooldown na prikaz"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "%eRestartovat cooldown na {0} pro {1}§e na {2} vteriny,"
-
-msgid "lists all the active cooldowns"
-msgstr "Seznam vsech aktivnich cooldownu"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCmd Cooldown"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eZadny aktivni cooldown pro §9{0}§e nenalezen."
-
-msgid "control debugging"
-msgstr "Kontrola odblokovani"
-
-msgid "set debug-level"
-msgstr "nastav uroven odblokovani"
-
-msgid "toggle debug-logging"
-msgstr "Prepinani protokolu o odblokovani."
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4Prihlaseni nebylo aktivni, takze ho nemuzes zakazat!"
-
-msgid "flush current content of the logger to file."
-msgstr "Datovy tok se ulozil do souboru."
-
-msgid "§eLog-file has been flushed."
-msgstr "§eLog soubor byl smazan."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4Protokolovani neni povoleno, use §d/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Neplatna neznamna, zkus INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eProtokolovani zakazano!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "Pokusi se opravit oblast flatland."
-
-msgid "§4No valid island found"
-msgstr "§4Zadny platny ostrov nenalezen."
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4Zadna volna plocha nenalezena na {0} ostrove!"
-
-msgid "flushes all caches to files"
-msgstr "Vsechna caches byla vyprazdnena"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr "§eSmazan §a{0} ostrov§e, §b{1}hrac a §6{2}a jeho ukoly."
-
-msgid "manually update the top 10 list"
-msgstr "Manualne upravit top 10 seznam"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eGenerovani seznamu TOP 10"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eDokonceno generovani seznamu TOP 10"
-
-msgid "advanced command for getting island-data"
-msgstr "Pokrocile prikazy pro ziskani informaci o ostrove."
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§eMomentalni hodnota pro {0} z ''{1}''"
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§cNelze ziskat informace pro: {0}"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§ePlatne pole jsou {0}"
-
-msgid "teleport to another players island"
-msgstr "Teleportovat k jinemu hraci na ostrov."
-
-msgid "§4Only supported for players"
-msgstr "§4Mohou pouzit pouze hraci."
-
-msgid "§4That player does not have an island!"
-msgstr "§4Tento hrac nema ostrov!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr ""
-
-msgid "imports players and islands from other formats"
-msgstr "Prenese hrace a ostrovy z jineho formatu."
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Statistiky prace"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/job"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "act"
-
-msgid "time"
-msgstr "cas"
-
-msgid "name"
-msgstr "jmeno"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "Zmeni jazyk pluginu a nacte ho znovu."
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aJazyk byl uspesne nastaven na  §e{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cZmena jazyku selhala §e{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Podporovane jazyky:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cNelze najit zadne jazyky."
-
-msgid "transfer leadership to another player"
-msgstr "Predat vedeni jinemu hraci."
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4Hrac {0} nema ostrov k preneseni!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§eHrac§d{0}§e jiz ma svuj ostrov.§ePouzij: §d/usb island remove <name>§e pro "
-"smazani ostrova."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bVedeni predano od {0}§b to {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr "Pokrocile informace o NBT "
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "Ukaze NBTTag pro drzeny predmet."
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§eInformace pro§9{0}"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - jmeno: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - nbttag: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§cZadny predmet v ruce!"
-
-msgid "§eCan only be executed as a player"
-msgstr "§eLze provest pouze jako hrac."
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "Nastaveni NBTTag pro momentalne drzeny predmet"
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "§eNastav §9{0}§e az §c{1}"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "Pridej NBTTag pro momentalne drzeny predmet"
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§ePridan §9{0}§e do §c{1}"
-
-msgid "manage orphans"
-msgstr "Sprava sirotku (opustenych ostrovu)"
-
-msgid "count orphans"
-msgstr "Pocet sirotku"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr ""
-"§ePocet starych pozice §5 {0} §e ostrovu budou uprednostneny pred novymi."
-
-msgid "clear orphans"
-msgstr "Mazani sirotku"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eMazani vsech sirotku"
-
-msgid "list orphans"
-msgstr "Seznam sirotku"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eZadny sirotek momentalne neni."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr ""
-
-msgid "protects all islands (time consuming)"
-msgstr "Ochrana vsech ostrovu ( chvili to potrva)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§cSnazim se prerusit ukol vsech ochran."
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-"§4Omlouvam se!§e Vsechny ochrany jiz bezi. Nech me prvne dokoncit nebo use "
-"§9usb protectall §cstop"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§eStartuji vsechny ochrany. Chvili to potrva."
-
-msgid "purges all abandoned islands"
-msgstr "Ocista vsech zapomenutych ostrovu."
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4Napis pocet dnu kdy se stane sirotkem!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr "§4Snazim se prerusit cisteni"
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr "§4Zacinam cisteni..."
-
-msgid "region manipulations"
-msgstr "Manipulace s regiony"
-
-msgid "shows the borders of the current island"
-msgstr "Ukazuje hranice aktualniho ostrova."
-
-msgid "§eNo island found at your current location"
-msgstr "§eNa aktualni pozici nebyl zadny ostrov nalezen."
-
-msgid "shows the borders of the current chunk"
-msgstr "Ukazuje hranice aktualniho chunku"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "Ukaze hranice vnejsiho chunku"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "Ukaze hranice nezarovnanych chunku"
-
-msgid "shows the borders of the outer-chunks"
-msgstr "ukaze hranice vnejsiho chunku"
-
-msgid "hides the regions again"
-msgstr "Znovu skryje regiony"
-
-msgid "§eStopped displaying regions"
-msgstr "§eZastavi zobrazovani regionu"
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§eV soucasne dobe se tomuto hraci nezobrazuji regiony."
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§eAnimacni tick zmenen na  {0}."
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§eAnimacni tick musí byt platny integer."
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "Nastavi hracuv ostrov do vasi aktualni polohy."
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "Nacitam konfigurace ze souboru."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eKonfigurace byly nacteny."
-
-msgid "advanced command for setting island-data"
-msgstr "Rozsirene prikazy pro nastaveni dat ostrova."
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§c{0} byl nastaven na ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§cNelze nastavit pole {0} az ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr "§cNelze nastavit pole{0} az ''{1}'', cislo bylo ocekavane "
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§cNespravne pole{0}"
-
-msgid "toggles maintenance mode"
-msgstr "Prepinani rezimu udrzby"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr "§cUDRZBA: §aActivated§e vsechny uSkyBlock fuknce momentalne aktivni "
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-"§cUDRZBA: §4Deactivated§e vsechny uSkyBlock funkce jsou zpet v provozu."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr "§cRezim udrzby muze byt spusten pouze z konzole!"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§cPRERUSENO:§e Ochrana vsech byla prerusena!"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr "§eOchrana vsech kompletni v {0}, {1} nove regiony vytvoreny!"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4PURGE:§9 Skenovani preruseno."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4PURGE:§9 Ocista zapomenutych ostrovu dokoncena."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4PURGE:§9 Ocista zapomenutych ostrovu prerusena."
-
-msgid "displays version information"
-msgstr "Zobrazi informace o verzi"
-
-msgid "various WorldGuard utilities"
-msgstr "Moznosti WorldGuard utilit"
-
-msgid "refreshes the chunks around the player"
-msgstr "Znovu nacte chunky okolo hrace."
-
-msgid "§eResending chunks to the client"
-msgstr "§ePreposlani chunku do klienta"
-
-msgid "load the region chunks"
-msgstr "Nacte chunky regionu."
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eNacitam chunky na {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eOdnacitam chunky v {0}"
-
-msgid "update the WG regions"
-msgstr "Aktualizace WG regionu"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§eOstrovni world-guard region aktualizovan pro  {0}"
-
-msgid "§eNo island found at your location!"
-msgstr "§eZadny ostrov na tve pozici nenalezen."
-
-msgid "refreshes the chunk around the player"
-msgstr ""
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Nejvyssi SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "Ukaz informace o hraci"
-
-msgid "try to complete a challenge"
-msgstr "Zkus dokoncit vyzvu."
-
-msgid "§cCommand only available for players."
-msgstr "§cPrikaz dostupny pouze pro hrace."
-
-msgid "show information about the challenge"
-msgstr "Ukaz informace o ukolu."
-
-msgid "§eRank: "
-msgstr "§eSekce: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4Ukol je neopakovatelny."
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr "§4Prijdes o vsechny potrebne predmety kdyz dokoncis tento ukol!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4Vsechny potrebne predmety musi byt umisteny na tvem ostrove, okolo {0} "
-"kolem tebe."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§ePro dokonceni tohoto ukolu, pouzij §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4Nazev ukolu je neplatny! Pouzij  /c help pro vice informaci."
-
-msgid "complete and list challenges"
-msgstr "Seznam kompletnich ukolu."
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eUkoly byly vypnuty. Kontaktuj admina."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4Ukoly muzes splnit pouze ve SkyBlock svete!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4Ukoly muzes splnit pouze kdyz mas ostrov!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4Tvuj ostrov je plny, nebo ma dosazen maximalni pocet pozvani. Nemuzes "
-"prizvat nikoho dalsiho."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4Tento hrac uz je vudce na jinem ostrove."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§ se te snazi pozvat, ale ty jsi uz v parte."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e tep pozval aby ses pridal na jeho ostrov!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr ""
-"§f/island [accept/reject]§e pro prijmuti nebo odmitnuti se k nemu pridat."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4VAROVANI: Prijdes o svuj momentalni ostrov pokud nabidku prijmes!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d pozval {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e odmitl tvoje pozvani."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4nemuzes ted pouzit tento prikaz. Nejdriv musís opustit soucasnou partu."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§aPridal ses na ostrov! Pouzij /island party pro zobrazeni ostatnich hracu v "
-"parte."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§ePozvanka pro {0}§e vyprsela nebo byla zrusena."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§ePozvanka na ostrov  {0}§e vyprsela nebo byla zrusena."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§ePrijmul si zadost pridat se na ostrov."
-
-msgid "§4You haven't been invited."
-msgstr "§4Nebyl jsi pozvan."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eOdmitl jsi pozvani na ostrov."
-
-msgid "accept/reject an invitation."
-msgstr "Prijmi nebo odmitni pozvani prikazy: §e/accept nebo /reject"
-
-msgid "teleports you to your island (or create one)"
-msgstr "Teleportuje te na tvuj ostrov (nebo zalozi novy)"
-
-msgid "ban/unban a player from your island."
-msgstr "Ban/Unban hraci na tvem ostrove."
-
-msgid "exempts user from being banned"
-msgstr ""
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§eNasledujici hraci byly zabanovani pro portovani na tvuj ostrov:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr "§ePro ban/unban pro tvuj ostrov, pouzij /island ban <player>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4Nemuzes zabanovat clena. Napred jej smaz! "
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4Nemas opravneni vyhodit/zabanovat hrace."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§eNelze zabanovat nezname hrace {0}"
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4{0} se te snazil zabanovat na jeho ostrove!"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4{0} je odbanovan."
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eJsi zabanovan §4{0}§e pro portovani na svuj ostrov."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eByl jsi §cBANNED§e pro ostrov hrace {0}§e''."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§eByl jsi odbanovan §a{0}§e pro portovani na svuj ostrov."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eBudes §aUNBANNED§e pro ostrov hrace {0}§e''."
-
-msgid "change the biome of the island"
-msgstr "Meni biom na ostrove."
-
-msgid "exempt player from biome-cooldown"
-msgstr ""
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr ""
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr "§cNemas opravneni zmenit biom na tomto ostrove."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4Nemas opravneni zmenit biom tohoto ostrova!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eMusis byt na svem ostrove aby si mohl zmenit biom!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr "§cZadal jsi spatne nazev biomu. Musi to byt jedno z {0}"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eMuzes znovu zmenit biom az za {0,number,#} minut."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cNemas opravneni menit toto podnebi."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-"§7Pracujeme na zmene biomu: §9{0}§7, nicmene chvili to potrva, bud "
-"trpelivy :) ."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr ""
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aPrave se zmenilo na ostrove podnebi na:  {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} zmenil sve podnebi na: {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr ""
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr ""
-
-msgid "create an island"
-msgstr "Vytvoreni ostrova"
-
-msgid "exempt player from create-cooldown"
-msgstr ""
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4Ostrov nalezen!§e Uz jeden ostrov mas, pokud chces zacit znovu na novem "
-"ostrove napis §b /is restart."
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4Ostrov nalezen. Uz jsi clenem party ktera vlastni ostrov. Pokud chces svuj "
-"vlastni nejprve musis opustit partu."
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eMuzes zalozit novy ostrov za {0,number,#}  sekund."
-
-msgid "teleport to the island home"
-msgstr "Teleportuje te domu na ostrov."
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§cMomentalne se nemuzes teleportovat domu na ostrov, protoze tvuj ostrov se "
-"jeste vytvari."
-
-msgid "check your or another''s island info"
-msgstr "Podivej se na informace o ostrove."
-
-msgid "allows user to see others island info"
-msgstr ""
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4Uroven ostrova není povolena, kontaktuj admina."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eMusis byt na svem ostrove aby si mohl pouzit tento prikaz."
-
-msgid "§4You do not have an island!"
-msgstr "§4Nemas ostrov!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4Nemas pristup k tomuto prikazu!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4Tento hrac neexistuje nebo nema ostrov."
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBloku na {0}s ostrove (page {1,number} of {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Skore poctu bloku"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aLevel ostrova je:  {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "Prizvi hrace na ostrov."
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§ePouzik prikaz §f /island invite <playername>§epro pozvani hrace do tve "
-"party na ostrove."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4Pouze majitel ostrova muze prizvat jiného hrace!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aMuzes jeste prizvat {0} hracu."
-
-msgid "§4You can't invite any more players."
-msgstr "§4Uz nemuzes prizvat dalsi hrace."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4Nemas povoleni prizvat hrace na tento ostrov!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4Tento hrac neni ve hre a nebo neexistuje."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4Nemuzes prizvat sam sebe!:)"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4Tento hrac je vudce tveho ostrova!"
-
-msgid "remove a member from your island."
-msgstr "Smaz hrace z tveho ostrova."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4Nemas povoleni vykopnout ostatni z tohoto ostrova!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4Nemuzes odstranit vudce z tohoto ostrova!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4Prestan se vyhazovat!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0} vas odstranil ze sveho ostrova!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} byl odstranen z ostrova."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0}  se te snazi vykopnout z jeho ostrova!"
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4{0} nyni uz dale nebude vyhazovan."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4{0} te vyhodil z jeho ostrova!"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0}  byl vyhozen z ostrova."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr "§4Tento hrac neni ve tve parte a ani na tvem ostrove."
-
-msgid "leave your party"
-msgstr "Opustil jsi skupinu."
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4Nemuzes opustit svuj ostrov pokud jsi na nem sam. Zkus pouzit /island "
-"restart pokud chces novy ostrov!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§eJsi vlastnikem tohoto ostrova, zkus /island remove <player>"
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eOpustil jsi ostrov a vratil ses na spawn."
-
 #, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0} opustil tvuj ostrov!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4Musis byt ve SkyBlock svete aby si opustil partu!"
-
-msgid "check your or anothers island level"
-msgstr "Zkontroluj svuj level ostrova a nebo ostatnich hracu"
-
-msgid "allows user to query for others levels"
-msgstr ""
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eInformace o ostrove hrace {0} :"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9Tva sekce:  {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "Uzamceni ostrova pro hrace, kteri nejsou clenove tve party."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4Nemas opravneni zamknout svuj ostrov!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4Nemas pristup k tomuto prikazu!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4Nemas opravneni odemknout svuj ostrov!"
-
-msgid "display log"
-msgstr "Zobrazeni logu"
-
-msgid "transfer leadership to another member"
-msgstr "Predani vudce jinemu clenu"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4Muzes pouze predat vlastnictví ostrova jednomu clenu z party !"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e uz je vudce na tvem ostrove!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4Pouze vudce muze predat vudcovstvi!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} se pokusil prevzit tvuj ostrov!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "Zobrazi informace o parte "
-
-msgid "shows information about your party"
-msgstr "Zobrazuje informace o tve parte"
-
-msgid "show pending invites"
-msgstr "Zobrazi nevyrizene pozvanky"
-
-msgid "§eNo pending invites"
-msgstr "§eZadne nevyrizene pozvani nemate."
-
-msgid "withdraw an invite"
-msgstr "Zrusit pozvanku"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4Nemas opravneni zrusit pozvani hrace."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4Tento prikaz muze pouzit pouze hrac"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4Nemas zadny ostrov. §eUse §b/is create§e aby si jeden dostal."
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "Smaz svuj ostrov a zaloz novy."
-
-msgid "exempt player from restart-cooldown"
-msgstr ""
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4Pouze vlastnik muze restartovat tento ostrov. Opust tento ostrov pomoci (/"
-"island leave) a zaloz si vlastni ostrov."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eMusis odstranit vsechny hrace z tveho ostrova (/island kick <player>) pred "
-"tim nez ho restartujes. Podivej se na seznam aktualnich hracu na tvem "
-"ostrove /island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§cOstrov muzes restartovat za {0}  sekund."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§cTvuj ostrov je ve fazi vytvareni, momentalne ho nemuzes restartovat."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§ePOZOR: Tvuj cely ostrov a vsechny veci na nem budou RESETOVANY!"
-
-msgid "set the island-home"
-msgstr "Nastav home pozici na ostrove"
-
-msgid "set your island''s warp location"
-msgstr "Nastav lokaci warpu na ostrove"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cNemas opravneni nastavit misto pro teleport!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr ""
-"§cMusis byt na svem vlastnim ostrove aby si mohl nastavit misto pro teleport."
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d zmenil na ostrove misto pro teleport."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "Teleportuji te na spawn Skyblocku"
-
-msgid "enable/disable warping to your island."
-msgstr "Zapnout/vypnout warpy na tvem ostrove"
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4Tvuj ostrov je uzamcen. Musis ho odemcit předtím nez nastavit teleport."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d  aktivoval teleport na ostrove."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d deaktivovat teleport na ostrove."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr "§cNemas opravneni povolit / zakazat teleport na ostrove!"
-
-msgid "display the top10 of islands"
-msgstr "Zobrazi 10 nejpelsich ostrovu."
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr ""
-
-msgid "trust/untrust a player to help on your island."
-msgstr "Duvera/neduvera ti pomahat od  hracu na ostrove"
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eNasledujici hraci na tvem ostrove jsou duveryhodni:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eNasledujici vudci ti duveruji:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr "§ePro duveru / neduveru tveho ostrova pouzij /island trust <player>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4Clenu ti uz veri!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Neznamy hrac {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eNyni ti zacal verit §4{0}' §ena tvem ostrove."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} veri {1} na ostrove"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eTi prestal verit §4{0}''s §eisland."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0} zrusil duveru {1} na ostrove"
-
-msgid "warp to another player''s island"
-msgstr "warp k ostrovu jneho hrace"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr ""
-"§aTvuj prichozi port je aktivni, hraci se mohou teleportovat na tvuj ostrov."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§4Tvuj prichozi port je neaktivni, hraci se nemohou teleportovat na tvuj "
-"ostrov."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr "§fNastav prichozi port na tve aktualni pozici pomoci §e/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr ""
-"§fZapnes nebo vypnes warpy na svem ostrove pomoci: §e/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4Nemas opravneni vytvorit teleport na svem ostrove!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§fTeleportuj se na jiny ostrov pomoci §e/island warp <player>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4Nemas opravneni teleportovat se na jiny ostrov!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§cTvuj ostrov je ve fazi vytvareni, nemuzes ted nastavit teleport pro "
-"ostatní hrace."
-
-msgid "§4That player does not exist!"
-msgstr "§4Tento hrac neexistuje!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4Tento hrac nema aktivni port."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§cOstrov tohoto hrace je ve fazi vytvareni, prave ted se k nemu nemuzes "
-"teleportovat."
-
-#, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cVAROVANI: §9{0}§e se teleportuje na tvuj ostrov!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4Tento hrac ti zakazal se teleportovat na jeho ostrov"
-
-msgid "general island command"
-msgstr "obecne prikazy ostrova"
-
-msgid "allows user to bypass cooldowns"
-msgstr ""
-
-msgid "allows user to bypass visitor-protections"
-msgstr ""
-
-msgid "allows user to bypass teleport-delay"
-msgstr ""
-
-msgid "allows user to use [usb] signs"
-msgstr ""
-
-msgid "allows user to place [usb] signs"
+msgid "{0}''s Wither"
 msgstr ""
 
 msgid "§eYou can not use another island''s portals!"
@@ -1729,33 +96,6 @@ msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr ""
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr ""
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eNavsteva nemuze vyhazovat predmety!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Vlastnik: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "Nemuzes zvedat predmety ostatnich hracu kdyz jsi na navsteve!"
-
-msgid "Config:"
-msgstr "Config:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§cNemas povoleni! §e Snazis se teleportovat na strechu §cNETHER§e, tohle "
-"neni povoleno!"
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr "§4Obsidian muzes promenit v lavu pouze jednou za 10 vterin."
@@ -1799,19 +139,85 @@ msgstr "§eVejce na spawnuti muzes pouzit pouze na svem ostrove."
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§cDosahl jsi sveho spawn limitu pro svuj ostrov."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eNavsteva nemuze vyhazovat predmety!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Vlastnik: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "Nemuzes zvedat predmety ostatnich hracu kdyz jsi na navsteve!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cBanned:§e Jsi zabanovan pro tento ostrov."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cLocked:§e Tento ostrov je uzamcen! Vstup neni povolen."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eCekam na tvuj tah §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "Neco se pokazilo, ukladani ostrova nebo udaje o parte!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr "Konvertuji data pro UUID, tohle muze chvili trvat!"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§cUDRZBA:§e uSkyBlock je momentalne v modu udrzby"
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Vytvarim ostrov...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"§buSkyBlock§e zalezi na §9{0}§e >= §av{1}§e ale pouze §cv{2}§e bylo "
+"nalezeno!\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e zalezi na§9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§eNemas pristup k planum ostrova!"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4Hrac je jiz prirazen na tento ostrov!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4Musis byt bliz sveho ostrova aby si mohl nastavit domov!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aTvuj domov na SkyBlocku byl nastaven na tvoje aktualni pozici."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4Tvoje momentalni pozice neni bezpecna pro nastaveni domova."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+"§7Pracujeme na zmene biomu: §9{0}§7, nicmene chvili to potrva, bud "
+"trpelivy :) ."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr "§cTvuj ostrov se prave vytvari, nemuzes hned zalozit novy!"
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "Pokud ti nejde zalozit ostrov, prosim kontaktuj admina."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+"§eTvuj ostrov bude brzy pripraven, bud trpelivy, muze to chvilku trvat."
+
+msgid "§cCommand is currently disabled!"
+msgstr "§cPrikaz je momentalne necinny!"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eJeste tyto bloky: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1824,9 +230,6 @@ msgid ""
 msgstr ""
 "§ePrikaz §9{0}§e je §criskantni§e. Opakuj prikaz do §a{1}§e sekund pro "
 "vykonani!"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4**Vstupujes do chranene, ale opustene oblasti ostrova."
@@ -1859,212 +262,33 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4Musis byt vudce party aby si odemcel svuj ostrov!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eCekam na tvuj tah §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Vytvarim ostrov...§e{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lUkol je uzamcen."
+
+msgid "READY"
+msgstr "PRIPRAVEN"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§7PlayerDB: Filtrovane {0} jmena"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§7MojangAPI: Pokousim se nacist  {0} hracu z Mojangu"
-
-msgid "SUCCESS"
-msgstr "V poradku"
-
-msgid "FAILED"
-msgstr "Chyba"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§7 - MojangAPI:§aCOMPLETED: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§7 - MojangAPI:§cERROR: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4Zadny import s nazvem §e{0}§4 nenalezen"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§eKonvertovano {0}/{1} souboru v  {2}"
-
-msgid "The island has been created."
-msgstr "Ostrov byl vytvoren."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d zamcel ostrov."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr ""
-"§4Od doby co byl tvuj ostrov uzamcen, tvoje prichozi porty jsou neaktivni."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d odemcel ostrov."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cSKY §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d byl odstranen z party ostrova."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9Vytvarim ostrov na tve pozici."
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9Vytvareni ostrova §7{0}§9 od tebe"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§4Tento ukol {0} neni zatim k dispozici!"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
-msgstr "§cOstrov a jeho soucasti budou smazany! Posilam te na spawn."
-
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§cOstrov na kterem jsi bude smazan! Posilam te na spawn."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eSEZNAM NEJLEPSICH HRACU SKYBLOCKU: (page {0} of {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr "§4Toplist je prazdny! Vypisuji se pouze ostrovy s levlem {0} a vyse ."
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eTve umisteni je: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "NEZNAMY"
-
-msgid "ANIMAL"
-msgstr "Zvirat"
-
-msgid "MONSTER"
-msgstr "Monster"
-
-msgid "VILLAGER"
-msgstr "Vesnicanu"
-
-msgid "GOLEM"
-msgstr "Golemu"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (max. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "Nemozne najit shcema {0}, kontaktuj admina"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aGratuluji! §eTvuj ostrov se objevil!"
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cPOZNAMKA:§e Stavba by mohla stale probíhat."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Pouzij §9/is h§r nebo  §9/is§r nabidku."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§cWatchdog!§9 Nemozne urcit pozici truhly v  {0}."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7Strana {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
+"§cVAROVANI:§e Nemohu prenest vsechny pozadovane itemy do tvého inventare!"
 
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr ""
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr ""
-
-msgid "Return"
-msgstr "Navrat"
-
-msgid "§9Integer Editor"
-msgstr "§9Integrovany editor"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eKonfigurace ulozena a restartovana."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cChyba! §9Nelze ulozit konfiguracni soubor!"
-
-msgid "§3First Page"
-msgstr "§3Dalsi stranka"
-
-msgid "§3Last Page"
-msgstr "§3Predchozi stranka"
-
-msgid "§cSave & Reload config"
-msgstr "§cUlozeni & znovunacteni konfigurace"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Ulozi nastaveni do\n"
-"§7souboru a znovu se nacte.\n"
-"§cPoznamka: §7pouzivejte to opatrne!!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (pouze ke cteni)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr "§cNedostatek itemu v truhle pro splneni ukolu!"
 
 msgid "true"
 msgstr "ano"
@@ -2492,6 +716,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "§7Aktualni stranka"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7Strana {0}"
+
 msgid "§7First Page"
 msgstr "§7Prvni strana"
 
@@ -2788,8 +1016,8 @@ msgstr "§cKlikni pro odchod"
 msgid "Island Restart Menu"
 msgstr "Restart menu ostrova"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§eNemas pristup k planum ostrova!"
+msgid "Config:"
+msgstr "Config:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2805,115 +1033,122 @@ msgstr "§cKlikni v §9{0}§c pro restart!"
 msgid "§aClick to restart!"
 msgstr "§aKIikni pro restartovani!"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr ""
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr ""
+
+msgid "Return"
+msgstr "Navrat"
+
+msgid "§9Integer Editor"
+msgstr "§9Integrovany editor"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9Textovy editor"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eKonfigurace ulozena a restartovana."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cChyba! §9Nelze ulozit konfiguracni soubor!"
+
+msgid "§3First Page"
+msgstr "§3Dalsi stranka"
+
+msgid "§3Last Page"
+msgstr "§3Predchozi stranka"
+
+msgid "§cSave & Reload config"
+msgstr "§cUlozeni & znovunacteni konfigurace"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Ulozi nastaveni do\n"
+"§7souboru a znovu se nacte.\n"
+"§cPoznamka: §7pouzivejte to opatrne!!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (pouze ke cteni)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4Zadny import s nazvem §e{0}§4 nenalezen"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§eKonvertovano {0}/{1} souboru v  {2}"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§7PlayerDB: Filtrovane {0} jmena"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§7MojangAPI: Pokousim se nacist  {0} hracu z Mojangu"
+
+msgid "SUCCESS"
+msgstr "V poradku"
+
+msgid "FAILED"
+msgstr "Chyba"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§7 - MojangAPI:§aCOMPLETED: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§7 - MojangAPI:§cERROR: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "Prilis mnoho pozadavku pro Mojang API ({0} within {1}), sleeping {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§ePosilam te na spawn."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§eOstrov bude  §cLOCKED§e."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aBudes teleportovan za {0} vterin."
-
-msgid "§7Teleport cancelled"
-msgstr "§7Teleport prerusen."
-
-msgid "READY"
-msgstr "PRIPRAVEN"
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-"§cVAROVANI:§e Nemohu prenest vsechny pozadovane itemy do tvého inventare!"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr "§cNedostatek itemu v truhle pro splneni ukolu!"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Neco se pokazilo, ukladani ostrova nebo udaje o parte!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr "Konvertuji data pro UUID, tohle muze chvili trvat!"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§cUDRZBA:§e uSkyBlock je momentalne v modu udrzby"
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"§buSkyBlock§e zalezi na §9{0}§e >= §av{1}§e ale pouze §cv{2}§e bylo "
-"nalezeno!\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e zalezi na§9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4Hrac je jiz prirazen na tento ostrov!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4Je nemozne najit bezpecny bod pro domov na tvem ostrove!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§cVAROVANI: §eTeleportuji te do vzduchu."
-
-msgid "§aTeleporting you to your island."
-msgstr "§aTeleportuji te na tvuj ostrov."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Je nemozne te teleportovat na ostrov tohoto hrace!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aTeleportuji te na ostrov hrace {0}."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4Musis byt bliz sveho ostrova aby si mohl nastavit domov!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aTvuj domov na SkyBlocku byl nastaven na tvoje aktualni pozici."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4Tvoje momentalni pozice neni bezpecna pro nastaveni domova."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cTvuj ostrov se prave vytvari, nemuzes hned zalozit novy!"
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "Pokud ti nejde zalozit ostrov, prosim kontaktuj admina."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-"§eTvuj ostrov bude brzy pripraven, bud trpelivy, muze to chvilku trvat."
-
-msgid "§cCommand is currently disabled!"
-msgstr "§cPrikaz je momentalne necinny!"
 
 msgid "North"
 msgstr "Sever"
@@ -2938,3 +1173,1764 @@ msgstr "Zapad"
 
 msgid "North-West"
 msgstr "Severozapad"
+
+msgid "The island has been created."
+msgstr "Ostrov byl vytvoren."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d zamcel ostrov."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr ""
+"§4Od doby co byl tvuj ostrov uzamcen, tvoje prichozi porty jsou neaktivni."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d deaktivovat teleport na ostrove."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d odemcel ostrov."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cSKY §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d byl odstranen z party ostrova."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9Vytvarim ostrov na tve pozici."
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9Vytvareni ostrova §7{0}§9 od tebe"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aGratuluji! §eTvuj ostrov se objevil!"
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cPOZNAMKA:§e Stavba by mohla stale probíhat."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Pouzij §9/is h§r nebo  §9/is§r nabidku."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "Nemozne najit shcema {0}, kontaktuj admina"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§cWatchdog!§9 Nemozne urcit pozici truhly v  {0}."
+
+msgid "UNKNOWN"
+msgstr "NEZNAMY"
+
+msgid "ANIMAL"
+msgstr "Zvirat"
+
+msgid "MONSTER"
+msgstr "Monster"
+
+msgid "VILLAGER"
+msgstr "Vesnicanu"
+
+msgid "GOLEM"
+msgstr "Golemu"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (max. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr "§cOstrov a jeho soucasti budou smazany! Posilam te na spawn."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§cOstrov na kterem jsi bude smazan! Posilam te na spawn."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eSEZNAM NEJLEPSICH HRACU SKYBLOCKU: (page {0} of {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr "§4Toplist je prazdny! Vypisuji se pouze ostrovy s levlem {0} a vyse ."
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4Uroven ostrova není povolena, kontaktuj admina."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eTve umisteni je: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "§7Chybi ti {0} jeste {1} §7ukoly"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7pro kompletni {0}"
+
+msgid "to unlock this rank"
+msgstr "k odemknuti teto sekce"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Za  {0} dni se obnovi zadani ukolu."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Za {0} hodin se obnovi zadani ukolu."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4Za  {0} minut se obnovi zadani ukolu."
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr ""
+
+msgid "§7and more..."
+msgstr "§7a vice..."
+
+msgid "§eItems will be traded for reward."
+msgstr ""
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr ""
+
+msgid "§6Item Reward: §a"
+msgstr "§6Odmeny: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Odmena financni: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Odmena v XP: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dCelkem splneno: §f{0} §dx"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4Ukol s timto nazvem {0} nebyl nalezen"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4Musis byt na svem ostrove!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4Tento ukol {0} nejde opakovat!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§ePokusil ses ukoncit ukol: §a{0}"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr "§4Pro splneni ukolu musis byt max {0} bloku od umistenych predmetu."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4Pro dokonceni tohoto ukolu je potreba mit level ostrova: {0} !"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Neznamy typ ukolu: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§eJeste tyto entity:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§ePro tento ukol potrebujes:{0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aUkol: {0} jsi uspesne splnil!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9{0}§f uspesne splnil ukol: §9{1}§f!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§eOdmeny: §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eXP odmena: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eFinancni odmena: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§ePozor! §4Mas plny inventar!§e. Odmeny budes mit vedle sebe na zemi."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lKlikni pro dokonceni ukolu."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lNemuzes opakovat tento ukol."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Sekce: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fKompletni splneni ukolu v teto sekci"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fodemkne nasledujici sekci."
+
+msgid "§eClick here to show previous page"
+msgstr "§eKlikni pro predchozi stranku"
+
+msgid "§eClick here to show next page"
+msgstr "§eKlikni pro nasledujici stranku"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr ""
+
+msgid "But you are Yelling in the wind!"
+msgstr ""
+
+msgid "But your fantasy friends are gone!"
+msgstr ""
+
+msgid "But you are Talking to your self!"
+msgstr ""
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cPromin! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr ""
+
+msgid "party"
+msgstr ""
+
+msgid "island"
+msgstr ""
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr ""
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr ""
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr ""
+
+msgid "§cCommand only available to players"
+msgstr ""
+
+msgid "talk to your island party"
+msgstr "mluv ke sve parte"
+
+msgid "talk to players on your island"
+msgstr "mluv k hracum na svem ostrove "
+
+msgid "manually update the top 10 list"
+msgstr "Manualne upravit top 10 seznam"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eGenerovani seznamu TOP 10"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eDokonceno generovani seznamu TOP 10"
+
+msgid "purges all abandoned islands"
+msgstr "Ocista vsech zapomenutych ostrovu."
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4Napis pocet dnu kdy se stane sirotkem!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr "§4Snazim se prerusit cisteni"
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr "§4Zacinam cisteni..."
+
+msgid "Controls player-cooldowns"
+msgstr "Kontrola cooldownu hrace."
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "Vymaze cooldown na prikaz (* = all)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eHrac uz není online."
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Cooldown smazan na {0} pro {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Zadny aktivni cooldown na{0} pro {1} nebyl nalezen."
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Neplatny prikaz, pouze restartovani a biom povolen!"
+
+msgid "restarts the cooldown on the command"
+msgstr "Restaruje cooldown na prikaz"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "%eRestartovat cooldown na {0} pro {1}§e na {2} vteriny,"
+
+msgid "lists all the active cooldowns"
+msgstr "Seznam vsech aktivnich cooldownu"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCmd Cooldown"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eZadny aktivni cooldown pro §9{0}§e nenalezen."
+
+msgid "toggles maintenance mode"
+msgstr "Prepinani rezimu udrzby"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr "§cUDRZBA: §aActivated§e vsechny uSkyBlock fuknce momentalne aktivni "
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+"§cUDRZBA: §4Deactivated§e vsechny uSkyBlock funkce jsou zpet v provozu."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr "§cRezim udrzby muze byt spusten pouze z konzole!"
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Statistiky prace"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/job"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "act"
+
+msgid "time"
+msgstr "cas"
+
+msgid "name"
+msgstr "jmeno"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§eTento hrac {0} nema zadny ostrov!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eNeplatny hrac {0} doplnen."
+
+msgid "flushes all caches to files"
+msgstr "Vsechna caches byla vyprazdnena"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr "§eSmazan §a{0} ostrov§e, §b{1}hrac a §6{2}a jeho ukoly."
+
+msgid "tries to fix the the area of flatland."
+msgstr "Pokusi se opravit oblast flatland."
+
+msgid "§4No valid island found"
+msgstr "§4Zadny platny ostrov nenalezen."
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4Zadna volna plocha nenalezena na {0} ostrove!"
+
+msgid "manage orphans"
+msgstr "Sprava sirotku (opustenych ostrovu)"
+
+msgid "count orphans"
+msgstr "Pocet sirotku"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr ""
+"§ePocet starych pozice §5 {0} §e ostrovu budou uprednostneny pred novymi."
+
+msgid "clear orphans"
+msgstr "Mazani sirotku"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eMazani vsech sirotku"
+
+msgid "list orphans"
+msgstr "Seznam sirotku"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eZadny sirotek momentalne neni."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "Predat vedeni jinemu hraci."
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4Hrac {0} nema ostrov k preneseni!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eHrac§d{0}§e jiz ma svuj ostrov.§ePouzij: §d/usb island remove <name>§e pro "
+"smazani ostrova."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bVedeni predano od {0}§b to {1}"
+
+msgid "open GUI for config"
+msgstr "Otevri GUI pro nastaveni"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§Neplatne konfiguracni jmeno"
+
+msgid "teleport to another players island"
+msgstr "Teleportovat k jinemu hraci na ostrov."
+
+msgid "§4Only supported for players"
+msgstr "§4Mohou pouzit pouze hraci."
+
+msgid "§4That player does not have an island!"
+msgstr "§4Tento hrac nema ostrov!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr ""
+
+msgid "various WorldGuard utilities"
+msgstr "Moznosti WorldGuard utilit"
+
+msgid "refreshes the chunks around the player"
+msgstr "Znovu nacte chunky okolo hrace."
+
+msgid "§eResending chunks to the client"
+msgstr "§ePreposlani chunku do klienta"
+
+msgid "load the region chunks"
+msgstr "Nacte chunky regionu."
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eNacitam chunky na {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eOdnacitam chunky v {0}"
+
+msgid "update the WG regions"
+msgstr "Aktualizace WG regionu"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§eOstrovni world-guard region aktualizovan pro  {0}"
+
+msgid "§eNo island found at your location!"
+msgstr "§eZadny ostrov na tve pozici nenalezen."
+
+msgid "refreshes the chunk around the player"
+msgstr ""
+
+msgid "region manipulations"
+msgstr "Manipulace s regiony"
+
+msgid "shows the borders of the current island"
+msgstr "Ukazuje hranice aktualniho ostrova."
+
+msgid "§eNo island found at your current location"
+msgstr "§eNa aktualni pozici nebyl zadny ostrov nalezen."
+
+msgid "§eCan only be executed as a player"
+msgstr "§eLze provest pouze jako hrac."
+
+msgid "shows the borders of the current chunk"
+msgstr "Ukazuje hranice aktualniho chunku"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "Ukaze hranice vnejsiho chunku"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "Ukaze hranice nezarovnanych chunku"
+
+msgid "shows the borders of the outer-chunks"
+msgstr "ukaze hranice vnejsiho chunku"
+
+msgid "hides the regions again"
+msgstr "Znovu skryje regiony"
+
+msgid "§eStopped displaying regions"
+msgstr "§eZastavi zobrazovani regionu"
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§eV soucasne dobe se tomuto hraci nezobrazuji regiony."
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§eAnimacni tick zmenen na  {0}."
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§eAnimacni tick musí byt platny integer."
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4PURGE:§9 Ocista zapomenutych ostrovu dokoncena."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4PURGE:§9 Ocista zapomenutych ostrovu prerusena."
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4PURGE:§9 Skenovani preruseno."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§cPRERUSENO:§e Ochrana vsech byla prerusena!"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr "§eOchrana vsech kompletni v {0}, {1} nove regiony vytvoreny!"
+
+msgid "control debugging"
+msgstr "Kontrola odblokovani"
+
+msgid "set debug-level"
+msgstr "nastav uroven odblokovani"
+
+msgid "toggle debug-logging"
+msgstr "Prepinani protokolu o odblokovani."
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4Prihlaseni nebylo aktivni, takze ho nemuzes zakazat!"
+
+msgid "flush current content of the logger to file."
+msgstr "Datovy tok se ulozil do souboru."
+
+msgid "§eLog-file has been flushed."
+msgstr "§eLog soubor byl smazan."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4Protokolovani neni povoleno, use §d/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Neplatna neznamna, zkus INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eProtokolovani zakazano!"
+
+msgid "advanced command for setting island-data"
+msgstr "Rozsirene prikazy pro nastaveni dat ostrova."
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§c{0} byl nastaven na ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§cNelze nastavit pole {0} az ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr "§cNelze nastavit pole{0} az ''{1}'', cislo bylo ocekavane "
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§cNespravne pole{0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§eMomentalni hodnota pro {0} z ''{1}''"
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§cNelze ziskat informace pro: {0}"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§ePlatne pole jsou {0}"
+
+msgid "set a player''s island to your location"
+msgstr "Nastavi hracuv ostrov do vasi aktualni polohy."
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr "Pokrocile informace o NBT "
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "Ukaze NBTTag pro drzeny predmet."
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§eInformace pro§9{0}"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - jmeno: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - nbttag: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§cZadny predmet v ruce!"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "Nastaveni NBTTag pro momentalne drzeny predmet"
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "§eNastav §9{0}§e az §c{1}"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "Pridej NBTTag pro momentalne drzeny predmet"
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§ePridan §9{0}§e do §c{1}"
+
+msgid "Manage challenges for a player"
+msgstr "Sprava ukolu pro hrace"
+
+msgid "resets the challenge for the player"
+msgstr "resetovat ukoly pro hrace"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4Ukol nebyl nikdy dokoncen"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§eUkol: {0} byl resetovan na {1}"
+
+msgid "resets all challenges for the player"
+msgstr "Reset vsech ukolu pro hrace"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0} ma vsechny ukoly zresetovat."
+
+msgid "complete all challenges in the rank"
+msgstr "dokoncil vsechny ukoly v sekci"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4Zadny hrac s timto jmenem {0} nebyl nalezen!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4Ukol {0} byl jiz dokoncen."
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§eUkol {0} byl dokoncen: {1}"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4Zadny ukol s timto nazvem {0} nebyl nalezen!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4Zadna sekce s timto nazvem{0} nebyla nalezena!"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "Ochrana vsech ostrovu ( chvili to potrva)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§cSnazim se prerusit ukol vsech ochran."
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4Omlouvam se!§e Vsechny ochrany jiz bezi. Nech me prvne dokoncit nebo use "
+"§9usb protectall §cstop"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§eStartuji vsechny ochrany. Chvili to potrva."
+
+msgid "reload configuration from file."
+msgstr "Nacitam konfigurace ze souboru."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eKonfigurace byly nacteny."
+
+msgid "manage islands"
+msgstr "Uprava ostrova"
+
+msgid "protects the island"
+msgstr "Ochrana ostrova"
+
+msgid "delete the island (removes the blocks)"
+msgstr "Smazat ostrov ( odstrani bloky)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Smaze zapomenuty ostrov na tve soucasne pozici"
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4Ostrov na této pozici ma cleny!\n"
+"§ePouzij §9/usb island delete <name>§e pro smazani."
+
+msgid "removes the player from the island"
+msgstr "Odstrani hrace z ostrova"
+
+msgid "adds the player to the island"
+msgstr "Prida hrace na ostrov."
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d se pridal na tvuj ostrov."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4Zadny hrac jmenem {0} nebyl nalezen!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+"§4Zadny platny ostrov nenalezen, ani zadni osamoceny ostrov nebo ostrov "
+"ktery jiz ma jmeno."
+
+msgid "print out info about the island"
+msgstr "Zobrazit informace o ostrovu."
+
+msgid "sets the biome of the island"
+msgstr "Nastavit biom ostrova."
+
+msgid "§4That player has no island."
+msgstr "§4Tento hrac nema ostrov."
+
+msgid "§4No valid island at your location"
+msgstr "§4Zadny ostrov na tomto miste."
+
+msgid "purges the island"
+msgstr "Ocistit ostrov."
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4Chyba! §9Zadny ostrov na ocisteni nebyl nazelen."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cPURGE: §9Cistim ostrov na {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "Prepinani ignorovani na ostrove"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cSet {0}s Ostrov ktery ma byt ignorovan v TOP-10 a ma byt ocisteny"
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cOdstraneno ignorovani  {0}s ostrova, nyni bude viditelny v TOP-10 a "
+"ocisten."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Jmeno hrace neni podporovane."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Odstranuji {0} z ostrova."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eZmena podnebi z {0} na ostrove  na:  {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eZmena podnebi z {0} na ostrove  na  OCEAN."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr "§aMozna budes muset jit na spawn a zpet, aby se zmeny projevily."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} bylo podnebi zmeneno na:  {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} bylo podnebi zmeneno na OCEAN."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eOdstranuji {0}''s ostrov."
+
+msgid "Error: That player does not have an island!"
+msgstr "Chyba: Tento hrac nema ostrov!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "e{0}s Ostrov  {1} je nyní chranen."
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4{0}s Ostrov at {1} uz je chranen."
+
+msgid "displays version information"
+msgstr "Zobrazi informace o verzi"
+
+msgid "imports players and islands from other formats"
+msgstr "Prenese hrace a ostrovy z jineho formatu."
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr ""
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "Zmeni jazyk pluginu a nacte ho znovu."
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aJazyk byl uspesne nastaven na  §e{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cZmena jazyku selhala §e{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Podporovane jazyky:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cNelze najit zadne jazyky."
+
+msgid "advanced command for getting island-data"
+msgstr "Pokrocile prikazy pro ziskani informaci o ostrove."
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Nejvyssi SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "Ukaz informace o hraci"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4Tvuj ostrov je plny, nebo ma dosazen maximalni pocet pozvani. Nemuzes "
+"prizvat nikoho dalsiho."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4Tento hrac uz je vudce na jinem ostrove."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§ se te snazi pozvat, ale ty jsi uz v parte."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e tep pozval aby ses pridal na jeho ostrov!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr ""
+"§f/island [accept/reject]§e pro prijmuti nebo odmitnuti se k nemu pridat."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4VAROVANI: Prijdes o svuj momentalni ostrov pokud nabidku prijmes!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d pozval {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e odmitl tvoje pozvani."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4nemuzes ted pouzit tento prikaz. Nejdriv musís opustit soucasnou partu."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§aPridal ses na ostrov! Pouzij /island party pro zobrazeni ostatnich hracu v "
+"parte."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§ePozvanka pro {0}§e vyprsela nebo byla zrusena."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§ePozvanka na ostrov  {0}§e vyprsela nebo byla zrusena."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§ePrijmul si zadost pridat se na ostrov."
+
+msgid "§4You haven't been invited."
+msgstr "§4Nebyl jsi pozvan."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eOdmitl jsi pozvani na ostrov."
+
+msgid "general island command"
+msgstr "obecne prikazy ostrova"
+
+msgid "allows user to bypass cooldowns"
+msgstr ""
+
+msgid "allows user to bypass visitor-protections"
+msgstr ""
+
+msgid "allows user to bypass teleport-delay"
+msgstr ""
+
+msgid "allows user to use [usb] signs"
+msgstr ""
+
+msgid "allows user to place [usb] signs"
+msgstr ""
+
+msgid "complete and list challenges"
+msgstr "Seznam kompletnich ukolu."
+
+msgid "§cCommand only available for players."
+msgstr "§cPrikaz dostupny pouze pro hrace."
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eUkoly byly vypnuty. Kontaktuj admina."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4Ukoly muzes splnit pouze ve SkyBlock svete!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4Ukoly muzes splnit pouze kdyz mas ostrov!"
+
+msgid "warp to another player''s island"
+msgstr "warp k ostrovu jneho hrace"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr ""
+"§aTvuj prichozi port je aktivni, hraci se mohou teleportovat na tvuj ostrov."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§4Tvuj prichozi port je neaktivni, hraci se nemohou teleportovat na tvuj "
+"ostrov."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr "§fNastav prichozi port na tve aktualni pozici pomoci §e/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr ""
+"§fZapnes nebo vypnes warpy na svem ostrove pomoci: §e/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4Nemas opravneni vytvorit teleport na svem ostrove!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§fTeleportuj se na jiny ostrov pomoci §e/island warp <player>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4Nemas opravneni teleportovat se na jiny ostrov!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cTvuj ostrov je ve fazi vytvareni, nemuzes ted nastavit teleport pro "
+"ostatní hrace."
+
+msgid "§4That player does not exist!"
+msgstr "§4Tento hrac neexistuje!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4Tento hrac nema aktivni port."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§cOstrov tohoto hrace je ve fazi vytvareni, prave ted se k nemu nemuzes "
+"teleportovat."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cVAROVANI: §9{0}§e se teleportuje na tvuj ostrov!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4Tento hrac ti zakazal se teleportovat na jeho ostrov"
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4Nemas zadny ostrov. §eUse §b/is create§e aby si jeden dostal."
+
+msgid "accept/reject an invitation."
+msgstr "Prijmi nebo odmitni pozvani prikazy: §e/accept nebo /reject"
+
+msgid "leave your party"
+msgstr "Opustil jsi skupinu."
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4Nemuzes opustit svuj ostrov pokud jsi na nem sam. Zkus pouzit /island "
+"restart pokud chces novy ostrov!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§eJsi vlastnikem tohoto ostrova, zkus /island remove <player>"
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eOpustil jsi ostrov a vratil ses na spawn."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0} opustil tvuj ostrov!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4Musis byt ve SkyBlock svete aby si opustil partu!"
+
+msgid "check your or anothers island level"
+msgstr "Zkontroluj svuj level ostrova a nebo ostatnich hracu"
+
+msgid "allows user to query for others levels"
+msgstr ""
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eMusis byt na svem ostrove aby si mohl pouzit tento prikaz."
+
+msgid "§4You do not have an island!"
+msgstr "§4Nemas ostrov!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4Nemas pristup k tomuto prikazu!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4Tento hrac neexistuje nebo nema ostrov."
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eInformace o ostrove hrace {0} :"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aLevel ostrova je:  {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9Tva sekce:  {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "Vytvoreni ostrova"
+
+msgid "exempt player from create-cooldown"
+msgstr ""
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4Ostrov nalezen!§e Uz jeden ostrov mas, pokud chces zacit znovu na novem "
+"ostrove napis §b /is restart."
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4Ostrov nalezen. Uz jsi clenem party ktera vlastni ostrov. Pokud chces svuj "
+"vlastni nejprve musis opustit partu."
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eMuzes zalozit novy ostrov za {0,number,#}  sekund."
+
+msgid "invite a player to your island"
+msgstr "Prizvi hrace na ostrov."
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§ePouzik prikaz §f /island invite <playername>§epro pozvani hrace do tve "
+"party na ostrove."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4Pouze majitel ostrova muze prizvat jiného hrace!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aMuzes jeste prizvat {0} hracu."
+
+msgid "§4You can't invite any more players."
+msgstr "§4Uz nemuzes prizvat dalsi hrace."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4Nemas povoleni prizvat hrace na tento ostrov!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4Tento hrac neni ve hre a nebo neexistuje."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4Nemuzes prizvat sam sebe!:)"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4Tento hrac je vudce tveho ostrova!"
+
+msgid "lock your island to non-party members."
+msgstr "Uzamceni ostrova pro hrace, kteri nejsou clenove tve party."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4Nemas opravneni zamknout svuj ostrov!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4Nemas pristup k tomuto prikazu!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4Nemas opravneni odemknout svuj ostrov!"
+
+msgid "display the top10 of islands"
+msgstr "Zobrazi 10 nejpelsich ostrovu."
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr ""
+
+msgid "remove a member from your island."
+msgstr "Smaz hrace z tveho ostrova."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4Nemas povoleni vykopnout ostatni z tohoto ostrova!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4Nemuzes odstranit vudce z tohoto ostrova!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4Prestan se vyhazovat!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0} vas odstranil ze sveho ostrova!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} byl odstranen z ostrova."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4{0}  se te snazi vykopnout z jeho ostrova!"
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4{0} nyni uz dale nebude vyhazovan."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4{0} te vyhodil z jeho ostrova!"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0}  byl vyhozen z ostrova."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr "§4Tento hrac neni ve tve parte a ani na tvem ostrove."
+
+msgid "teleport to the island home"
+msgstr "Teleportuje te domu na ostrov."
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§cMomentalne se nemuzes teleportovat domu na ostrov, protoze tvuj ostrov se "
+"jeste vytvari."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4Tento prikaz muze pouzit pouze hrac"
+
+msgid "transfer leadership to another member"
+msgstr "Predani vudce jinemu clenu"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4Muzes pouze predat vlastnictví ostrova jednomu clenu z party !"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e uz je vudce na tvem ostrove!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4Pouze vudce muze predat vudcovstvi!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} se pokusil prevzit tvuj ostrov!"
+
+msgid "show party information"
+msgstr "Zobrazi informace o parte "
+
+msgid "shows information about your party"
+msgstr "Zobrazuje informace o tve parte"
+
+msgid "show pending invites"
+msgstr "Zobrazi nevyrizene pozvanky"
+
+msgid "§eNo pending invites"
+msgstr "§eZadne nevyrizene pozvani nemate."
+
+msgid "withdraw an invite"
+msgstr "Zrusit pozvanku"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4Nemas opravneni zrusit pozvani hrace."
+
+msgid "check your or another''s island info"
+msgstr "Podivej se na informace o ostrove."
+
+msgid "allows user to see others island info"
+msgstr ""
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBloku na {0}s ostrove (page {1,number} of {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Skore poctu bloku"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "Duvera/neduvera ti pomahat od  hracu na ostrove"
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eNasledujici hraci na tvem ostrove jsou duveryhodni:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eNasledujici vudci ti duveruji:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr "§ePro duveru / neduveru tveho ostrova pouzij /island trust <player>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4Clenu ti uz veri!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Neznamy hrac {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eNyni ti zacal verit §4{0}' §ena tvem ostrove."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} veri {1} na ostrove"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eTi prestal verit §4{0}''s §eisland."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0} zrusil duveru {1} na ostrove"
+
+msgid "delete your island and start a new one."
+msgstr "Smaz svuj ostrov a zaloz novy."
+
+msgid "exempt player from restart-cooldown"
+msgstr ""
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4Pouze vlastnik muze restartovat tento ostrov. Opust tento ostrov pomoci (/"
+"island leave) a zaloz si vlastni ostrov."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eMusis odstranit vsechny hrace z tveho ostrova (/island kick <player>) pred "
+"tim nez ho restartujes. Podivej se na seznam aktualnich hracu na tvem "
+"ostrove /island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§cOstrov muzes restartovat za {0}  sekund."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr "§cTvuj ostrov je ve fazi vytvareni, momentalne ho nemuzes restartovat."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§ePOZOR: Tvuj cely ostrov a vsechny veci na nem budou RESETOVANY!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "Teleportuji te na spawn Skyblocku"
+
+msgid "change the biome of the island"
+msgstr "Meni biom na ostrove."
+
+msgid "exempt player from biome-cooldown"
+msgstr ""
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr ""
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr "§cNemas opravneni zmenit biom na tomto ostrove."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4Nemas opravneni zmenit biom tohoto ostrova!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eMusis byt na svem ostrove aby si mohl zmenit biom!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr "§cZadal jsi spatne nazev biomu. Musi to byt jedno z {0}"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eMuzes znovu zmenit biom az za {0,number,#} minut."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§cNemas opravneni menit toto podnebi."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr ""
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aPrave se zmenilo na ostrove podnebi na:  {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} zmenil sve podnebi na: {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr ""
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr ""
+
+msgid "set your island''s warp location"
+msgstr "Nastav lokaci warpu na ostrove"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cNemas opravneni nastavit misto pro teleport!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr ""
+"§cMusis byt na svem vlastnim ostrove aby si mohl nastavit misto pro teleport."
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d zmenil na ostrove misto pro teleport."
+
+msgid "teleports you to your island (or create one)"
+msgstr "Teleportuje te na tvuj ostrov (nebo zalozi novy)"
+
+msgid "ban/unban a player from your island."
+msgstr "Ban/Unban hraci na tvem ostrove."
+
+msgid "exempts user from being banned"
+msgstr ""
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§eNasledujici hraci byly zabanovani pro portovani na tvuj ostrov:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr "§ePro ban/unban pro tvuj ostrov, pouzij /island ban <player>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4Nemuzes zabanovat clena. Napred jej smaz! "
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4Nemas opravneni vyhodit/zabanovat hrace."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§eNelze zabanovat nezname hrace {0}"
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4{0} se te snazil zabanovat na jeho ostrove!"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4{0} je odbanovan."
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eJsi zabanovan §4{0}§e pro portovani na svuj ostrov."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eByl jsi §cBANNED§e pro ostrov hrace {0}§e''."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§eByl jsi odbanovan §a{0}§e pro portovani na svuj ostrov."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eBudes §aUNBANNED§e pro ostrov hrace {0}§e''."
+
+msgid "display log"
+msgstr "Zobrazeni logu"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "Nastav home pozici na ostrove"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "Zapnout/vypnout warpy na tvem ostrove"
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4Tvuj ostrov je uzamcen. Musis ho odemcit předtím nez nastavit teleport."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d  aktivoval teleport na ostrove."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr "§cNemas opravneni povolit / zakazat teleport na ostrove!"
+
+msgid "try to complete a challenge"
+msgstr "Zkus dokoncit vyzvu."
+
+msgid "show information about the challenge"
+msgstr "Ukaz informace o ukolu."
+
+msgid "§eRank: "
+msgstr "§eSekce: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4Ukol je neopakovatelny."
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr "§4Prijdes o vsechny potrebne predmety kdyz dokoncis tento ukol!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4Vsechny potrebne predmety musi byt umisteny na tvem ostrove, okolo {0} "
+"kolem tebe."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§ePro dokonceni tohoto ukolu, pouzij §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4Nazev ukolu je neplatny! Pouzij  /c help pro vice informaci."
+
+msgid "§eSending you to spawn."
+msgstr "§ePosilam te na spawn."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§eOstrov bude  §cLOCKED§e."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4Je nemozne najit bezpecny bod pro domov na tvem ostrove!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§cVAROVANI: §eTeleportuji te do vzduchu."
+
+msgid "§aTeleporting you to your island."
+msgstr "§aTeleportuji te na tvuj ostrov."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aBudes teleportovan za {0} vterin."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Je nemozne te teleportovat na ostrov tohoto hrace!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aTeleportuji te na ostrov hrace {0}."
+
+msgid "§7Teleport cancelled"
+msgstr "§7Teleport prerusen."

--- a/uSkyBlock-Core/src/main/po/da.po
+++ b/uSkyBlock-Core/src/main/po/da.po
@@ -16,6 +16,30 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.9\n"
 
+msgid "d"
+msgstr "d"
+
+msgid "h"
+msgstr "t"
+
+msgid "m"
+msgstr "m"
+
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§eDu har ikke adgang (§4{0}§e)"
@@ -23,6 +47,15 @@ msgstr "§eDu har ikke adgang (§4{0}§e)"
 #, java-format
 msgid "§eInvalid command: {0}"
 msgstr "§eForkert kommando: {0}"
+
+msgid "Command"
+msgstr "Kommando"
+
+msgid "Permission"
+msgstr "Tilladelse"
+
+msgid "Description"
+msgstr "Beskrivelse"
 
 #, java-format
 msgid "§7Usage: {0}"
@@ -47,1675 +80,12 @@ msgstr "Skrev dokumentation til {0}"
 msgid "§4Error writing documentation: {0}"
 msgstr "§4Fejl ved skrivning af dokumentation: {0}"
 
-msgid "Command"
-msgstr "Kommando"
+msgid "§cWither Despawned!§e It wandered too far from your island."
+msgstr "§cWither Despawnede!§e Den vandrede for langt fra din ø."
 
-msgid "Permission"
-msgstr "Tilladelse"
-
-msgid "Description"
-msgstr "Beskrivelse"
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-msgid "d"
-msgstr "d"
-
-msgid "h"
-msgstr "t"
-
-msgid "m"
-msgstr "m"
-
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eDu mangler stadig følgende blokke: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr "§4Du kan gennemføre dette {0} gange mere."
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4Kravene vil nulstilles om {0} dage."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4Kravene vil nulstilles om {0} timer."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4Kravene vil nulstilles om {0} minutter."
-
-msgid "§4This challenge is currently unavailable."
-msgstr "§4Denne udfordring er pt. utilgængelig."
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr "§4Du kan gennemføre dette igen om {0} dage."
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr "§4Du kan gennemføre dette igen om {0} timer."
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr "§4Du kan gennemføre dette igen om {0} minutter."
-
-msgid "§eThis challenge requires:"
-msgstr "§eDenne udfordring kræver:"
-
-msgid "§7and more..."
-msgstr "§7og flere..."
-
-msgid "§eItems will be traded for reward."
-msgstr "§eTingene vil blive byttet for en gevinst."
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr "§eSkal være inden for {0} meter."
-
-msgid "§6Item Reward: §a"
-msgstr "§6Ting: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Økonomi: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Erfaring: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dTotalt antal aflevering: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr "§7Kræver {0}"
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4Ingen udfordringer med navn {0} fundet"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4Du skal være på din ø, for at gøre det!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§4{0} udfordringen er ikke tilgængelig endnu!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4{0} udfordringen er ikke gentagelig!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr "§4Du kan ikke gennemføre {0} udfordringen endnu!"
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§eForsøger at gennemføre §a{0}"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr "§4Du skal stå inden for {0} blokke af alle de påkrævede elementer."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4Din ø skal mindst være level {0} for at gennemføre denne udfordring!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Ukendt udfordrings-type: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§eDu mangler stadig følgende elementer:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eDu mangler følgende:{0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aDo you gennemført {0}-udfordringen!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9{0}§f har gennemført §9{1}§f udfordringen!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§ePræmie: §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eXP præmie: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§ePenge præmie: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eDine tasker ef §4fulde§e. Tingene er faldet på jorden."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lKlik for at gennemføre."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lDu kan ikke gentage denne udfordring."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Rank: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fGennemfør de fleste udfordringer"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fpå dette niveau, for at åbne det næste."
-
-msgid "§eClick here to show previous page"
-msgstr "§fKlik her for forrige side"
-
-msgid "§eClick here to show next page"
-msgstr "§fKlik her for næste side"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lLåst udfordring"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "§7Gennemfør yderligere {0} {1} §7udfordringer"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Gennemfør {0}"
-
-msgid "to unlock this rank"
-msgstr "for at låse denne rank op"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "Men du er helt alene!"
-
-msgid "But you are Yelling in the wind!"
-msgstr "Men du råber i vinden!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "Men dine fantasivenner er smuttet!"
-
-msgid "But you are Talking to your self!"
-msgstr "Men du taler til dig selv!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cUndskyld! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr "Send en besked til din gruppe, eller toggle chat on/off."
-
-msgid "party"
-msgstr "selskab"
-
-msgid "island"
-msgstr "ø"
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§cTogglede chat til {0} §aON"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§cGentag §9{0}§c for at deaktivere igen"
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§aTogglede chat §cOFF§a for {0}"
-
-msgid "§cCommand only available to players"
-msgstr "§cKommandoen er kun tilgængelig for spillere"
-
-msgid "talk to players on your island"
-msgstr "snak med spillere på din ø"
-
-msgid "talk to your island party"
-msgstr "tal til medlemmerne af din ø"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§eSpiller {0} har ingen ø!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eForkert spiller-navn {0} givet."
-
-msgid "Manage challenges for a player"
-msgstr "Hånter udfordringer for en spiller"
-
-msgid "resets the challenge for the player"
-msgstr "nulstiller udfordringer for spilleren"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4Udfordringen er aldrig blevet gennemført"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§eudfordring: {0} er blevet nulstillet for {1}"
-
-msgid "resets all challenges for the player"
-msgstr "nulstiller alle spillerens udfordringer"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0} har fået alle udfordringer nulstillet."
-
-msgid "complete all challenges in the rank"
-msgstr "gennemfør alle udfordringerne i kategorien"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4Ingen spiller med navn {0} fundet!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4Udfordringen {0} er allerede blevet gennemført"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§eUdfordring {0} er blevet gennemført af {1}"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4Ingen udfordringer med navn {0} fundet!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4Ingen kategori med navnet {0} findes!"
-
-msgid "manage islands"
-msgstr "håndter øer"
-
-msgid "protects the island"
-msgstr "beskytter øen"
-
-msgid "delete the island (removes the blocks)"
-msgstr "fjern øen (fjerne alle blokke)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Slettede en forladt ø på din nuværende position."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4Øen på denne position har medlemmer!\n"
-"§eBrug §9/usb island delete <navn>§e for at slette den."
-
-msgid "removes the player from the island"
-msgstr "fjerner spilleren fra øen"
-
-msgid "adds the player to the island"
-msgstr "tilføjer spilleren til øen"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d er blevet medlem af øen."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4Ingen spiller med navn {0} fundet!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr "§4Ingen valid ø fundet, enten stå på en ø, eller skriv et navn"
-
-msgid "print out info about the island"
-msgstr "vis informationer om øen"
-
-msgid "sets the biome of the island"
-msgstr "sætter øens biome"
-
-msgid "§4That player has no island."
-msgstr "§4Den spiller har ingen ø."
-
-msgid "§4No valid island at your location"
-msgstr "§4Ingen valid ø på din position"
-
-msgid "purges the island"
-msgstr "markerer øen til genbrug"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Fejl! §9Ingen valid ø fundet, til genbrug."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cOPRYDNING: §9Markede øen ved {0} til genbrug"
-
-msgid "toggles the islands ignore status"
-msgstr "skift øens ignore-tilstand"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cIngorer {0}s ø på top 10 og ved genbrug."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§cFjernede ignore-flaget på {0}s ø, den vil nu blive vist på top 10 og være "
-"kandidat til oprydning."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Intet validt spiller-navn givet."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Fjerner {0} fra ø"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eÆndrede biomen for {0}s ø til {1}"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eÆndrede biomen for {0}s ø til HAV."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr ""
-"§aDu bliver måske nødt til at gå til spawn, eller relogge, for at se "
-"ændringerne."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} har fået deres biome ændret til {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} har fået deres biome ændret til HAV."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eFjerner {0}''s ø."
-
-msgid "Error: That player does not have an island!"
-msgstr "Fejl: Den spiller har ingen ø!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§e{0}s ø ved {1} er blevet beskyttet"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4{0}s ø ved {1} var allerede beskyttet"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "vis konfigurations UI"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§eForkert konfiguraionsnavn"
-
-msgid "Controls player-cooldowns"
-msgstr "Håndterer spiller-cooldowns"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "fjerner et cooldown fra en kommando (* = alle)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eDen spiller er ikke online"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Nulstillede cooldown på {0} for {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Ingen aktiv cooldowns på {0} for {1}!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Forkert kommando givet, kun restart og biome er understøttet!"
-
-msgid "restarts the cooldown on the command"
-msgstr "genstart et cooldown på en kommando"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eReset cooldown on {0} for {1}§e to {2} seconds"
-
-msgid "lists all the active cooldowns"
-msgstr "list alle aktive cooldowns"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCmd Cooldown"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eIngen aktive cooldowns for §9{0}§e fundet."
-
-msgid "control debugging"
-msgstr "håndter debugging"
-
-msgid "set debug-level"
-msgstr "sæt debug-niveau"
-
-msgid "toggle debug-logging"
-msgstr "slå bebugging til/fra"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4Ligning er ikke aktiv, så du kan ikke stoppe det!"
-
-msgid "flush current content of the logger to file."
-msgstr "skriv log-filen til disk."
-
-msgid "§eLog-file has been flushed."
-msgstr "§eLog-filen er blevet skrevet."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4Logning er ikke aktiv, brug §9/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Forkert argument, prøv INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eLogning deaktiveret!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "forsøger at fjerne flatland under øen."
-
-msgid "§4No valid island found"
-msgstr "§4Ingen valid ø fundet"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4Intet fladland fundet ved {0}''s ø!"
-
-msgid "flushes all caches to files"
-msgstr "gemmer alle caches til filer"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr "§eGemte §a{0} øer§e, §b{1} spillere og §6{2} udfordringer."
-
-msgid "manually update the top 10 list"
-msgstr "opdater top 10 listen manuelt"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eGenererer top 10 listen"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eBlev færdig med genereringen af top 10"
-
-msgid "advanced command for getting island-data"
-msgstr "avanceret kommando til at læse ø-data"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§eNuværende værdi for {0} er ''{1}''"
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§cKan ikke læse tilstand for {0}"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§eFelter {0}"
-
-msgid "teleport to another players island"
-msgstr "teleporterer til en andens ø"
-
-msgid "§4Only supported for players"
-msgstr "§4Kun understøttet for spillere"
-
-msgid "§4That player does not have an island!"
-msgstr "§4Den spiller har ingen ø!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr "§aTeleporterer til {0}''s ø."
-
-msgid "imports players and islands from other formats"
-msgstr "importer spillere og øer fra andre formater"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Job Statistik"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/job"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "akt"
-
-msgid "time"
-msgstr "tid"
-
-msgid "name"
-msgstr "navn"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "skifter sprog af pluginnet, og genindlæser det"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aSkiftede sprog til §e{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cKunne ikke skifte sprog til §e{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Understøttede sprog:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 af {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cKunne ikke finde nogle sprog."
-
-msgid "transfer leadership to another player"
-msgstr "overfør ejerskab til en anden spiller"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4Spiller {0} har ingen ø at overføre!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§eSpiller §d{0}§e har allerede en ø.§eBrug §9/usb island remove <navn>§efor "
-"at fjerne ham først."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bEjerskab overført af {0}§b til {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr "avanceret info om NBT"
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "viser NBTTag for den ting du har i hånden"
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§eInfo for §9{0}"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - navn: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - nbttag: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§cDu har tomme hænder!"
-
-msgid "§eCan only be executed as a player"
-msgstr "§eKan kun udføres som spiller"
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "sætter NBTTagget på tingen i din hånd"
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "§eSatte §9{0}§e til §c{1}"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "tilføjer NBTTags til tingen i din hånd"
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§eTilføjede §9{0}§e til §c{1}"
-
-msgid "manage orphans"
-msgstr "håndter forældreløse"
-
-msgid "count orphans"
-msgstr "tæl horeunger"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§e{0} gamle ø-placeringer vil blive brugt før nye."
-
-msgid "clear orphans"
-msgstr "nulstil horeunger"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eFjerner alle gamle (tomme) ø-placering."
-
-msgid "list orphans"
-msgstr "list horeunger"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eIngen forældreløse øer registreret i øjeblikket."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr "ekstra goder {0}"
-
-msgid "protects all islands (time consuming)"
-msgstr "beskytter alle øer (tidskrævende)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§cForsøger at afbryde protect-all opgaven."
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-"§4Undskyld!§e En protect-all er allerede igangværende. Vent til den er "
-"færdig, eller brug §9usb protectall §cstop"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§eStarter en kørsel af protect-all. Det vil tage et stykke tid."
-
-msgid "purges all abandoned islands"
-msgstr "fjerner alle forladte øer"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4Do skal angive hvor gamle (i dage) øerne til purge skal være!"
-
-msgid "§4The level must be a valid number"
-msgstr "§4Niveauet skal være et validt nummer"
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr "§4Forsøger at afbryde oprydning"
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr "§4Starter oprydning..."
-
-msgid "region manipulations"
-msgstr "region manipulationer"
-
-msgid "shows the borders of the current island"
-msgstr "viser kanterne for den nuværende ø"
-
-msgid "§eNo island found at your current location"
-msgstr "§eIngen ø fundet ved din nuværende position"
-
-msgid "shows the borders of the current chunk"
-msgstr "viser kanterne i den nuværende chunk"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "viser de indre chunks"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "viser de ikke-chunk-tilrettede kanter"
-
-msgid "shows the borders of the outer-chunks"
-msgstr "viser kanterne for de ydre chunks"
-
-msgid "hides the regions again"
-msgstr "skjuler regionerne igen"
-
-msgid "§eStopped displaying regions"
-msgstr "§eStoppede med at vise regioner"
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§eIngen regioner at vise for denne spiller"
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§eAnimations-tick ændret til {0}."
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§eAnimations-tick skal være et validt heltal."
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "tildeler øen til en spiller"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr "§aSæt {0}s ø til den nuværende."
-
-msgid "§4Island not found: unable to set the island!"
-msgstr "§4Ø ikke fundet: ude af stand til at overføre ejerskabet!"
-
-msgid "reload configuration from file."
-msgstr "genindlæs konfigurationen fra fil."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eKonfigurationen blev genindlæst fra fil."
-
-msgid "advanced command for setting island-data"
-msgstr "avanceret kommando til at sætte ø-data"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§c{0} blev sat til ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§cKan ikke sætte {0} til ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr "§cKan ikke sætte {0} til ''{1}'', det skal være et tal"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§cUkendt felt {0}"
-
-msgid "toggles maintenance mode"
-msgstr "skifter vedligeholdelsestilstand"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-"§cVEDLIGEHOLDELSE: §aAktiveret§e all uSkyBlock funktioner er deaktiveret."
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr "§cVEDLIGEHOLDELSE: §4Deaktiveret§e alle funktioner operationelle igen."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr "§cVedligeholdelsestilstand kan kun ændres fra konsollen!"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§cAFBRUDT:§e Protect-All blev afbrudt!"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr "§eFuldførte protect-all på {0}, {1} nye regioner blev oprettet!"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§7- SKANNER: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4OPRYDNING:§9 Skanning afbrudt."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4OPRYDNING:§9 Forladte øer er nu blevet sendt til genbrug."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4OPRYDNING:§9 Afbrød oprydning af forladte øer."
-
-msgid "displays version information"
-msgstr "viser versionsinformationer"
-
-msgid "various WorldGuard utilities"
-msgstr "blandede WorldGuard værktøjer"
-
-msgid "refreshes the chunks around the player"
-msgstr "genindlæser chunks omkring spilleren"
-
-msgid "§eResending chunks to the client"
-msgstr "§eGensender chunks til klienten"
-
-msgid "load the region chunks"
-msgstr "load chunks fra regionen"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eHenter chunks ved {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eFrigiver chunks ved {0}"
-
-msgid "update the WG regions"
-msgstr "opdater world-guard regioner"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§eØens world-guard region opdateret for {0}"
-
-msgid "§eNo island found at your location!"
-msgstr "§4Ingen valid ø på din position!"
-
-msgid "refreshes the chunk around the player"
-msgstr "indlæser det omkringliggende gitter"
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "vis spiller-information"
-
-msgid "try to complete a challenge"
-msgstr "forsøg at aflever en udfordring"
-
-msgid "§cCommand only available for players."
-msgstr "§cKommandoen er kun tilgængelig for spillere."
-
-msgid "show information about the challenge"
-msgstr "vis informationer om udfordringer"
-
-msgid "§eRank: "
-msgstr "§eRank: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4Denne udfording er ikke gentagelig!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr ""
-"§4Du vil miste alle de påkrævede ting, når du gennemfører denne udfordring!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4Alle de påkrævede elementer skal være på din ø, indenfor {0} meter fra dig."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§eFor at gennemføre denne udfordring, brug §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4Forkert udfordringsnavn!§e Brug §9/c help§e for mere info"
-
-msgid "complete and list challenges"
-msgstr "aflever og se udfordringer"
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eUdfordringer er deaktiveret. Kontakt en administrator."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4Du kan kun gennemføre udfordringer i skyblock verdenen!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4Du kan kun gennemføre udfordringer når du har en ø!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4Din ø er fuld, eller du har for mange udestående invitationer. Du kan ikke "
-"invitere flere."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4Den spiller er allerede leder på en anden ø."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e forsøgte at invitere dig, men du er allerede i en gruppe."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr "§aInvitation sent til {0}"
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e har inviteret dig til at deltage på sin ø!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§f/island [accept/reject]§e for at acceptere invitationen."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4ADVARSEL: Du vil miste din nuværende ø hvis du accepterer!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d inviterede {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e har afvist invitationen."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4Du kan ikke bruge den kommando lige nu. Forlad din nuværende ø først."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§aDu er blevet medlem af en ø! Brug §9/island party§a for at se de andre "
-"medlemmer."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§eInvitationen til {0}§e er udløbet og er blevet annulleret."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§eInvitationen til {0}''s ø er udløbet og er blevet annulleret."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§eDu har accepteret en invitation til at blive medlem af en ø."
-
-msgid "§4You haven't been invited."
-msgstr "§4Du er ikke blevet inviteret."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eDu har afvist invitationen til en ø."
-
-msgid "accept/reject an invitation."
-msgstr "afvis eller accepter invitationen."
-
-msgid "teleports you to your island (or create one)"
-msgstr "teleporterer dig til din ø (eller opretter en ny)"
-
-msgid "ban/unban a player from your island."
-msgstr "ban/unban en spiller fra din ø."
-
-msgid "exempts user from being banned"
-msgstr "bloker brugeren fra at blive bannet"
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§eDe følgende spillere er udelukket fra at teleportere til din ø:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr "§eFor at udelukke/tilgive spillere, brug §9/is ban <spiller>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4Du kan ikke udelukke medlemmer. Fjern dem først!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4Du har ikke tilladelse til at udelukke spillere."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§eUde af stand til at banne ukende spiller {0}"
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4{0} forsøgte at udelukke dig fra deres ø!"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4{0} kan ikke bannes."
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eDu har udelukket §4{0}§e fra at teleportere til din ø."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eDu er blevet §cFORVIST§e fra {0}§e''s ø."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§eDu har tilladt §a{0}§e at teleportere til din ø."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eDu er blevet §aBENÅDET§e af {0}."
-
-msgid "change the biome of the island"
-msgstr "ændr øens biome"
-
-msgid "exempt player from biome-cooldown"
-msgstr "lad brugeren undgå biome-tidsbegrænsning"
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr "Tillad spilleren at ændre øens biome til {0}"
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr "§cDu har ikke tilladelse til at ændre biome for din ø."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4Du har ikke tilladelse til at ændre biome for denne ø!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eDu skal være på din ø, for at ændre biome!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr "§cDu har stavet biomen forkert. Skal være en af {0}"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eDu kan ikke ændre biome de næste {0,number,#} minutter."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§4Du har ikke tilladelse til at ændre til den biome."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-"§7De små feer har travlt med at ændre naturen omkring dig til §9{0}§7, vær "
-"tålmodig."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-"§7Feerne har travlt med at ændre biomen for din ø til §9{0}§7, vær venligst "
-"tålmodig."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr "§eForkert biome {0} angivet!"
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aDu har ændret din ø''s biome til {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} ændrede øens biome til {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr "§aDu har ændret {0} blokke omkring dig til {1} biomen"
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr "{0} oprettede et område med {1} biome"
-
-msgid "create an island"
-msgstr "opret en ø"
-
-msgid "exempt player from create-cooldown"
-msgstr "lad brugeren undgå oprettelsestidsbegrænsning"
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4Ø fundet!§e Du har allerede en ø. Hvis du vil have en ny, brug §b/is "
-"restart§e"
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§Ø fundet!§e Du er allerede medlem af en ø. Hvis du vil have din egen, "
-"forlad den først §b/is leave"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eDu kan opette en ny ø om {0,number,#} sekunder."
-
-msgid "teleport to the island home"
-msgstr "teleporter til øens hjem"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§cDin ø er under konstruktion, du kan ikke teleportere til den i øjeblikket."
-
-msgid "check your or another''s island info"
-msgstr "få information om din eller en andens ø"
-
-msgid "allows user to see others island info"
-msgstr "tillader brugere at se andre øers informationer"
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4Ø levels er blevet deaktiveret, kontakt en administrator."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr "§4Tag den med ro! §eDu bliver nødt til at være tålmodig..."
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eDu skal være på en ø, for at bruge denne kommando."
-
-msgid "§4You do not have an island!"
-msgstr "§4Du har ikke en ø!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4Du har ikke adgang til den kommando!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4Den spiller er invalid eller har ingen ø!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBlokke på {0}s ø (side {1,number} af {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Score Antal Blok"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr "{0,number,00.00}  {1,number,#} {2}"
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§eØen niveau er {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "inviter en spiller til din ø"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§eBrug §9/island invite <spillernavn>§e for at invite en spiller til din ø."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4Kun øens ejer kan invitere!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aDu kan invitere yderligere {0} spillere til din ø."
-
-msgid "§4You can't invite any more players."
-msgstr "§4Du kan ikke invitere flere spillere."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4Du har ikke tilladelse til at invite flere til din ø!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4Den spiller er offline eller eksisterer ikke."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4Du kan ikke invitere dig selv!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4Den spiller er leder på din ø!"
-
-msgid "remove a member from your island."
-msgstr "fjern et medlem fra din ø."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4Du har ikke tilladelse til at eksludere spillere fra denne ø!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4Du kan ikke fjerne lederen fra en ø!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4Stop med at sparke dig selv!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0} har fjernet dig fra deres ø!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} er blevet sparket ud af øen."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0} førsøgte at fjerne dig fra deres ø!"
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4{0} kan ikke sparkes."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4{0} har fjernet dig fra deres ø!"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0} er blevet sparket af øen."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr "§4Den spiller er hverken medlem af din ø, eller gæst på den!"
-
-msgid "leave your party"
-msgstr "forlad dit selskab"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4Du kan ikke forlade en ø, hvis du er den eneste der. Prøv at bruge §9/"
-"island restart§4 hvis du vil have en ny!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§eDu er ejer af denne ø. Brug §9/island remove <spiller>§e istedet."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eDu har forladt øen, og er blevet sendt til spawn."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0} har forladt din ø!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4Du skal være i skyblock-verdenen for at forlade din ø!"
-
-msgid "check your or anothers island level"
-msgstr "check din eller en andens øs niveau"
-
-msgid "allows user to query for others levels"
-msgstr "tillader brugere at spørge til andres niveau"
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eInformation om {0}s ø:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§eDin position er: §f{0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "lås din ø for ikke-medlemmer."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4Du har ikke tilladelse til at låse din ø!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4Du har ikke adgang til denne kommando!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4Du har ikke tilladelse til at låse din ø op!"
-
-msgid "display log"
-msgstr "vis aktivitetslog"
-
-msgid "transfer leadership to another member"
-msgstr "overfør ejerskab til et andet medlem"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4Du kan kun overføre ejerskab til andre medlemmer!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e er allerede leder på din ø!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4Kun lederen an overføre lederskab!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} forsøgte at overtage øen!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "vis medlemsinformation"
-
-msgid "shows information about your party"
-msgstr "viser informationer om dit selskab"
-
-msgid "show pending invites"
-msgstr "vis udestående invitationer"
-
-msgid "§eNo pending invites"
-msgstr "§eIngen udestående invitationer"
-
-msgid "withdraw an invite"
-msgstr "træk en invitation tilbage"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4Du har ikke tilladelse til at afvise invitationer."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4Denne kommando kan kun udføres af spillere"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4Ingen ø. §e Brug §9/is create§e for at få en"
-
-msgid "changes a members island-permissions"
-msgstr "ændrer et medlems tilladelser på øen"
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr "§eTilladelser for §9{0}§e:"
-
-msgid "§aON"
-msgstr "§aON"
-
-msgid "§cOFF"
-msgstr "§cOFF"
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr "§7 - §6{0}§7 : {1}"
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr "§cUgyldig tilladelse {0}. Skal være en af {1}"
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr "§eÆndrede tilladelse §9{0}§e for §9{1}§e til {2}"
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr "§eUde af stand til at ændre tilladelse §9{0}§e for §9{1}"
-
-msgid "delete your island and start a new one."
-msgstr "slet din ø og start på en ny."
-
-msgid "exempt player from restart-cooldown"
-msgstr "lad brugeren undgå genstart-tidsbegrænsning"
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4Kun ejeren må genstarte en ø. Forlad øen for at starte din egen (§9/island "
-"leave§4)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eDu skal fjerne alle medlemmer af din ø, før du kan genstarte den (§9/"
-"island kick <spiller>§e).Se en liste af medlemmerne med §9/island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§cDu kan genstarte din ø om {0} sekunder."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§cDin ø er ved at re-generere, du kan ikke genstarte nu."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eBEMÆRK: Hele din ø, og alle dine ejendele vil blive tabt!"
-
-msgid "set the island-home"
-msgstr "sæt øens start-position"
-
-msgid "set your island''s warp location"
-msgstr "sæt din øs besøgspunkt"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cDu har ikke tilladelse til at sætte din ø''s besøgsportal!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§4Du skal være på din ø, for at gøre det!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d ændrede øens besøgsportal."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "teleporter dig til skyblock spawn"
-
-msgid "enable/disable warping to your island."
-msgstr "tillad/bloker besøg på din ø."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4Din er er låst. Du bliver nødt til at låse den op, før du kan aktivere "
-"besøgsportal."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d aktiverede øens besøgsportal."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d deaktiverede øens besøgsportal."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr ""
-"§cDu har ikke tilladelse til at aktivere/deaktivere din ø''s besøgsportal!"
-
-msgid "display the top10 of islands"
-msgstr "vis top10 af øer"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr "tillader brugeren altid at generere top 10"
-
-msgid "trust/untrust a player to help on your island."
-msgstr "tillad en spiller at hjælpe med på din ø."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eDe følgende spillere betroet på din ø:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eDe følgende ledere har tiltro til dig:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr "§eFor at betro spillere adgang, brug §9/is trust <spiller>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4Medlemmet er allerede betroet!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Ukendt spiller {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eDu er nu betroet på §4{0}§es ø."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} tilføjede {1} som ven til øen"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eDu er ikke længere betroet på §4{0}§es ø."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0} fjernede {1} som ven af øen"
-
-msgid "warp to another player''s island"
-msgstr "besøg en andens ø"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr "§aDin besøgsportal er aktiv. Spillere kan teleportere til din ø."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§4Din besøgsportal er inaktiv. Spillere kan ikke teleportere til din ø."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr ""
-"§fSæt besøgsportalen til din nuværende position ved at bruge §e/island "
-"setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§fSkift adgang til din besøgsportal ved brug af §9/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4Du har ikke tilladelse til at oprette en besøgsportal på din ø!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§fTeleporter til en anden ø med §9/island warp <spiller>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4Du har ikke tilladelse til at teleportere til andre øer!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§cDin ø er ved at blive re-genereret, du kan ikke bruge warp i øjeblikket."
-
-msgid "§4That player does not exist!"
-msgstr "§4Ingen spiller fundet!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4Den spiller har ikke en aktiv besøgsportal."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§cDen spillers ø er under konstruktion, du kan ikke warpe til den i "
-"øjeblikket."
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cADVARSEL: §9{0}§e kommer på besøg på din ø!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4Den spiller har udelukket dig fra sin ø."
-
-msgid "general island command"
-msgstr "generel ø kommando"
-
-msgid "allows user to bypass cooldowns"
-msgstr "tillader brugere at omgå tidsbegrænsninger"
-
-msgid "allows user to bypass visitor-protections"
-msgstr "tillader brugere at omgå besøgsbeskyttelser"
-
-msgid "allows user to bypass teleport-delay"
-msgstr "tillader brugere at omgå teleport-forsinkelse"
-
-msgid "allows user to use [usb] signs"
-msgstr "tillader brugere at bruge [usb] skilte"
-
-msgid "allows user to place [usb] signs"
-msgstr "tillader brugere at placere [usb] skilte"
+msgid "{0}''s Wither"
+msgstr "{0}''s Wither"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr ""
@@ -1731,33 +101,6 @@ msgstr "§eRidning er kun tilladt på din egen ø!"
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr "§eDu kan ikke smadre køretøjer som en besøgende!"
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr "§cWither Despawnede!§e Den vandrede for langt fra din ø."
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "{0}''s Wither"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eBesøgende kan ikke smide ting!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Ejer: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "Du kan ikke samle en andens ting op, når du er besøgende!"
-
-msgid "Config:"
-msgstr "Konfiguration:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§cIngen adgang! §eDu prøver at komme til taget af §cNETHER§e, det er ikke "
-"tilladt."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr "§4Do kan kun konvertere obsidian en gang hvert 10. sekund"
@@ -1805,19 +148,86 @@ msgstr "§eDu kan kun brug spawn-æg på din egen ø."
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§eDu har nået din øs spawn-grænse."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eBesøgende kan ikke smide ting!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Ejer: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "Du kan ikke samle en andens ting op, når du er besøgende!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cForvist:§e Du har ikke lov til at komme på denne ø."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cLåst:§e Den ø er låst! Ingen adgang."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eVenter på din tur §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "Der opstod en fejl under gemning af øens data!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr "Konverterer data til UUID, dette kan godt tage noget tid!"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§cVEDLIGEHOLDELSE:§e uSkyBlock er i vedligeholdelsestilstand"
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Bygger øen...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"§buSkyBlock§e afhænger af §9{0}§e >= §av{1}§e men kun §cv{2}§e blev fundet!\n"
+"\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e afhænger af §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§4Du har ikke adgang til den ø-type!"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4Spilleren er allerede del af denne ø!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4Du er nødt til at være tættere på din ø, for at sætte dit hjem!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aDit hjemsted er blevet sat til din nuværende position."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4Din nuværende position er ikke et sikkert hjemsted."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+"§7Feerne har travlt med at ændre biomen for din ø til §9{0}§7, vær venligst "
+"tålmodig."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr ""
+"§cDin ø er ved at blive re-genereret, det er ikke muligt at oprette nu."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "Kunne ikke oprette din ø. Venligst kontakt en server administrator."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+"§eForbereder din ø til dig, venligst vær tålmodig, det kan tage noget tid."
+
+msgid "§cCommand is currently disabled!"
+msgstr "§cKommando er utilgængelig i øjeblikket!"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eDu mangler stadig følgende blokke: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1830,9 +240,6 @@ msgid ""
 msgstr ""
 "§eAt udføre §9{0}§e er §cRISIKABELT§e. Gentag kommandoen inden for §a{1}§e "
 "sekunder for at fortsætte!"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** Du ankommer nu til en beskyttet - men forladt - ø."
@@ -1865,213 +272,32 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4Kun lederen kan låse din ø op!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§7PlayerDB: Filtrerer {0} spillere vha. uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eVenter på din tur §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Bygger øen...§e{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lLåst udfordring"
+
+msgid "READY"
+msgstr "KLAR"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§7PlayerDB: Filtrerede {0} navne"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§7MojangAPI: Forsøger at hente {0} spillere fra Mojang"
-
-msgid "SUCCESS"
-msgstr "SUCCESS"
-
-msgid "FAILED"
-msgstr "FEJLEDE"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§7 - MojangAPI:§aFULDFØRT: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§7 - MojangAPI:§cFEJL: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-"§eProgress: {0,number,##}% ({1}/{2} - ok:{3}, fejl:{4}, skipped:{5}) ~ {6}"
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4Ingen §e{0}§4 importer fundet"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§eKonverterede {0}/{1} filer på {2}"
-
-msgid "The island has been created."
-msgstr "Øen blev oprettet."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d låste øen."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§4Da din ø er låst, er din besøgsportal blevet deaktiveret."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d låste øen op."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cSKY §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d er blevet fjernet fra øens medlemsliste."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9Opretter en ø på din nuværende position"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9Opretter en ø §7{0}§9 for dig"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§4{0} udfordringen er ikke tilgængelig endnu!"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
-msgstr ""
-"§cØen der ejer denne del af nether bliver slettet! Du bliver sendt til spawn."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
+msgstr "§cADVARSEL:§e Kunne ikke overføre de nødvendige ting til din taske!"
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§cØen du er på bliver slettet! Du bliver sendt til spawn."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eTOP (side {0} af {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr "§4Top 10 listen er tom! Kun øer over niveau {0} er på listen."
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eDin position er: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "ukendt"
-
-msgid "ANIMAL"
-msgstr "dyr"
-
-msgid "MONSTER"
-msgstr "monster"
-
-msgid "VILLAGER"
-msgstr "by-boer"
-
-msgid "GOLEM"
-msgstr "golem"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0} §a{1}§7 (max. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr ""
-"Ude af stand til at finde skabelon {0}, kontakt en server-administrator"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aTillykke! §eDin ø er ankommet."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cBemærk:§e Det kan være der stadig arbejdes på den."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Brug §9/is h§r eller §9/is§r menuen til at tage derhen."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr ""
-"§cVagthund!§9 Ude af stand til at finde en kiste inden for {0}, giver op."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7Side {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr "§c{0,number,#}"
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr "§a+{0,number,#}"
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr "§a{0,number,#}"
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr "&aVenstre:&7 Tilføj {0}"
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr "&cHøjre-Klik:&7 Sæt til {0}"
-
-msgid "Return"
-msgstr "Tilbage"
-
-msgid "§9Integer Editor"
-msgstr "§9Tal Redigering"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eKonfigurationen gemt og genindlæst."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cFejl! §9Kunne ikke gemme konfigurationsfilen!"
-
-msgid "§3First Page"
-msgstr "§7Første side"
-
-msgid "§3Last Page"
-msgstr "§3Sidste side"
-
-msgid "§cSave & Reload config"
-msgstr "§cGem og genindlæs konfigurationen"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Gemmer indstillingerne\n"
-"§7& genindlæser pluginnet.\n"
-"§cBemærk: §7Brug på eget ansvar!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (låst)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr "§cIkke nok ting i kisten til at fuldføre udfordringen!"
 
 msgid "true"
 msgstr "sand"
@@ -2507,6 +733,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "§7Denne side"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7Side {0}"
+
 msgid "§7First Page"
 msgstr "§7Første side"
 
@@ -2805,8 +1035,8 @@ msgstr "§cKlik for at forlade"
 msgid "Island Restart Menu"
 msgstr "Ø Genstarts Menu"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§4Du har ikke adgang til den ø-type!"
+msgid "Config:"
+msgstr "Konfiguration:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2822,115 +1052,121 @@ msgstr "§cKlik inden for §9{0} for at genstarte!"
 msgid "§aClick to restart!"
 msgstr "§a§lKlik for at genstarte!"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr "§c{0,number,#}"
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr "§a+{0,number,#}"
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr "§a{0,number,#}"
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr "&aVenstre:&7 Tilføj {0}"
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr "&cHøjre-Klik:&7 Sæt til {0}"
+
+msgid "Return"
+msgstr "Tilbage"
+
+msgid "§9Integer Editor"
+msgstr "§9Tal Redigering"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9Tekst Editor"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eKonfigurationen gemt og genindlæst."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cFejl! §9Kunne ikke gemme konfigurationsfilen!"
+
+msgid "§3First Page"
+msgstr "§7Første side"
+
+msgid "§3Last Page"
+msgstr "§3Sidste side"
+
+msgid "§cSave & Reload config"
+msgstr "§cGem og genindlæs konfigurationen"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Gemmer indstillingerne\n"
+"§7& genindlæser pluginnet.\n"
+"§cBemærk: §7Brug på eget ansvar!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (låst)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+"§eProgress: {0,number,##}% ({1}/{2} - ok:{3}, fejl:{4}, skipped:{5}) ~ {6}"
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4Ingen §e{0}§4 importer fundet"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§eKonverterede {0}/{1} filer på {2}"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§7PlayerDB: Filtrerer {0} spillere vha. uuid2name.yml"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§7PlayerDB: Filtrerede {0} navne"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§7MojangAPI: Forsøger at hente {0} spillere fra Mojang"
+
+msgid "SUCCESS"
+msgstr "SUCCESS"
+
+msgid "FAILED"
+msgstr "FEJLEDE"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§7 - MojangAPI:§aFULDFØRT: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§7 - MojangAPI:§cFEJL: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "For mange forespørgsler til Mojang ({0} inden for {1}), venter {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr "§9Hold hesten an! Du skal være tålmodig..."
-
-msgid "§9Not really patient, are you?"
-msgstr "§9Du er ikke specielt tålmodig, er du?"
-
-msgid "§9Be patient, young padawan"
-msgstr "§9Vær tålmodig, lille ven"
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr "§9Tålmodig, du må være, unge mester"
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr "§9De to stærkeste krigere er tålmodighed og tid."
-
-msgid "§eSending you to spawn."
-msgstr "§aTeleporterer dig til spawn."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§eØen er blevet §cLÅST§e."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§eDu vil blive teleporteret om {0} sekunder."
-
-msgid "§7Teleport cancelled"
-msgstr "§7Teleport afbrudt"
-
-msgid "READY"
-msgstr "KLAR"
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr "§cADVARSEL:§e Kunne ikke overføre de nødvendige ting til din taske!"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr "§cIkke nok ting i kisten til at fuldføre udfordringen!"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Der opstod en fejl under gemning af øens data!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr "Konverterer data til UUID, dette kan godt tage noget tid!"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§cVEDLIGEHOLDELSE:§e uSkyBlock er i vedligeholdelsestilstand"
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"§buSkyBlock§e afhænger af §9{0}§e >= §av{1}§e men kun §cv{2}§e blev fundet!\n"
-"\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e afhænger af §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4Spilleren er allerede del af denne ø!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4Ude af stand til at finde et sikkert sted på din ø!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§cADVARSEL:§e Teleporterer dig op i luften."
-
-msgid "§aTeleporting you to your island."
-msgstr "§aTeleporterer dig til din ø."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Ude af stand til at teleportere dig til den spillers ø!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aTeleporterer dig til {0}s ø."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4Du er nødt til at være tættere på din ø, for at sætte dit hjem!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aDit hjemsted er blevet sat til din nuværende position."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4Din nuværende position er ikke et sikkert hjemsted."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr ""
-"§cDin ø er ved at blive re-genereret, det er ikke muligt at oprette nu."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "Kunne ikke oprette din ø. Venligst kontakt en server administrator."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-"§eForbereder din ø til dig, venligst vær tålmodig, det kan tage noget tid."
-
-msgid "§cCommand is currently disabled!"
-msgstr "§cKommando er utilgængelig i øjeblikket!"
 
 msgid "North"
 msgstr "Nord"
@@ -2955,3 +1191,1763 @@ msgstr "Vest"
 
 msgid "North-West"
 msgstr "Nord-Vest"
+
+msgid "The island has been created."
+msgstr "Øen blev oprettet."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d låste øen."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§4Da din ø er låst, er din besøgsportal blevet deaktiveret."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d deaktiverede øens besøgsportal."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d låste øen op."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cSKY §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d er blevet fjernet fra øens medlemsliste."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9Opretter en ø på din nuværende position"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9Opretter en ø §7{0}§9 for dig"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aTillykke! §eDin ø er ankommet."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cBemærk:§e Det kan være der stadig arbejdes på den."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Brug §9/is h§r eller §9/is§r menuen til at tage derhen."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr ""
+"Ude af stand til at finde skabelon {0}, kontakt en server-administrator"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr ""
+"§cVagthund!§9 Ude af stand til at finde en kiste inden for {0}, giver op."
+
+msgid "UNKNOWN"
+msgstr "ukendt"
+
+msgid "ANIMAL"
+msgstr "dyr"
+
+msgid "MONSTER"
+msgstr "monster"
+
+msgid "VILLAGER"
+msgstr "by-boer"
+
+msgid "GOLEM"
+msgstr "golem"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0} §a{1}§7 (max. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§cØen der ejer denne del af nether bliver slettet! Du bliver sendt til spawn."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§cØen du er på bliver slettet! Du bliver sendt til spawn."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eTOP (side {0} af {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr "§4Top 10 listen er tom! Kun øer over niveau {0} er på listen."
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4Ø levels er blevet deaktiveret, kontakt en administrator."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eDin position er: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "§7Gennemfør yderligere {0} {1} §7udfordringer"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Gennemfør {0}"
+
+msgid "to unlock this rank"
+msgstr "for at låse denne rank op"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr "§4Du kan gennemføre dette {0} gange mere."
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Kravene vil nulstilles om {0} dage."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Kravene vil nulstilles om {0} timer."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4Kravene vil nulstilles om {0} minutter."
+
+msgid "§4This challenge is currently unavailable."
+msgstr "§4Denne udfordring er pt. utilgængelig."
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr "§4Du kan gennemføre dette igen om {0} dage."
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr "§4Du kan gennemføre dette igen om {0} timer."
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr "§4Du kan gennemføre dette igen om {0} minutter."
+
+msgid "§eThis challenge requires:"
+msgstr "§eDenne udfordring kræver:"
+
+msgid "§7and more..."
+msgstr "§7og flere..."
+
+msgid "§eItems will be traded for reward."
+msgstr "§eTingene vil blive byttet for en gevinst."
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr "§eSkal være inden for {0} meter."
+
+msgid "§6Item Reward: §a"
+msgstr "§6Ting: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Økonomi: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Erfaring: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dTotalt antal aflevering: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr "§7Kræver {0}"
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4Ingen udfordringer med navn {0} fundet"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4Du skal være på din ø, for at gøre det!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4{0} udfordringen er ikke gentagelig!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr "§4Du kan ikke gennemføre {0} udfordringen endnu!"
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§eForsøger at gennemføre §a{0}"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr "§4Du skal stå inden for {0} blokke af alle de påkrævede elementer."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4Din ø skal mindst være level {0} for at gennemføre denne udfordring!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Ukendt udfordrings-type: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§eDu mangler stadig følgende elementer:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eDu mangler følgende:{0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aDo you gennemført {0}-udfordringen!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9{0}§f har gennemført §9{1}§f udfordringen!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§ePræmie: §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eXP præmie: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§ePenge præmie: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eDine tasker ef §4fulde§e. Tingene er faldet på jorden."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lKlik for at gennemføre."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lDu kan ikke gentage denne udfordring."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Rank: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fGennemfør de fleste udfordringer"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fpå dette niveau, for at åbne det næste."
+
+msgid "§eClick here to show previous page"
+msgstr "§fKlik her for forrige side"
+
+msgid "§eClick here to show next page"
+msgstr "§fKlik her for næste side"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "Men du er helt alene!"
+
+msgid "But you are Yelling in the wind!"
+msgstr "Men du råber i vinden!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "Men dine fantasivenner er smuttet!"
+
+msgid "But you are Talking to your self!"
+msgstr "Men du taler til dig selv!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cUndskyld! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr "Send en besked til din gruppe, eller toggle chat on/off."
+
+msgid "party"
+msgstr "selskab"
+
+msgid "island"
+msgstr "ø"
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§cTogglede chat til {0} §aON"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§cGentag §9{0}§c for at deaktivere igen"
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§aTogglede chat §cOFF§a for {0}"
+
+msgid "§cCommand only available to players"
+msgstr "§cKommandoen er kun tilgængelig for spillere"
+
+msgid "talk to your island party"
+msgstr "tal til medlemmerne af din ø"
+
+msgid "talk to players on your island"
+msgstr "snak med spillere på din ø"
+
+msgid "manually update the top 10 list"
+msgstr "opdater top 10 listen manuelt"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eGenererer top 10 listen"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eBlev færdig med genereringen af top 10"
+
+msgid "purges all abandoned islands"
+msgstr "fjerner alle forladte øer"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4Do skal angive hvor gamle (i dage) øerne til purge skal være!"
+
+msgid "§4The level must be a valid number"
+msgstr "§4Niveauet skal være et validt nummer"
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr "§4Forsøger at afbryde oprydning"
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr "§4Starter oprydning..."
+
+msgid "Controls player-cooldowns"
+msgstr "Håndterer spiller-cooldowns"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "fjerner et cooldown fra en kommando (* = alle)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eDen spiller er ikke online"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Nulstillede cooldown på {0} for {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Ingen aktiv cooldowns på {0} for {1}!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Forkert kommando givet, kun restart og biome er understøttet!"
+
+msgid "restarts the cooldown on the command"
+msgstr "genstart et cooldown på en kommando"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eReset cooldown on {0} for {1}§e to {2} seconds"
+
+msgid "lists all the active cooldowns"
+msgstr "list alle aktive cooldowns"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCmd Cooldown"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eIngen aktive cooldowns for §9{0}§e fundet."
+
+msgid "toggles maintenance mode"
+msgstr "skifter vedligeholdelsestilstand"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+"§cVEDLIGEHOLDELSE: §aAktiveret§e all uSkyBlock funktioner er deaktiveret."
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr "§cVEDLIGEHOLDELSE: §4Deaktiveret§e alle funktioner operationelle igen."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr "§cVedligeholdelsestilstand kan kun ændres fra konsollen!"
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Job Statistik"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/job"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "akt"
+
+msgid "time"
+msgstr "tid"
+
+msgid "name"
+msgstr "navn"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§eSpiller {0} har ingen ø!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eForkert spiller-navn {0} givet."
+
+msgid "flushes all caches to files"
+msgstr "gemmer alle caches til filer"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr "§eGemte §a{0} øer§e, §b{1} spillere og §6{2} udfordringer."
+
+msgid "tries to fix the the area of flatland."
+msgstr "forsøger at fjerne flatland under øen."
+
+msgid "§4No valid island found"
+msgstr "§4Ingen valid ø fundet"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4Intet fladland fundet ved {0}''s ø!"
+
+msgid "manage orphans"
+msgstr "håndter forældreløse"
+
+msgid "count orphans"
+msgstr "tæl horeunger"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§e{0} gamle ø-placeringer vil blive brugt før nye."
+
+msgid "clear orphans"
+msgstr "nulstil horeunger"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eFjerner alle gamle (tomme) ø-placering."
+
+msgid "list orphans"
+msgstr "list horeunger"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eIngen forældreløse øer registreret i øjeblikket."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "overfør ejerskab til en anden spiller"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4Spiller {0} har ingen ø at overføre!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eSpiller §d{0}§e har allerede en ø.§eBrug §9/usb island remove <navn>§efor "
+"at fjerne ham først."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bEjerskab overført af {0}§b til {1}"
+
+msgid "open GUI for config"
+msgstr "vis konfigurations UI"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§eForkert konfiguraionsnavn"
+
+msgid "teleport to another players island"
+msgstr "teleporterer til en andens ø"
+
+msgid "§4Only supported for players"
+msgstr "§4Kun understøttet for spillere"
+
+msgid "§4That player does not have an island!"
+msgstr "§4Den spiller har ingen ø!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr "§aTeleporterer til {0}''s ø."
+
+msgid "various WorldGuard utilities"
+msgstr "blandede WorldGuard værktøjer"
+
+msgid "refreshes the chunks around the player"
+msgstr "genindlæser chunks omkring spilleren"
+
+msgid "§eResending chunks to the client"
+msgstr "§eGensender chunks til klienten"
+
+msgid "load the region chunks"
+msgstr "load chunks fra regionen"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eHenter chunks ved {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eFrigiver chunks ved {0}"
+
+msgid "update the WG regions"
+msgstr "opdater world-guard regioner"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§eØens world-guard region opdateret for {0}"
+
+msgid "§eNo island found at your location!"
+msgstr "§4Ingen valid ø på din position!"
+
+msgid "refreshes the chunk around the player"
+msgstr "indlæser det omkringliggende gitter"
+
+msgid "region manipulations"
+msgstr "region manipulationer"
+
+msgid "shows the borders of the current island"
+msgstr "viser kanterne for den nuværende ø"
+
+msgid "§eNo island found at your current location"
+msgstr "§eIngen ø fundet ved din nuværende position"
+
+msgid "§eCan only be executed as a player"
+msgstr "§eKan kun udføres som spiller"
+
+msgid "shows the borders of the current chunk"
+msgstr "viser kanterne i den nuværende chunk"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "viser de indre chunks"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "viser de ikke-chunk-tilrettede kanter"
+
+msgid "shows the borders of the outer-chunks"
+msgstr "viser kanterne for de ydre chunks"
+
+msgid "hides the regions again"
+msgstr "skjuler regionerne igen"
+
+msgid "§eStopped displaying regions"
+msgstr "§eStoppede med at vise regioner"
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§eIngen regioner at vise for denne spiller"
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§eAnimations-tick ændret til {0}."
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§eAnimations-tick skal være et validt heltal."
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4OPRYDNING:§9 Forladte øer er nu blevet sendt til genbrug."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4OPRYDNING:§9 Afbrød oprydning af forladte øer."
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§7- SKANNER: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4OPRYDNING:§9 Skanning afbrudt."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§cAFBRUDT:§e Protect-All blev afbrudt!"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr "§eFuldførte protect-all på {0}, {1} nye regioner blev oprettet!"
+
+msgid "control debugging"
+msgstr "håndter debugging"
+
+msgid "set debug-level"
+msgstr "sæt debug-niveau"
+
+msgid "toggle debug-logging"
+msgstr "slå bebugging til/fra"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4Ligning er ikke aktiv, så du kan ikke stoppe det!"
+
+msgid "flush current content of the logger to file."
+msgstr "skriv log-filen til disk."
+
+msgid "§eLog-file has been flushed."
+msgstr "§eLog-filen er blevet skrevet."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4Logning er ikke aktiv, brug §9/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Forkert argument, prøv INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eLogning deaktiveret!"
+
+msgid "advanced command for setting island-data"
+msgstr "avanceret kommando til at sætte ø-data"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§c{0} blev sat til ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§cKan ikke sætte {0} til ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr "§cKan ikke sætte {0} til ''{1}'', det skal være et tal"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§cUkendt felt {0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§eNuværende værdi for {0} er ''{1}''"
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§cKan ikke læse tilstand for {0}"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§eFelter {0}"
+
+msgid "set a player''s island to your location"
+msgstr "tildeler øen til en spiller"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr "§aSæt {0}s ø til den nuværende."
+
+msgid "§4Island not found: unable to set the island!"
+msgstr "§4Ø ikke fundet: ude af stand til at overføre ejerskabet!"
+
+msgid "advanced info about NBT stuff"
+msgstr "avanceret info om NBT"
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "viser NBTTag for den ting du har i hånden"
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§eInfo for §9{0}"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - navn: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - nbttag: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§cDu har tomme hænder!"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "sætter NBTTagget på tingen i din hånd"
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "§eSatte §9{0}§e til §c{1}"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "tilføjer NBTTags til tingen i din hånd"
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§eTilføjede §9{0}§e til §c{1}"
+
+msgid "Manage challenges for a player"
+msgstr "Hånter udfordringer for en spiller"
+
+msgid "resets the challenge for the player"
+msgstr "nulstiller udfordringer for spilleren"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4Udfordringen er aldrig blevet gennemført"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§eudfordring: {0} er blevet nulstillet for {1}"
+
+msgid "resets all challenges for the player"
+msgstr "nulstiller alle spillerens udfordringer"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0} har fået alle udfordringer nulstillet."
+
+msgid "complete all challenges in the rank"
+msgstr "gennemfør alle udfordringerne i kategorien"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4Ingen spiller med navn {0} fundet!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4Udfordringen {0} er allerede blevet gennemført"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§eUdfordring {0} er blevet gennemført af {1}"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4Ingen udfordringer med navn {0} fundet!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4Ingen kategori med navnet {0} findes!"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "beskytter alle øer (tidskrævende)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§cForsøger at afbryde protect-all opgaven."
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4Undskyld!§e En protect-all er allerede igangværende. Vent til den er "
+"færdig, eller brug §9usb protectall §cstop"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§eStarter en kørsel af protect-all. Det vil tage et stykke tid."
+
+msgid "reload configuration from file."
+msgstr "genindlæs konfigurationen fra fil."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eKonfigurationen blev genindlæst fra fil."
+
+msgid "manage islands"
+msgstr "håndter øer"
+
+msgid "protects the island"
+msgstr "beskytter øen"
+
+msgid "delete the island (removes the blocks)"
+msgstr "fjern øen (fjerne alle blokke)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Slettede en forladt ø på din nuværende position."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4Øen på denne position har medlemmer!\n"
+"§eBrug §9/usb island delete <navn>§e for at slette den."
+
+msgid "removes the player from the island"
+msgstr "fjerner spilleren fra øen"
+
+msgid "adds the player to the island"
+msgstr "tilføjer spilleren til øen"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d er blevet medlem af øen."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4Ingen spiller med navn {0} fundet!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr "§4Ingen valid ø fundet, enten stå på en ø, eller skriv et navn"
+
+msgid "print out info about the island"
+msgstr "vis informationer om øen"
+
+msgid "sets the biome of the island"
+msgstr "sætter øens biome"
+
+msgid "§4That player has no island."
+msgstr "§4Den spiller har ingen ø."
+
+msgid "§4No valid island at your location"
+msgstr "§4Ingen valid ø på din position"
+
+msgid "purges the island"
+msgstr "markerer øen til genbrug"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4Fejl! §9Ingen valid ø fundet, til genbrug."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cOPRYDNING: §9Markede øen ved {0} til genbrug"
+
+msgid "toggles the islands ignore status"
+msgstr "skift øens ignore-tilstand"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cIngorer {0}s ø på top 10 og ved genbrug."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cFjernede ignore-flaget på {0}s ø, den vil nu blive vist på top 10 og være "
+"kandidat til oprydning."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Intet validt spiller-navn givet."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Fjerner {0} fra ø"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eÆndrede biomen for {0}s ø til {1}"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eÆndrede biomen for {0}s ø til HAV."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr ""
+"§aDu bliver måske nødt til at gå til spawn, eller relogge, for at se "
+"ændringerne."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} har fået deres biome ændret til {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} har fået deres biome ændret til HAV."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eFjerner {0}''s ø."
+
+msgid "Error: That player does not have an island!"
+msgstr "Fejl: Den spiller har ingen ø!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§e{0}s ø ved {1} er blevet beskyttet"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4{0}s ø ved {1} var allerede beskyttet"
+
+msgid "displays version information"
+msgstr "viser versionsinformationer"
+
+msgid "imports players and islands from other formats"
+msgstr "importer spillere og øer fra andre formater"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr "ekstra goder {0}"
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "skifter sprog af pluginnet, og genindlæser det"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aSkiftede sprog til §e{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cKunne ikke skifte sprog til §e{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Understøttede sprog:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 af {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cKunne ikke finde nogle sprog."
+
+msgid "advanced command for getting island-data"
+msgstr "avanceret kommando til at læse ø-data"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "vis spiller-information"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4Din ø er fuld, eller du har for mange udestående invitationer. Du kan ikke "
+"invitere flere."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4Den spiller er allerede leder på en anden ø."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e forsøgte at invitere dig, men du er allerede i en gruppe."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr "§aInvitation sent til {0}"
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e har inviteret dig til at deltage på sin ø!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§f/island [accept/reject]§e for at acceptere invitationen."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4ADVARSEL: Du vil miste din nuværende ø hvis du accepterer!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d inviterede {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e har afvist invitationen."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4Du kan ikke bruge den kommando lige nu. Forlad din nuværende ø først."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§aDu er blevet medlem af en ø! Brug §9/island party§a for at se de andre "
+"medlemmer."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§eInvitationen til {0}§e er udløbet og er blevet annulleret."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§eInvitationen til {0}''s ø er udløbet og er blevet annulleret."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§eDu har accepteret en invitation til at blive medlem af en ø."
+
+msgid "§4You haven't been invited."
+msgstr "§4Du er ikke blevet inviteret."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eDu har afvist invitationen til en ø."
+
+msgid "general island command"
+msgstr "generel ø kommando"
+
+msgid "allows user to bypass cooldowns"
+msgstr "tillader brugere at omgå tidsbegrænsninger"
+
+msgid "allows user to bypass visitor-protections"
+msgstr "tillader brugere at omgå besøgsbeskyttelser"
+
+msgid "allows user to bypass teleport-delay"
+msgstr "tillader brugere at omgå teleport-forsinkelse"
+
+msgid "allows user to use [usb] signs"
+msgstr "tillader brugere at bruge [usb] skilte"
+
+msgid "allows user to place [usb] signs"
+msgstr "tillader brugere at placere [usb] skilte"
+
+msgid "complete and list challenges"
+msgstr "aflever og se udfordringer"
+
+msgid "§cCommand only available for players."
+msgstr "§cKommandoen er kun tilgængelig for spillere."
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eUdfordringer er deaktiveret. Kontakt en administrator."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4Du kan kun gennemføre udfordringer i skyblock verdenen!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4Du kan kun gennemføre udfordringer når du har en ø!"
+
+msgid "warp to another player''s island"
+msgstr "besøg en andens ø"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr "§aDin besøgsportal er aktiv. Spillere kan teleportere til din ø."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§4Din besøgsportal er inaktiv. Spillere kan ikke teleportere til din ø."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr ""
+"§fSæt besøgsportalen til din nuværende position ved at bruge §e/island "
+"setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§fSkift adgang til din besøgsportal ved brug af §9/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4Du har ikke tilladelse til at oprette en besøgsportal på din ø!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§fTeleporter til en anden ø med §9/island warp <spiller>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4Du har ikke tilladelse til at teleportere til andre øer!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cDin ø er ved at blive re-genereret, du kan ikke bruge warp i øjeblikket."
+
+msgid "§4That player does not exist!"
+msgstr "§4Ingen spiller fundet!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4Den spiller har ikke en aktiv besøgsportal."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§cDen spillers ø er under konstruktion, du kan ikke warpe til den i "
+"øjeblikket."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cADVARSEL: §9{0}§e kommer på besøg på din ø!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4Den spiller har udelukket dig fra sin ø."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4Ingen ø. §e Brug §9/is create§e for at få en"
+
+msgid "accept/reject an invitation."
+msgstr "afvis eller accepter invitationen."
+
+msgid "leave your party"
+msgstr "forlad dit selskab"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4Du kan ikke forlade en ø, hvis du er den eneste der. Prøv at bruge §9/"
+"island restart§4 hvis du vil have en ny!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§eDu er ejer af denne ø. Brug §9/island remove <spiller>§e istedet."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eDu har forladt øen, og er blevet sendt til spawn."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0} har forladt din ø!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4Du skal være i skyblock-verdenen for at forlade din ø!"
+
+msgid "check your or anothers island level"
+msgstr "check din eller en andens øs niveau"
+
+msgid "allows user to query for others levels"
+msgstr "tillader brugere at spørge til andres niveau"
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eDu skal være på en ø, for at bruge denne kommando."
+
+msgid "§4You do not have an island!"
+msgstr "§4Du har ikke en ø!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4Du har ikke adgang til den kommando!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4Den spiller er invalid eller har ingen ø!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eInformation om {0}s ø:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§eØen niveau er {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§eDin position er: §f{0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "opret en ø"
+
+msgid "exempt player from create-cooldown"
+msgstr "lad brugeren undgå oprettelsestidsbegrænsning"
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4Ø fundet!§e Du har allerede en ø. Hvis du vil have en ny, brug §b/is "
+"restart§e"
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§Ø fundet!§e Du er allerede medlem af en ø. Hvis du vil have din egen, "
+"forlad den først §b/is leave"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eDu kan opette en ny ø om {0,number,#} sekunder."
+
+msgid "invite a player to your island"
+msgstr "inviter en spiller til din ø"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§eBrug §9/island invite <spillernavn>§e for at invite en spiller til din ø."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4Kun øens ejer kan invitere!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aDu kan invitere yderligere {0} spillere til din ø."
+
+msgid "§4You can't invite any more players."
+msgstr "§4Du kan ikke invitere flere spillere."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4Du har ikke tilladelse til at invite flere til din ø!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4Den spiller er offline eller eksisterer ikke."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4Du kan ikke invitere dig selv!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4Den spiller er leder på din ø!"
+
+msgid "lock your island to non-party members."
+msgstr "lås din ø for ikke-medlemmer."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4Du har ikke tilladelse til at låse din ø!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4Du har ikke adgang til denne kommando!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4Du har ikke tilladelse til at låse din ø op!"
+
+msgid "display the top10 of islands"
+msgstr "vis top10 af øer"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr "tillader brugeren altid at generere top 10"
+
+msgid "remove a member from your island."
+msgstr "fjern et medlem fra din ø."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4Du har ikke tilladelse til at eksludere spillere fra denne ø!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4Du kan ikke fjerne lederen fra en ø!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4Stop med at sparke dig selv!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0} har fjernet dig fra deres ø!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} er blevet sparket ud af øen."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4{0} førsøgte at fjerne dig fra deres ø!"
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4{0} kan ikke sparkes."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4{0} har fjernet dig fra deres ø!"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0} er blevet sparket af øen."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr "§4Den spiller er hverken medlem af din ø, eller gæst på den!"
+
+msgid "teleport to the island home"
+msgstr "teleporter til øens hjem"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§cDin ø er under konstruktion, du kan ikke teleportere til den i øjeblikket."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4Denne kommando kan kun udføres af spillere"
+
+msgid "transfer leadership to another member"
+msgstr "overfør ejerskab til et andet medlem"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4Du kan kun overføre ejerskab til andre medlemmer!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e er allerede leder på din ø!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4Kun lederen an overføre lederskab!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} forsøgte at overtage øen!"
+
+msgid "show party information"
+msgstr "vis medlemsinformation"
+
+msgid "shows information about your party"
+msgstr "viser informationer om dit selskab"
+
+msgid "show pending invites"
+msgstr "vis udestående invitationer"
+
+msgid "§eNo pending invites"
+msgstr "§eIngen udestående invitationer"
+
+msgid "withdraw an invite"
+msgstr "træk en invitation tilbage"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4Du har ikke tilladelse til at afvise invitationer."
+
+msgid "check your or another''s island info"
+msgstr "få information om din eller en andens ø"
+
+msgid "allows user to see others island info"
+msgstr "tillader brugere at se andre øers informationer"
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr "§4Tag den med ro! §eDu bliver nødt til at være tålmodig..."
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBlokke på {0}s ø (side {1,number} af {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Score Antal Blok"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr "{0,number,00.00}  {1,number,#} {2}"
+
+msgid "trust/untrust a player to help on your island."
+msgstr "tillad en spiller at hjælpe med på din ø."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eDe følgende spillere betroet på din ø:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eDe følgende ledere har tiltro til dig:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr "§eFor at betro spillere adgang, brug §9/is trust <spiller>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4Medlemmet er allerede betroet!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Ukendt spiller {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eDu er nu betroet på §4{0}§es ø."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} tilføjede {1} som ven til øen"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eDu er ikke længere betroet på §4{0}§es ø."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0} fjernede {1} som ven af øen"
+
+msgid "delete your island and start a new one."
+msgstr "slet din ø og start på en ny."
+
+msgid "exempt player from restart-cooldown"
+msgstr "lad brugeren undgå genstart-tidsbegrænsning"
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4Kun ejeren må genstarte en ø. Forlad øen for at starte din egen (§9/island "
+"leave§4)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eDu skal fjerne alle medlemmer af din ø, før du kan genstarte den (§9/"
+"island kick <spiller>§e).Se en liste af medlemmerne med §9/island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§cDu kan genstarte din ø om {0} sekunder."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr "§cDin ø er ved at re-generere, du kan ikke genstarte nu."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§eBEMÆRK: Hele din ø, og alle dine ejendele vil blive tabt!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "teleporter dig til skyblock spawn"
+
+msgid "change the biome of the island"
+msgstr "ændr øens biome"
+
+msgid "exempt player from biome-cooldown"
+msgstr "lad brugeren undgå biome-tidsbegrænsning"
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr "Tillad spilleren at ændre øens biome til {0}"
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr "§cDu har ikke tilladelse til at ændre biome for din ø."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4Du har ikke tilladelse til at ændre biome for denne ø!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eDu skal være på din ø, for at ændre biome!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr "§cDu har stavet biomen forkert. Skal være en af {0}"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eDu kan ikke ændre biome de næste {0,number,#} minutter."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§4Du har ikke tilladelse til at ændre til den biome."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+"§7De små feer har travlt med at ændre naturen omkring dig til §9{0}§7, vær "
+"tålmodig."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr "§eForkert biome {0} angivet!"
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aDu har ændret din ø''s biome til {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} ændrede øens biome til {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr "§aDu har ændret {0} blokke omkring dig til {1} biomen"
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr "{0} oprettede et område med {1} biome"
+
+msgid "set your island''s warp location"
+msgstr "sæt din øs besøgspunkt"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cDu har ikke tilladelse til at sætte din ø''s besøgsportal!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§4Du skal være på din ø, for at gøre det!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d ændrede øens besøgsportal."
+
+msgid "teleports you to your island (or create one)"
+msgstr "teleporterer dig til din ø (eller opretter en ny)"
+
+msgid "ban/unban a player from your island."
+msgstr "ban/unban en spiller fra din ø."
+
+msgid "exempts user from being banned"
+msgstr "bloker brugeren fra at blive bannet"
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§eDe følgende spillere er udelukket fra at teleportere til din ø:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr "§eFor at udelukke/tilgive spillere, brug §9/is ban <spiller>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4Du kan ikke udelukke medlemmer. Fjern dem først!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4Du har ikke tilladelse til at udelukke spillere."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§eUde af stand til at banne ukende spiller {0}"
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4{0} forsøgte at udelukke dig fra deres ø!"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4{0} kan ikke bannes."
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eDu har udelukket §4{0}§e fra at teleportere til din ø."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eDu er blevet §cFORVIST§e fra {0}§e''s ø."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§eDu har tilladt §a{0}§e at teleportere til din ø."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eDu er blevet §aBENÅDET§e af {0}."
+
+msgid "display log"
+msgstr "vis aktivitetslog"
+
+msgid "changes a members island-permissions"
+msgstr "ændrer et medlems tilladelser på øen"
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr "§eTilladelser for §9{0}§e:"
+
+msgid "§aON"
+msgstr "§aON"
+
+msgid "§cOFF"
+msgstr "§cOFF"
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr "§7 - §6{0}§7 : {1}"
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr "§cUgyldig tilladelse {0}. Skal være en af {1}"
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr "§eÆndrede tilladelse §9{0}§e for §9{1}§e til {2}"
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr "§eUde af stand til at ændre tilladelse §9{0}§e for §9{1}"
+
+msgid "set the island-home"
+msgstr "sæt øens start-position"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "tillad/bloker besøg på din ø."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4Din er er låst. Du bliver nødt til at låse den op, før du kan aktivere "
+"besøgsportal."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d aktiverede øens besøgsportal."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr ""
+"§cDu har ikke tilladelse til at aktivere/deaktivere din ø''s besøgsportal!"
+
+msgid "try to complete a challenge"
+msgstr "forsøg at aflever en udfordring"
+
+msgid "show information about the challenge"
+msgstr "vis informationer om udfordringer"
+
+msgid "§eRank: "
+msgstr "§eRank: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4Denne udfording er ikke gentagelig!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr ""
+"§4Du vil miste alle de påkrævede ting, når du gennemfører denne udfordring!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4Alle de påkrævede elementer skal være på din ø, indenfor {0} meter fra dig."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§eFor at gennemføre denne udfordring, brug §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4Forkert udfordringsnavn!§e Brug §9/c help§e for mere info"
+
+msgid "§eSending you to spawn."
+msgstr "§aTeleporterer dig til spawn."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§eØen er blevet §cLÅST§e."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr "§9Hold hesten an! Du skal være tålmodig..."
+
+msgid "§9Not really patient, are you?"
+msgstr "§9Du er ikke specielt tålmodig, er du?"
+
+msgid "§9Be patient, young padawan"
+msgstr "§9Vær tålmodig, lille ven"
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr "§9Tålmodig, du må være, unge mester"
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr "§9De to stærkeste krigere er tålmodighed og tid."
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4Ude af stand til at finde et sikkert sted på din ø!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§cADVARSEL:§e Teleporterer dig op i luften."
+
+msgid "§aTeleporting you to your island."
+msgstr "§aTeleporterer dig til din ø."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§eDu vil blive teleporteret om {0} sekunder."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Ude af stand til at teleportere dig til den spillers ø!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aTeleporterer dig til {0}s ø."
+
+msgid "§7Teleport cancelled"
+msgstr "§7Teleport afbrudt"

--- a/uSkyBlock-Core/src/main/po/de.po
+++ b/uSkyBlock-Core/src/main/po/de.po
@@ -16,6 +16,34 @@ msgstr ""
 "X-Loco-Target-Locale: zz_ZZ\n"
 "X-Generator: Poedit 1.8.10\n"
 
+# ???
+msgid "d"
+msgstr "d"
+
+# ???
+msgid "h"
+msgstr "h"
+
+# ???
+msgid "m"
+msgstr "m"
+
+# ???
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§eDu hast keinen Zugriff (§4{0}§e)"
@@ -23,6 +51,15 @@ msgstr "§eDu hast keinen Zugriff (§4{0}§e)"
 #, java-format
 msgid "§eInvalid command: {0}"
 msgstr "§eUngültiger Befehl: {0}"
+
+msgid "Command"
+msgstr "Kommando"
+
+msgid "Permission"
+msgstr "Permission"
+
+msgid "Description"
+msgstr "Beschreibung"
 
 #, java-format
 msgid "§7Usage: {0}"
@@ -47,1705 +84,13 @@ msgstr "Hat die Dokumentaion nach {0} geschrieben"
 msgid "§4Error writing documentation: {0}"
 msgstr "§4Fehler beim schreiben der Dokumentation: {0}"
 
-msgid "Command"
-msgstr "Kommando"
-
-msgid "Permission"
-msgstr "Permission"
-
-msgid "Description"
-msgstr "Beschreibung"
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-# ???
-msgid "d"
-msgstr "d"
-
-# ???
-msgid "h"
-msgstr "h"
-
-# ???
-msgid "m"
-msgstr "m"
-
-# ???
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eDir fehlen: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4Anforderungen werden in {0} Tagen zurückgesetzt."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4Anforderungen werden in {0} Stunden zurückgesetzt."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4Anforderungen werden in {0} Minuten zurückgesetzt."
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr "§eDiese Aufgabe erfordert:"
-
-msgid "§7and more..."
-msgstr "§7und mehr..."
-
-msgid "§eItems will be traded for reward."
-msgstr "§eItems werden gegen die Belohnung eingetauscht."
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr "§eMuss innerhalb von {0} Meter befinden."
-
-msgid "§6Item Reward: §a"
-msgstr "§6Gegenstandsbelohnung: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Währungsbelohnung: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Erfahrungsbelohnung: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dSchon §f{0} §dmal abgeschlossen."
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr "§7Erfordert {0}"
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4Keine Aufgabe namens {0} gefunden."
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4Du musst auf deiner Insel sein um das zu tun!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§4Die Aufgabe {0} ist noch nicht verfügbar!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4Diese {0} Aufgabe kannst du nicht Wiederholen!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§eVersuche die §a{0} §eAufgabe abzuschliessen"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr ""
-"§4Du musst in {0} Blöcke Abstand von den benötigten Gegenständen stehen."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4Deine Insel muss Stufe {0} haben um die Aufgabe zu beenden!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Unbekannte Aufgabe: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr "§eDir fehlen: {0}"
-
-# ???
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eDir fehlen:{0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aDu hast die {0} Aufgabe beendet!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9{0}§f hat die §9{1}§f Aufgabe abgeschlossen!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§eGegenstandsbelohnung: §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eErfahrungsbelohnung: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eWährungsbelohnung: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eDein Inventar ist §4voll§e. Die Gegenstände fallen auf den Boden!"
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lKlick hier um die Aufgabe zu beenden!"
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lDu kannst diese Aufgabe nicht wiederholen!"
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Rang: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fBeende die meisten Aufgaben in"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fdiesem Rang, um den nächsten Rang freizuschalten."
-
-msgid "§eClick here to show previous page"
-msgstr "§eKlick hier um zur vorherigen Seite zu gelangen."
-
-msgid "§eClick here to show next page"
-msgstr "§eKlick hier um zur nächsten Seite zu gelangen."
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lGesperrte Aufgabe."
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "§7Schliesse {0} mehr {1} §7Aufgaben ab"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Schliesse {0} ab"
-
-msgid "to unlock this rank"
-msgstr "um diesen Rang freizuschalten"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "Du bist ALLLLLEEEEEEIIIIINE!"
-
-msgid "But you are Yelling in the wind!"
-msgstr "But you are Yelling in the wind!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "Deine Fantasiefreunde sind weg!"
-
-msgid "But you are Talking to your self!"
-msgstr "Du sprichst mit dir selber...!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cTschuldigung! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr "Sende eine Nachricht an deine Gruppe oder schalte es an oder aus."
-
-msgid "party"
-msgstr "Party"
-
-msgid "island"
-msgstr "Insel"
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§cSchaltet den Chat zu {0} §aON"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§cWiederhole §9{0}§c um es auzuschalten"
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§aSchalte den Chat für {0} §cAUS"
-
-msgid "§cCommand only available to players"
-msgstr "§cKommando nur für Spieler verfügbar"
-
-msgid "talk to players on your island"
-msgstr "rede zu Spielern auf deiner Insel"
-
-msgid "talk to your island party"
-msgstr "redet mit deinen Insel Mitgliedern"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§eSpieler {0} hat keine Insel!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eUngültiger Spieler {0} angegeben!"
-
-msgid "Manage challenges for a player"
-msgstr "Verwalte die Aufgaben für einen Spieler."
-
-msgid "resets the challenge for the player"
-msgstr "Setzt die Aufgaben für einen Spieler zurück."
-
-msgid "§4Challenge has never been completed"
-msgstr "§4Aufgabe wurde noch nicht beendet."
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§eAufgabe: {0} wurde für {1} zurückgesetzt."
-
-msgid "resets all challenges for the player"
-msgstr "Setzt alle Aufgaben für den Spieler zurück!"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0} hat alle Aufgaben zurücksetzen lassen."
-
-msgid "complete all challenges in the rank"
-msgstr "schliesst alle Aufgaben auf dem Rang ab"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4Kein Spieler mit dem Namen {0} wurde gefunden!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4Aufgabe {0} wurde schon abgeschlossen"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§eAufgabe {0} wurde schon {1} abgeschlossen"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4Keine Aufgabe mit dem Namen {0} wurde gefunden!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4Kein Rang namens {0} wurde gefunden"
-
-msgid "manage islands"
-msgstr "Bearbeite die Inseln"
-
-msgid "protects the island"
-msgstr "Sichert die Insel"
-
-msgid "delete the island (removes the blocks)"
-msgstr "Löscht die Insel (Entfernt auch die Blöcke)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Löscht verlassene Insel an deiner aktuellen Position"
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4Die Insel an ihrem Standort hat Mitglieder!\n"
-"§eBenutze §9/usb island delete <name>§e um die Insel zu löschen."
-
-msgid "removes the player from the island"
-msgstr "Entfernt den Spieler von der Insel."
-
-msgid "adds the player to the island"
-msgstr "fügt den Spieler zur Insel hinzu"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d ist deiner Inselgruppe beigetreten."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4Kein Spieler namens {0} gefunden"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr "§4Keine gültige Insel angegeben. Stehe auf einer oder gib eine an."
-
-msgid "print out info about the island"
-msgstr "Zeige Informationen zu der Insel."
-
-msgid "sets the biome of the island"
-msgstr "Setzt das Biome einer Insel"
-
-msgid "§4That player has no island."
-msgstr "§4Dieser Spieler hat keine Insel."
-
-msgid "§4No valid island at your location"
-msgstr "§4Keine gültige Insel an deiner Position."
-
-msgid "purges the island"
-msgstr "löscht die Insel"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Fehler! §9Keine gültige Insel zum löschen gefunden"
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cPURGE: §9Lösche Insel bei {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "ändert den Insel Ignorier Status"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cIgnoriert {0}s Insel auf der Top 10 Liste und löscht sie"
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr "§c{0}s Insel wird nun nicht länger ignoriert."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Kein Gültiger Spielername angegeben."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Entferne {0} von der Insel."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eJetzige Biome {0} der Insel, zu {1} gewechselt."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eBiome von {0} zu OZEAN gewechselt."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr ""
-"§aDu musst eventuell zum Spawn gehen oder dich neu einloggen um die "
-"Änderungen zu sehen."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} Hat ihr Biom geändert zu {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} Hat ihr Biom geändert zu OZEAN."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eEntferne {0}''s Insel."
-
-msgid "Error: That player does not have an island!"
-msgstr "Fehler: Dieser Spieler hat keine Insel!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§e{0}s Insel bei {1} ist nun geschützt"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4{0}s Insel bei {1} war schon geschützt"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "Öffne Konfigurations Menü"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§eUngültiger Konfigurationsname"
-
-msgid "Controls player-cooldowns"
-msgstr "Kontrolliert Spieler-Abklingzeiten"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "Löscht die Abklingzeit von einem Befehl (* = alle)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eDer Spieler ist nicht online."
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Abklingzeit von {0} für {1} gelöscht."
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Keine aktive Abklingzeit bei {0} für {1} gefunden!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Ungültiger Befehl! Nur Neustart und Biome werden unterstützt!"
-
-msgid "restarts the cooldown on the command"
-msgstr "startet die Abklingzeit auf dem Komanndo neu"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eSetzt die Abklingzeit von {0} für {1}§e, zu {2} Sekunden"
-
-msgid "lists all the active cooldowns"
-msgstr "Zeige alle aktiven Abklingzeiten"
-
-# ???
-msgid "§eCmd Cooldown"
-msgstr "§eCmd Cooldown"
-
-# ???
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eKeine Aktiven abklingzeiten von §9{0}§e gefunden."
-
-msgid "control debugging"
-msgstr "Steuert Fehlerüberprüfung"
-
-msgid "set debug-level"
-msgstr "Setzt Fehlerprüfungs-Level"
-
-# ???
-msgid "toggle debug-logging"
-msgstr "toggle debug-logging"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4Aufzeichnen ist nicht aktiv, deshalb kannst du es nicht ausschalten!"
-
-msgid "flush current content of the logger to file."
-msgstr "Speichert die aktuellen Aufzeichnungen in eine Datei."
-
-msgid "§eLog-file has been flushed."
-msgstr "§eLog-Datei wurde geleert."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4Aufzeichnen ist nicht aktiv, benutze §d/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Ungültiges Agument, versuche: INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eAufzeichnen ausgeschaltet!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "Versucht das Flachland zu reparieren."
-
-msgid "§4No valid island found"
-msgstr "§4Keine gültige Insel gefunden"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4Kein Flachland gefunden an {0}''s Insel!"
-
-msgid "flushes all caches to files"
-msgstr "Leert alle Zwischenspeicher und schreibt es in die Dateien"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-"§e{0} Inseln, §b{1} Spieler und §{2} abgeschlossenen Aufgaben wurden gelöscht"
-
-msgid "manually update the top 10 list"
-msgstr "Aktualisiere manuell die 10 Besten Liste!"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eErstellt die 10 Besten Liste"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eDie 10 Besten Liste wurde erfolgreich erstellt"
-
-msgid "advanced command for getting island-data"
-msgstr "erweitertes Kommando für Insel Infos"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§eDerzeitiger Wert für {0} ist ''{1}''"
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§cKonnte den Status von {0} §cnicht ermitteln"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§eGültige Werte sind: {0}"
-
-msgid "teleport to another players island"
-msgstr "zu einer anderen Insel teleportieren"
-
-msgid "§4Only supported for players"
-msgstr "§4Nur für Spieler unterstützt"
-
-msgid "§4That player does not have an island!"
-msgstr "§4Dieser Spieler besitzt keine Insel!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr "§aTeleportiert dich zu {0}''s Insel."
-
-msgid "imports players and islands from other formats"
-msgstr "Importiere Spieler und Inseln aus anderen Formaten"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Aufgaben Statistiken"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/job"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "act"
-
-msgid "time"
-msgstr "Zeit"
-
-msgid "name"
-msgstr "Name"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "ändert die Sprache des Plugin und läd es neu"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aSprache wurde erfolgreich zu §e{0} §a geändert"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cSprache konnte nicht zu §e{0} geändert werden"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Unterstützte Sprachen:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cKonnte keine Sprachen finden"
-
-msgid "transfer leadership to another player"
-msgstr "Übergib die Führung an einen anderen Spieler"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4Spieler {0} Hat keine Insel zum übertragen!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§eSpieler §d{0}§e hat bereits eine Insel.§eBenutze §d/usb island remove "
-"<name>§e um ihn zuerst zu entfernen."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bFührung übergeben von {0}§b an {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr "Genauere Infos über NBT Tags"
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "zeigt den NBT Tag für das Item in der Hand"
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§eInfo für §9{0}"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - Name: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - NBT Tag: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§cKein Item in der Hand!"
-
-msgid "§eCan only be executed as a player"
-msgstr "§eKann nur als Spieler ausgeführt werden"
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "setzt den NBT Tag auf das Item in der Hand"
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "eSetzt §9{0}§e zu §c{1}"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "fügt den NBT Tag zum Item in der Hand hinzu"
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§9{0}§e zu §c{1} §ehinzugefügt"
-
-msgid "manage orphans"
-msgstr "Handhabe Waise"
-
-msgid "count orphans"
-msgstr "Zähle Waise"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§e{0} Alte Inselstandorte werden genutzt bevor neue erstellt werden."
-
-msgid "clear orphans"
-msgstr "Lösche Waise"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eLösche alle alten (Leeren) Insel Standorte."
-
-msgid "list orphans"
-msgstr "Zeige Waise"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eDerzeit sind keine verwaisten Inseln registriert"
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr "Zusätzliche Fähigkeiten {0}"
-
-msgid "protects all islands (time consuming)"
-msgstr "Schützt alle Inseln (Zeitaufwändig)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§cVersuche den \"Protect-all\" Task zu unterbrechen."
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-"§4Sorry!§e Ein Protect-all läuft bereits. Warte bis es fertig ist oder "
-"breche es mit §9usb protectall §cstop $eab"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§eStarte ALLES-SCHÜTZEN. Das wird jetzt etwas dauern..."
-
-msgid "purges all abandoned islands"
-msgstr "Löscht alle verlassenen Inseln"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4Du musst die Zeit für die Säuberung in Tagen angeben!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr "§4Versuche Purge abzubrechen"
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr "§4Starte Purge"
-
-msgid "region manipulations"
-msgstr "Regions Veränderungen"
-
-msgid "shows the borders of the current island"
-msgstr "zeigt die Grenze dieser Insel"
-
-msgid "§eNo island found at your current location"
-msgstr "§eEs wurde keine Insel an Deiner Position gefunden"
-
-msgid "shows the borders of the current chunk"
-msgstr "zeigt die Grenze des derzeitigen Chunks"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "zeigt die Grenze des inneren Chunks"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "zeigt die Grenzen die sich nicht an Chunks befinden"
-
-msgid "shows the borders of the outer-chunks"
-msgstr "zeigt die Grenzen von den äußeren Chunks"
-
-msgid "hides the regions again"
-msgstr "versteckt die Region wieder"
-
-msgid "§eStopped displaying regions"
-msgstr "§eAnzeigen von Regionen gestoppt"
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§eFür diesen Spieler werden derzeit keine Regionen gezeigt"
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§eAnimation-tick wurde zu {0} §egeändert."
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§eAnimation-tick muss ein gültiger Integer sein."
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "Setze die Insel eines Spielers an deine Position"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "Lade die Einstellungen von einer Datei."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eEInstellungen geladen von der Datei."
-
-msgid "advanced command for setting island-data"
-msgstr "fortgeschrittenes Kommando um Insel Einstellungen festzulegen"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§c{0} wurde zu ''{1}'' §cgesetzt"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§cKonnte Wert {0} nicht zu ''{1}'' §c setzen"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr "§cKonnte Wert {0} nicht zu ''{1}'' §csetzen, da es keine Zahl ist"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§cUngültiger Wert {0}"
-
-msgid "toggles maintenance mode"
-msgstr "schaltet den Wartungsmodus and und aus"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-"§cWARTUNGSMODUS: §aAktiviert§e Alle uSkyBlock Features sind derzeit "
-"deaktiviert."
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-"§cWARTUNGSMODUS: §4Deaktiviert§e Alle uSkyBlock Features funktionieren "
-"wieder normal."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr ""
-"§cDer Wartungsmodus kann nur in der Konsole aktiviert und deaktivert werden"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§cABGEBROCHEN:§e Protect-All wurde unterbrochen!"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr ""
-"§eCompleted wurde in {0} $eabgeschlossen, {1} neue Regionen wurden erstellt!"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§7- DURCHSUCHE: {0,number,##}% ({1}/{2} fehlgeschlagen: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4SÄUBERUNG:§9 Durchsuchen abgebrochen."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4PURGE:§9 Verlassene Inseln wurde entfernt."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4SÄUBERUNG:§9 Das säubern von verlassenen Inseln wurde abgebrochen."
-
-msgid "displays version information"
-msgstr "Zeige Versions Informationen"
-
-msgid "various WorldGuard utilities"
-msgstr "WorldGuard Einstellungen"
-
-msgid "refreshes the chunks around the player"
-msgstr "Aktualisiere die Chunks um den Spieler"
-
-msgid "§eResending chunks to the client"
-msgstr "§eChunks werden erneut zum Client gesendet"
-
-msgid "load the region chunks"
-msgstr "Lade die Regionalen Chunks"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eLade chunks bei {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eEntlade chunks bei {0}"
-
-msgid "update the WG regions"
-msgstr "Update WG Regionen"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§eWorldGuard Regionen wurden für {0} aktualisiert"
-
-msgid "§eNo island found at your location!"
-msgstr "§eEs wurden keine Inseln an deiner Position gefunden!"
-
-msgid "refreshes the chunk around the player"
-msgstr "erneuert den Chunk um den Spieler"
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "Zeige Spieler Informationen"
-
-msgid "try to complete a challenge"
-msgstr "versucht eine Aufgabe abzuschliessen"
-
-msgid "§cCommand only available for players."
-msgstr "§cDieses Kommando ist nur für Spieler verfügbar"
-
-msgid "show information about the challenge"
-msgstr "zeigt Informationen über die Aufgabe"
-
-msgid "§eRank: "
-msgstr "§eRang: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4Diese Aufgabe kannst du nicht wiederholen!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr ""
-"§4Du wirst alle benötigten Gegenstände zerstören wenn du die Aufgabe "
-"beendest."
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4Alle benötigten Items müssen in max {0} Blöcken Abstand von dir auf Deiner "
-"Insel platziert werden"
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§eUm diese Aufgabe abzuschliesse nutze §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4Ungültiger Aufgaben Name! Benutze /c für mehr Informationen."
-
-msgid "complete and list challenges"
-msgstr "vervollständige und zeige Aufgaben an"
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eAufgaben wurden deaktiviert. Wende dich an einen Admin."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4Du kannst nur in der SkyBlock Welt Aufgaben erledigen."
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4Du kannst nur Aufgaben erledigen wenn du eine Insel besitzt."
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4Deine Insel ist voll, oder du hast zu viele laufende Einladungen. Du "
-"kannst keinen mehr einladen."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4Dieser Spieler ist bereits Anführer einer anderen Insel."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr ""
-"§e{0}§e hat versucht dich einzuladen, aber du bist bereits in einer Gruppe."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr "§aEinladung an {0} $agesendet"
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e Hat dich auf seine Insel eingeladen"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr ""
-"§f/island [accept/reject]§e um die Einladung zu bestätigen oder abzulehnen."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4WARNUNG: Du verlierst deine Insel wenn du bestätigst!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d Eingeladen {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e Hat deine Einladung abgelehnt."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4Du kannst diesen Befehl im Moment nicht nutzen. Verlasse zuerst deine "
-"Gruppe."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§aDu bist einer Inselgruppe beigetreten. Benutze /island party um die "
-"anderen Mitglieder zu sehen."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§eDie Einladung für {0}§e wurde abgebrochen oder ist ausgelaufen"
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr ""
-"§eDie Einladung für {0}''s Insel wurde abgebrochen oder ist ausgelaufen."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§eDu hast die Inseleinladung angenommen."
-
-msgid "§4You haven't been invited."
-msgstr "§4Du wurdest nicht eingeladen."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eDu hast die Einladung einer Insel beizutreten abgelehnt."
-
-msgid "accept/reject an invitation."
-msgstr "An/-ablehnen einer Einladung."
-
-msgid "teleports you to your island (or create one)"
-msgstr "teleportiert Dich zu Deiner Insel (oder erstellt eine)"
-
-msgid "ban/unban a player from your island."
-msgstr "Banne/Entbanne Spieler von deiner Insel."
-
-msgid "exempts user from being banned"
-msgstr "schließt Spieler vom gebannt werden aus"
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§eDie folgenden Spieler dürfen sich nicht auf deine insel warpen:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr ""
-"§eUm einen Spieler von deiner Insel zu Bannen/Entbannen nutze: /island ban "
-"<player>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4Du kannst keine Mitglieder bannen. Entferne sie zuerst!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4Du hast nicht die Rechte dazu andere zu kicken/bannen."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§eKonnte den folgenden unbekannten Spieler nicht bannen: {0}"
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4{0} hat Dich versucht von seiner Insel zu bannen."
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4{0} kann nicht gebannt werden."
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr ""
-"§eDu hast §4{0}§e Verbannt. Diese(r) kann sich nicht mehr auf deine Insel "
-"warpen."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eDu wurdest von  {0}§e''s Insel §cGEBANNT§e."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr ""
-"§eDu hast §4{0}§e Entbannt. Diese(r) kann sich wieder auf deine Insel warpen."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eDu wurdest von {0}§e''s Insel §aENTBANNT§e."
-
-msgid "change the biome of the island"
-msgstr "Ändere das Biome der Insel"
-
-msgid "exempt player from biome-cooldown"
-msgstr "dieser Spieler hat kein Biom-Cooldown"
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr "Lässt den Spieler sein Insel Biom zu {0} ändern"
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr ""
-"§cDu verfügst nicht über die Rechte um von deiner aktuellen Insel das Biom "
-"zu ändern."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4Du hast nicht die Rechte um das Biom der Insel zu ändern!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eDu musst auf deiner Insel sein um das Biom zu ändern."
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr "§cDies ist kein gültiger Biomname. Muss eins hiervon sein: {0}"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eDu kannst in {0,number,#} Minuten das Biom wieder ändern."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cDu kannst Dein InselBiom nicht zu diesem Biom ändern."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr "§7Das Biom wird gerade zu §9{0}§7 geändert, hab Geduld."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-"§7Das Biom deiner Insel wird zu §9{0}§7 geändert, habe ein wenig Geduld."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr "§e{0} ist ein ungültiges Biom"
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aDu hast das Inselbiom zu {0} gewechselt"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} Wechselte das Inselbiom zu {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr "§aDu hast {0} Blöcke um dich herum zu {1} Biom geändert"
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr "{0} erstellte ein Gebiet mit {1} Biom"
-
-msgid "create an island"
-msgstr "Erstelle eine Insel"
-
-msgid "exempt player from create-cooldown"
-msgstr "schließt den Spieler vom Insel erstellen Cooldown aus"
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4Insel gefunden!§e Du besitzt bereits eine Insel. Willst du neu starten, "
-"gib§b /is restart§e ein."
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4Insel gefunden!§e Du bist Mitglied auf einr Insel. Um deine eigene zu "
-"starten gib§b /is leave§e ein."
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eDu kannst in {0,number,#} Sekunden eine neue Insel erstellen."
-
-msgid "teleport to the island home"
-msgstr "Teleportiert zum Insel Home"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§cDeine Insel wird gerade erstellt. Du kannst dich jetzt nicht auf sie "
-"teleportieren"
-
-msgid "check your or another''s island info"
-msgstr "Prüfe deine oder die Inseldaten eines anderen Spielers"
-
-msgid "allows user to see others island info"
-msgstr "erlaubt den Spieler Infos von anderen Insel anzugucken"
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4Insel Level wurde deaktiviert, kontaktiere einen Administrator."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eDu musst auf deiner Insel sein um den Befehl nutzen zu können."
-
-msgid "§4You do not have an island!"
-msgstr "§4Du hast keine Insel!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4Du hast keinen Zugriff auf diesen Befehl!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4Dieser Spieler ist ungültig oder hat keine Insel!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBlöcke von {0}s Insel (Seite {1,number} von {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Werte der Blöcke und deren Anzahl"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aDein Insel Level: {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "Läd einen anderen Spieler auf deine Insel ein."
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§eBenutze§f /island invite <playername>§eUm einen Spieler auf deine Insel "
-"einzuladen."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4Nur der Inselbesitzer kann andere einladen!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aDu kannst noch {0} Spieler einladen."
-
-msgid "§4You can't invite any more players."
-msgstr "§4Du kannst keine weiteren Spieler einladen."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4Du hast keine Rechte andere auf deine Insel einzuladen!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4Dieser Spieler ist entweder offline oder existiert nicht."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4Du kannst dich nicht selber einladen!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4Dieser Spieler ist der Anfüher auf deiner Insel!"
-
-msgid "remove a member from your island."
-msgstr "Entferne einen Spieler von deiner Insel."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4Du hast nicht die Rechte um andere Spieler von der Insel zu werfen!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4Du kannst den Anführer der Insel nicht entfernen!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4Hör auf dich selber raus zu werfen!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0} hat Dich von seiner Insel entfernt"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} wurde von der Insel entfernt."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0} hat versucht Dich von seiner Insel zu werfen."
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4{0} kann nicht rausgeworfen werden."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4{0} hat Dich von seiner Insel geworfen"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0} wurde von der Insel geschmissen."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr ""
-"§4Dieser Spieler ist nicht in deiner Inselgruppe und nicht auf deiner Insel!"
-
-msgid "leave your party"
-msgstr "Verlasse deine Gruppe"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4Du kannst deine Insel nicht verlassen wenn du die einzige Person auf der "
-"Insel bist. Versuche /island restart falls du eine neue Insel möchtest."
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§eDir gehört die Insel, benutze anstelle /island remove <player>."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eDu hast die Insel verlassen und kommst zurück zum Spieler Spawn."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0} Hat deine Insel verlassen."
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4Du musst in der SkyBlock Welt sein um die Gruppe zu verlassen!"
-
-msgid "check your or anothers island level"
-msgstr "Zeige die Stufe deiner oder einer anderen Insel"
-
-msgid "allows user to query for others levels"
-msgstr ""
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eInformationen über {0}''s Insel"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9Stufe ist {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "Sperrt deine Insel für nicht Mitglieder."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4Du hast nicht die Rechte um die Insel zu sperren!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4Du darfst diesen Befehl nicht ausführen!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4Du hast nicht die Rechte um die Insel zu entsperren!"
-
-msgid "display log"
-msgstr "Log anzeigen"
-
-msgid "transfer leadership to another member"
-msgstr "Übertrage die Führerrolle zu einem anderen Spieler"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4Du kannst die Führerschaft nur auf Gruppenmitglieder übertragen!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e ist bereits der Anführer der Insel!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4Nur Anführer können die Führerschaft übertragen!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} hat versucht die Insel zu übernehmen!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "Zeige Gruppen Information"
-
-msgid "shows information about your party"
-msgstr "Zeigt Informationen über deine Gruppe"
-
-msgid "show pending invites"
-msgstr "Zeige ausstehende Einladungen"
-
-msgid "§eNo pending invites"
-msgstr "§eKeine ausstehenden Einladungen"
-
-msgid "withdraw an invite"
-msgstr "Ziehe eine Einladung zurück"
-
-# ???
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4Du hast keine Rechte um Insel Mitglieder zu entfernen"
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4Dieser Befehl kann nur von Spielern ausgeführt werden"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4Keine Insel. §eBenutze §b/is create§e um eine zu starten"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "Löscht deine Insel und startet eine neue."
-
-msgid "exempt player from restart-cooldown"
-msgstr ""
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4Nur der Besitzer kann die Insel neustarten. Um deine eigene Starten zu "
-"können verlasse die Insel mit (/island leave)"
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eDu musst zuerst alle Spieler mit (/island kick <player>) von der Insel "
-"entfernen. Nutze (/island party) um zu sehen welche Spieler zu deine Insel "
-"gehören."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§cDu kanst Deine Insel in {0} Sekunden neustarten."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr ""
-"§cDeine Insel wird gerade erstellt. Du kannst sie jetzt nicht neustarten"
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgid "§cWither Despawned!§e It wandered too far from your island."
 msgstr ""
-"§eHINWEIS: Deine komplette Insel und alle Errungenschaften werden "
-"zurückgesetzt!"
+"§cDer Wither ist despawned! §eEr hat sich zu weit von Deiner Insel entfernt."
 
-msgid "set the island-home"
-msgstr "Setze dein Home"
-
-msgid "set your island''s warp location"
-msgstr "Setze dein Insel Warp Punkt."
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cDu hast keine Rechte um einen Insel Warppunkt zu setzen!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§cDu musst auf deiner eigenen Insel sein um den Warppunkt zu setzen!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d hat die Position des Warppunktes geändert."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "Teleportiert dich zum SkyBlock Spawn"
-
-msgid "enable/disable warping to your island."
-msgstr "Aktiviere/Deaktiviere Warping zu deiner Insel."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4Deine Insel ist gesperrt. Du musst sie entsperren um das warpen freizu "
-"schalten."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d hat den Insel Warp aktiviert"
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d hat den Insel Warp deaktiviert."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr ""
-
-msgid "display the top10 of islands"
-msgstr "Zeige die top 10 Inseln"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr ""
-
-msgid "trust/untrust a player to help on your island."
-msgstr "Vertraue/Mistraue einen Spieler auf deiner Insel."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eDu vertraust den folgenden Spielern auf deiner Insel:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eDie folgenden Besitzer trauen dir:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr ""
-"§eUm einen Spieler zu Vertrauen/Mistrauen gib : „/island trust <player>“ ein."
-
-msgid "§4Members are already trusted!"
-msgstr "§4Mitgliedern wird bereits vertraut!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Unbekanter Spieler {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eDu darfst nun auf §4{0}''s §eInsel bauen"
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} hat {1} erlaubt auf seiner Insel zu bauen"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eDu kannst nun nicht mehr auf  §4{0}''s §eInsel bauen."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0} hat die Baurechte von {1} auf der Insel entzogen"
-
-msgid "warp to another player''s island"
-msgstr "Warpt dich auf die Insel eines anderen Spielers"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr "§aDein Warp ist aktiv, Spieler können sich zu Deiner Insel warpen."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§aDein Warp ist inaktiv, Spieler können sich nicht zu Deiner Insel warpen."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr ""
-"§fSetze den Warp für die ankommenden Spieler mit §e/island setwarp §fan "
-"deine aktuelle Position."
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§fSchalte deinen Warp ein/aus mit  §e/island togglewarp§f."
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr ""
-"§4Du verfügst nicht über die Rechte einen Warp auf deiner Insel zu erstellen!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr ""
-"§fUm dich auf die Insel eines anderen Spielers zu Warpen nutze §e/island "
-"warp <player>§f."
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4Du hast keine Rechte um die auf andere Inseln zu Warpen!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§cDeine Insel wird gerade erstellt. Du kannst dich noch nicht zu ihr warpen."
-
-msgid "§4That player does not exist!"
-msgstr "§4Dieser Spieler existiert nicht!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4Dieser Spieler besitzt keinen aktiven Warp."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§cDiese Insel wird gerade erstellt. Du kannst dich noch nicht dorthin warpen"
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cACHTUNG: §9{0}§e warpt sich zu deiner Insel!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4Dieser Spieler hat dir Verboten sich auf seine Insel zu Warpen."
-
-msgid "general island command"
-msgstr "Allgemeine Insel Befehle"
-
-msgid "allows user to bypass cooldowns"
-msgstr ""
-
-msgid "allows user to bypass visitor-protections"
-msgstr ""
-
-msgid "allows user to bypass teleport-delay"
-msgstr ""
-
-msgid "allows user to use [usb] signs"
-msgstr ""
-
-msgid "allows user to place [usb] signs"
-msgstr ""
+msgid "{0}''s Wither"
+msgstr "{0}''s Wither"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr ""
@@ -1761,34 +106,6 @@ msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr ""
-"§cDer Wither ist despawned! §eEr hat sich zu weit von Deiner Insel entfernt."
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "{0}''s Wither"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eBesucher können keine Items droppen"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Besitzer: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "Du kannst keine Items auf fremden Inseln aufheben"
-
-msgid "Config:"
-msgstr "Config:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§cKein Zugang! §eDu versuchst dich auf das Dach des §cNETHER§e zu "
-"teleportieren. Dies ist nicht erlaubt."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr "§4Du kannst Obsidian nur alle 10 Sekunden konvertieren"
@@ -1833,19 +150,87 @@ msgstr "§eDu kannst Spawn-Eier nur auf Deiner eigenen Insel nutzen"
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§cDas Spawnlimit für Deine Insel wurde erreicht"
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eBesucher können keine Items droppen"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Besitzer: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "Du kannst keine Items auf fremden Inseln aufheben"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§eGebannt: §eDu bist von dieser Insel gebannt"
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cAbgeschloßen:§e Diese Insel ist geschlossen, kein Eintritt möglich"
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eWartet auf deine Eingabe §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "Etwas ist Schiefgelaufen beim speichern der Insel/Spieler Daten...!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr ""
+"Die Daten werden in das UUID Format konvertiert. Dies kann lange dauern!"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§cWARTUNGSMODUS:§e uSkyBlock ist derzeit im Wartungsmodus"
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Erstelle Insel...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"§buSkyBlock§e braucht §9{0}§e >= §av{1}§e aber nur §cv{2}§e wurde gefunden!\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e braucht §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§eDu hast keinen Zugriff auf diese Insel Schematic"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4Dieser Spieler gehört bereits zu deiner Insel!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr ""
+"§4Du musst Dich näher an Deiner Insel befinden, um dein SkyBlock Home zu "
+"setzen!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aDein SkyBlock Home wurde an Deine aktuelle Position gesetzt."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4Deine jetztige Home-Position ist nicht sicher"
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+"§7Das Biom deiner Insel wird zu §9{0}§7 geändert, habe ein wenig Geduld."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr "§cDeine Insel wird gerade generiert. Du kannst keine neue erstellen"
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr ""
+"Deine Insel konnte nicht erschaffen werden. Bitte kontaktiere einen Admin/"
+"Moderator"
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr "§eDeine Insel wird erstellt. Habe einen Moment Geduld"
+
+msgid "§cCommand is currently disabled!"
+msgstr "§cDieses Kommando ist derzeit deaktiviert!"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eDir fehlen: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1859,9 +244,6 @@ msgid ""
 msgstr ""
 "§9{0}§e ist §cGefährlich§e. Wiederhole den Befehl innerhalb von §a{1}§e "
 "Sekunden zum bestätigen!"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** Du hast eine geschütze aber verlassenen Insel betreten"
@@ -1896,216 +278,36 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4Du musst der Gruppenleiter sein um deine Insel zu entsperren!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§7PlayerDB: Filtert {0}  Spieler von uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eWartet auf deine Eingabe §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Erstelle Insel...§e{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lGesperrte Aufgabe."
+
+msgid "READY"
+msgstr "BEREIT"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§7PlayerDB: Filterte {0} names"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, Fehlgeschlagen:{3} ~ "
-"{5,number,##}%), {6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§7MojangAPI: Versuche {0} Spieler von Mojang abzufragen"
-
-msgid "SUCCESS"
-msgstr "ERFOLGREICH"
-
-msgid "FAILED"
-msgstr "FEHLGESCHLAGEN"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§7 - MojangAPI:§aABGESCHLOSSEN: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§7 - MojangAPI:§cFEHLER: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-"§eFortschritt: {0,number,##}% ({1}/{2} - Erfolgreich:{3}, Fehlgeschlagen:"
-"{4}, Übersprungen:{5}) ~ {6}"
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4Kein import mit dem Namen §e{0}§4 gefunden"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§eKonvertierte {0}/{1} Dateien in {2}"
-
-msgid "The island has been created."
-msgstr "Die Insel wurde erstellt"
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d hat die Insel gesperrt."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§4Seit deine Insel gesperrt ist, ist dein Warp deaktiviert."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d hat die Insel entsperrt"
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cSKY §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d wurde von der Insel Gruppe entfernt."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9Erstellt eine Insel an deiner Position"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9Erstelle eine Insel §7{0}§9 von dir"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§4Die Aufgabe {0} ist noch nicht verfügbar!"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
-"§cDie Insel die dieses Teil des Nether gehört wird gelöscht. Du wirst zum "
-"Spawn gesendet"
+"§cWARNUNG§e Es konnten nicht alle benötigten Gegenstände in dein Inventar "
+"gelegt werden!"
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgid "§cNot enough items in chest to complete challenge!"
 msgstr ""
-"§cDie Insel auf der Du warst wurde gelöscht! Du wirst zum Spawn teleportiert."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eRangliste der Inseln sortiert nach Insel Leveln (Seite {0} von {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr ""
-"§4Die Top 10 Liste ist leer! Nur Inseln über Level {0} werden berücksichtigt."
-
-# ???
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eDeine Stufe ist: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "Unbekannt"
-
-msgid "ANIMAL"
-msgstr "Tier"
-
-msgid "MONSTER"
-msgstr "Monster"
-
-msgid "VILLAGER"
-msgstr "Dorfbewohner"
-
-msgid "GOLEM"
-msgstr "Golem"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (max. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "Konnt das Schematic {0} nicht finden. Kontaktiere einen Admin"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aGlückwunsch! §eDeine Insel wurde erstellt"
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "Bitte Warten"
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Nutze §9/is h§r oder das §9/is§r Menü um dort hinzugelangen"
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§cWatchdog!§9 Konnte die Chest in {0} nicht finden."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7Seite {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr ""
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr "&cRechtsklick:&7 Setze auf {0}"
-
-msgid "Return"
-msgstr "Zurückkehren"
-
-msgid "§9Integer Editor"
-msgstr "§9Integer Editor"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eKonfiguration wurde gespeichert und neu geladen"
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cFehler! §9Config Datei konnte nicht gespeichert werden"
-
-msgid "§3First Page"
-msgstr "§3Erste Seite"
-
-msgid "§3Last Page"
-msgstr "§3Letzte Seite"
-
-msgid "§cSave & Reload config"
-msgstr "§cConfig speichern und neu laden"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Sepeichert die Config\n"
-"§7Datei und läd sie neu.\n"
-"§cAchtung: §7Sei vorsichtig!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (nur lesbar)"
+"§cEs befinden sich nicht gneug Gegenstände in der Kiste um die Aufgabe "
+"abzuschliessen!"
 
 msgid "true"
 msgstr "true"
@@ -2528,6 +730,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "§7Derzeitige Seite"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7Seite {0}"
+
 msgid "§7First Page"
 msgstr "§7Erste Seite"
 
@@ -2825,8 +1031,8 @@ msgstr "§cKlicke um zu verlassen"
 msgid "Island Restart Menu"
 msgstr "Insel Neustart Menü"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§eDu hast keinen Zugriff auf diese Insel Schematic"
+msgid "Config:"
+msgstr "Config:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2844,121 +1050,122 @@ msgstr ""
 msgid "§aClick to restart!"
 msgstr "§aKlicke zum neustarten!"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr ""
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr "&cRechtsklick:&7 Setze auf {0}"
+
+msgid "Return"
+msgstr "Zurückkehren"
+
+msgid "§9Integer Editor"
+msgstr "§9Integer Editor"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9Text Editor"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eKonfiguration wurde gespeichert und neu geladen"
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cFehler! §9Config Datei konnte nicht gespeichert werden"
+
+msgid "§3First Page"
+msgstr "§3Erste Seite"
+
+msgid "§3Last Page"
+msgstr "§3Letzte Seite"
+
+msgid "§cSave & Reload config"
+msgstr "§cConfig speichern und neu laden"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Sepeichert die Config\n"
+"§7Datei und läd sie neu.\n"
+"§cAchtung: §7Sei vorsichtig!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (nur lesbar)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+"§eFortschritt: {0,number,##}% ({1}/{2} - Erfolgreich:{3}, Fehlgeschlagen:"
+"{4}, Übersprungen:{5}) ~ {6}"
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4Kein import mit dem Namen §e{0}§4 gefunden"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§eKonvertierte {0}/{1} Dateien in {2}"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§7PlayerDB: Filtert {0}  Spieler von uuid2name.yml"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§7PlayerDB: Filterte {0} names"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, Fehlgeschlagen:{3} ~ "
+"{5,number,##}%), {6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§7MojangAPI: Versuche {0} Spieler von Mojang abzufragen"
+
+msgid "SUCCESS"
+msgstr "ERFOLGREICH"
+
+msgid "FAILED"
+msgstr "FEHLGESCHLAGEN"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§7 - MojangAPI:§aABGESCHLOSSEN: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§7 - MojangAPI:§cFEHLER: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "Zu viele Anfragen an die Mojang API ({0} innerhalb von {1}), warte {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§eDu wirst zum Spawn gesendet"
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§eDie Insel wurde §cGESPERRT§e."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aDu wirst in {0} Sekunden Teleportiert."
-
-msgid "§7Teleport cancelled"
-msgstr "§7Teleport abgebrochen"
-
-msgid "READY"
-msgstr "BEREIT"
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-"§cWARNUNG§e Es konnten nicht alle benötigten Gegenstände in dein Inventar "
-"gelegt werden!"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr ""
-"§cEs befinden sich nicht gneug Gegenstände in der Kiste um die Aufgabe "
-"abzuschliessen!"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Etwas ist Schiefgelaufen beim speichern der Insel/Spieler Daten...!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr ""
-"Die Daten werden in das UUID Format konvertiert. Dies kann lange dauern!"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§cWARTUNGSMODUS:§e uSkyBlock ist derzeit im Wartungsmodus"
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"§buSkyBlock§e braucht §9{0}§e >= §av{1}§e aber nur §cv{2}§e wurde gefunden!\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e braucht §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4Dieser Spieler gehört bereits zu deiner Insel!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4Es konnte kein sicherer Ort für dein Home gefunden werden!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§cWARNUNG: §eDu wirst in die Luft geportet."
-
-msgid "§aTeleporting you to your island."
-msgstr "§aDu wirst zu Deiner Insel teleportiert."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Es ist nicht möglich Dich zu der Insel von dem Spieler zu Warpen!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aDu wirst zu {0}''s Insel teleportiert."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr ""
-"§4Du musst Dich näher an Deiner Insel befinden, um dein SkyBlock Home zu "
-"setzen!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aDein SkyBlock Home wurde an Deine aktuelle Position gesetzt."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4Deine jetztige Home-Position ist nicht sicher"
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cDeine Insel wird gerade generiert. Du kannst keine neue erstellen"
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr ""
-"Deine Insel konnte nicht erschaffen werden. Bitte kontaktiere einen Admin/"
-"Moderator"
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr "§eDeine Insel wird erstellt. Habe einen Moment Geduld"
-
-msgid "§cCommand is currently disabled!"
-msgstr "§cDieses Kommando ist derzeit deaktiviert!"
 
 msgid "North"
 msgstr "Norden"
@@ -2983,3 +1190,1792 @@ msgstr "Westen"
 
 msgid "North-West"
 msgstr "Nord-Westen"
+
+msgid "The island has been created."
+msgstr "Die Insel wurde erstellt"
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d hat die Insel gesperrt."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§4Seit deine Insel gesperrt ist, ist dein Warp deaktiviert."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d hat den Insel Warp deaktiviert."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d hat die Insel entsperrt"
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cSKY §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d wurde von der Insel Gruppe entfernt."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9Erstellt eine Insel an deiner Position"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9Erstelle eine Insel §7{0}§9 von dir"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aGlückwunsch! §eDeine Insel wurde erstellt"
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "Bitte Warten"
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Nutze §9/is h§r oder das §9/is§r Menü um dort hinzugelangen"
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "Konnt das Schematic {0} nicht finden. Kontaktiere einen Admin"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§cWatchdog!§9 Konnte die Chest in {0} nicht finden."
+
+msgid "UNKNOWN"
+msgstr "Unbekannt"
+
+msgid "ANIMAL"
+msgstr "Tier"
+
+msgid "MONSTER"
+msgstr "Monster"
+
+msgid "VILLAGER"
+msgstr "Dorfbewohner"
+
+msgid "GOLEM"
+msgstr "Golem"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (max. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§cDie Insel die dieses Teil des Nether gehört wird gelöscht. Du wirst zum "
+"Spawn gesendet"
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr ""
+"§cDie Insel auf der Du warst wurde gelöscht! Du wirst zum Spawn teleportiert."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eRangliste der Inseln sortiert nach Insel Leveln (Seite {0} von {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr ""
+"§4Die Top 10 Liste ist leer! Nur Inseln über Level {0} werden berücksichtigt."
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4Insel Level wurde deaktiviert, kontaktiere einen Administrator."
+
+# ???
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eDeine Stufe ist: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "§7Schliesse {0} mehr {1} §7Aufgaben ab"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Schliesse {0} ab"
+
+msgid "to unlock this rank"
+msgstr "um diesen Rang freizuschalten"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Anforderungen werden in {0} Tagen zurückgesetzt."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Anforderungen werden in {0} Stunden zurückgesetzt."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4Anforderungen werden in {0} Minuten zurückgesetzt."
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr "§eDiese Aufgabe erfordert:"
+
+msgid "§7and more..."
+msgstr "§7und mehr..."
+
+msgid "§eItems will be traded for reward."
+msgstr "§eItems werden gegen die Belohnung eingetauscht."
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr "§eMuss innerhalb von {0} Meter befinden."
+
+msgid "§6Item Reward: §a"
+msgstr "§6Gegenstandsbelohnung: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Währungsbelohnung: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Erfahrungsbelohnung: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dSchon §f{0} §dmal abgeschlossen."
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr "§7Erfordert {0}"
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4Keine Aufgabe namens {0} gefunden."
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4Du musst auf deiner Insel sein um das zu tun!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4Diese {0} Aufgabe kannst du nicht Wiederholen!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§eVersuche die §a{0} §eAufgabe abzuschliessen"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr ""
+"§4Du musst in {0} Blöcke Abstand von den benötigten Gegenständen stehen."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4Deine Insel muss Stufe {0} haben um die Aufgabe zu beenden!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Unbekannte Aufgabe: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr "§eDir fehlen: {0}"
+
+# ???
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eDir fehlen:{0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aDu hast die {0} Aufgabe beendet!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9{0}§f hat die §9{1}§f Aufgabe abgeschlossen!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§eGegenstandsbelohnung: §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eErfahrungsbelohnung: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eWährungsbelohnung: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eDein Inventar ist §4voll§e. Die Gegenstände fallen auf den Boden!"
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lKlick hier um die Aufgabe zu beenden!"
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lDu kannst diese Aufgabe nicht wiederholen!"
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Rang: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fBeende die meisten Aufgaben in"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fdiesem Rang, um den nächsten Rang freizuschalten."
+
+msgid "§eClick here to show previous page"
+msgstr "§eKlick hier um zur vorherigen Seite zu gelangen."
+
+msgid "§eClick here to show next page"
+msgstr "§eKlick hier um zur nächsten Seite zu gelangen."
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "Du bist ALLLLLEEEEEEIIIIINE!"
+
+msgid "But you are Yelling in the wind!"
+msgstr "But you are Yelling in the wind!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "Deine Fantasiefreunde sind weg!"
+
+msgid "But you are Talking to your self!"
+msgstr "Du sprichst mit dir selber...!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cTschuldigung! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr "Sende eine Nachricht an deine Gruppe oder schalte es an oder aus."
+
+msgid "party"
+msgstr "Party"
+
+msgid "island"
+msgstr "Insel"
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§cSchaltet den Chat zu {0} §aON"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§cWiederhole §9{0}§c um es auzuschalten"
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§aSchalte den Chat für {0} §cAUS"
+
+msgid "§cCommand only available to players"
+msgstr "§cKommando nur für Spieler verfügbar"
+
+msgid "talk to your island party"
+msgstr "redet mit deinen Insel Mitgliedern"
+
+msgid "talk to players on your island"
+msgstr "rede zu Spielern auf deiner Insel"
+
+msgid "manually update the top 10 list"
+msgstr "Aktualisiere manuell die 10 Besten Liste!"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eErstellt die 10 Besten Liste"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eDie 10 Besten Liste wurde erfolgreich erstellt"
+
+msgid "purges all abandoned islands"
+msgstr "Löscht alle verlassenen Inseln"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4Du musst die Zeit für die Säuberung in Tagen angeben!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr "§4Versuche Purge abzubrechen"
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr "§4Starte Purge"
+
+msgid "Controls player-cooldowns"
+msgstr "Kontrolliert Spieler-Abklingzeiten"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "Löscht die Abklingzeit von einem Befehl (* = alle)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eDer Spieler ist nicht online."
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Abklingzeit von {0} für {1} gelöscht."
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Keine aktive Abklingzeit bei {0} für {1} gefunden!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Ungültiger Befehl! Nur Neustart und Biome werden unterstützt!"
+
+msgid "restarts the cooldown on the command"
+msgstr "startet die Abklingzeit auf dem Komanndo neu"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eSetzt die Abklingzeit von {0} für {1}§e, zu {2} Sekunden"
+
+msgid "lists all the active cooldowns"
+msgstr "Zeige alle aktiven Abklingzeiten"
+
+# ???
+msgid "§eCmd Cooldown"
+msgstr "§eCmd Cooldown"
+
+# ???
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eKeine Aktiven abklingzeiten von §9{0}§e gefunden."
+
+msgid "toggles maintenance mode"
+msgstr "schaltet den Wartungsmodus and und aus"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+"§cWARTUNGSMODUS: §aAktiviert§e Alle uSkyBlock Features sind derzeit "
+"deaktiviert."
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+"§cWARTUNGSMODUS: §4Deaktiviert§e Alle uSkyBlock Features funktionieren "
+"wieder normal."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr ""
+"§cDer Wartungsmodus kann nur in der Konsole aktiviert und deaktivert werden"
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Aufgaben Statistiken"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/job"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "act"
+
+msgid "time"
+msgstr "Zeit"
+
+msgid "name"
+msgstr "Name"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§eSpieler {0} hat keine Insel!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eUngültiger Spieler {0} angegeben!"
+
+msgid "flushes all caches to files"
+msgstr "Leert alle Zwischenspeicher und schreibt es in die Dateien"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+"§e{0} Inseln, §b{1} Spieler und §{2} abgeschlossenen Aufgaben wurden gelöscht"
+
+msgid "tries to fix the the area of flatland."
+msgstr "Versucht das Flachland zu reparieren."
+
+msgid "§4No valid island found"
+msgstr "§4Keine gültige Insel gefunden"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4Kein Flachland gefunden an {0}''s Insel!"
+
+msgid "manage orphans"
+msgstr "Handhabe Waise"
+
+msgid "count orphans"
+msgstr "Zähle Waise"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§e{0} Alte Inselstandorte werden genutzt bevor neue erstellt werden."
+
+msgid "clear orphans"
+msgstr "Lösche Waise"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eLösche alle alten (Leeren) Insel Standorte."
+
+msgid "list orphans"
+msgstr "Zeige Waise"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eDerzeit sind keine verwaisten Inseln registriert"
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "Übergib die Führung an einen anderen Spieler"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4Spieler {0} Hat keine Insel zum übertragen!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eSpieler §d{0}§e hat bereits eine Insel.§eBenutze §d/usb island remove "
+"<name>§e um ihn zuerst zu entfernen."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bFührung übergeben von {0}§b an {1}"
+
+msgid "open GUI for config"
+msgstr "Öffne Konfigurations Menü"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§eUngültiger Konfigurationsname"
+
+msgid "teleport to another players island"
+msgstr "zu einer anderen Insel teleportieren"
+
+msgid "§4Only supported for players"
+msgstr "§4Nur für Spieler unterstützt"
+
+msgid "§4That player does not have an island!"
+msgstr "§4Dieser Spieler besitzt keine Insel!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr "§aTeleportiert dich zu {0}''s Insel."
+
+msgid "various WorldGuard utilities"
+msgstr "WorldGuard Einstellungen"
+
+msgid "refreshes the chunks around the player"
+msgstr "Aktualisiere die Chunks um den Spieler"
+
+msgid "§eResending chunks to the client"
+msgstr "§eChunks werden erneut zum Client gesendet"
+
+msgid "load the region chunks"
+msgstr "Lade die Regionalen Chunks"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eLade chunks bei {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eEntlade chunks bei {0}"
+
+msgid "update the WG regions"
+msgstr "Update WG Regionen"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§eWorldGuard Regionen wurden für {0} aktualisiert"
+
+msgid "§eNo island found at your location!"
+msgstr "§eEs wurden keine Inseln an deiner Position gefunden!"
+
+msgid "refreshes the chunk around the player"
+msgstr "erneuert den Chunk um den Spieler"
+
+msgid "region manipulations"
+msgstr "Regions Veränderungen"
+
+msgid "shows the borders of the current island"
+msgstr "zeigt die Grenze dieser Insel"
+
+msgid "§eNo island found at your current location"
+msgstr "§eEs wurde keine Insel an Deiner Position gefunden"
+
+msgid "§eCan only be executed as a player"
+msgstr "§eKann nur als Spieler ausgeführt werden"
+
+msgid "shows the borders of the current chunk"
+msgstr "zeigt die Grenze des derzeitigen Chunks"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "zeigt die Grenze des inneren Chunks"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "zeigt die Grenzen die sich nicht an Chunks befinden"
+
+msgid "shows the borders of the outer-chunks"
+msgstr "zeigt die Grenzen von den äußeren Chunks"
+
+msgid "hides the regions again"
+msgstr "versteckt die Region wieder"
+
+msgid "§eStopped displaying regions"
+msgstr "§eAnzeigen von Regionen gestoppt"
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§eFür diesen Spieler werden derzeit keine Regionen gezeigt"
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§eAnimation-tick wurde zu {0} §egeändert."
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§eAnimation-tick muss ein gültiger Integer sein."
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4PURGE:§9 Verlassene Inseln wurde entfernt."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4SÄUBERUNG:§9 Das säubern von verlassenen Inseln wurde abgebrochen."
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§7- DURCHSUCHE: {0,number,##}% ({1}/{2} fehlgeschlagen: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4SÄUBERUNG:§9 Durchsuchen abgebrochen."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§cABGEBROCHEN:§e Protect-All wurde unterbrochen!"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr ""
+"§eCompleted wurde in {0} $eabgeschlossen, {1} neue Regionen wurden erstellt!"
+
+msgid "control debugging"
+msgstr "Steuert Fehlerüberprüfung"
+
+msgid "set debug-level"
+msgstr "Setzt Fehlerprüfungs-Level"
+
+# ???
+msgid "toggle debug-logging"
+msgstr "toggle debug-logging"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4Aufzeichnen ist nicht aktiv, deshalb kannst du es nicht ausschalten!"
+
+msgid "flush current content of the logger to file."
+msgstr "Speichert die aktuellen Aufzeichnungen in eine Datei."
+
+msgid "§eLog-file has been flushed."
+msgstr "§eLog-Datei wurde geleert."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4Aufzeichnen ist nicht aktiv, benutze §d/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Ungültiges Agument, versuche: INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eAufzeichnen ausgeschaltet!"
+
+msgid "advanced command for setting island-data"
+msgstr "fortgeschrittenes Kommando um Insel Einstellungen festzulegen"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§c{0} wurde zu ''{1}'' §cgesetzt"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§cKonnte Wert {0} nicht zu ''{1}'' §c setzen"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr "§cKonnte Wert {0} nicht zu ''{1}'' §csetzen, da es keine Zahl ist"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§cUngültiger Wert {0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§eDerzeitiger Wert für {0} ist ''{1}''"
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§cKonnte den Status von {0} §cnicht ermitteln"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§eGültige Werte sind: {0}"
+
+msgid "set a player''s island to your location"
+msgstr "Setze die Insel eines Spielers an deine Position"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr "Genauere Infos über NBT Tags"
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "zeigt den NBT Tag für das Item in der Hand"
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§eInfo für §9{0}"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - Name: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - NBT Tag: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§cKein Item in der Hand!"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "setzt den NBT Tag auf das Item in der Hand"
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "eSetzt §9{0}§e zu §c{1}"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "fügt den NBT Tag zum Item in der Hand hinzu"
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§9{0}§e zu §c{1} §ehinzugefügt"
+
+msgid "Manage challenges for a player"
+msgstr "Verwalte die Aufgaben für einen Spieler."
+
+msgid "resets the challenge for the player"
+msgstr "Setzt die Aufgaben für einen Spieler zurück."
+
+msgid "§4Challenge has never been completed"
+msgstr "§4Aufgabe wurde noch nicht beendet."
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§eAufgabe: {0} wurde für {1} zurückgesetzt."
+
+msgid "resets all challenges for the player"
+msgstr "Setzt alle Aufgaben für den Spieler zurück!"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0} hat alle Aufgaben zurücksetzen lassen."
+
+msgid "complete all challenges in the rank"
+msgstr "schliesst alle Aufgaben auf dem Rang ab"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4Kein Spieler mit dem Namen {0} wurde gefunden!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4Aufgabe {0} wurde schon abgeschlossen"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§eAufgabe {0} wurde schon {1} abgeschlossen"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4Keine Aufgabe mit dem Namen {0} wurde gefunden!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4Kein Rang namens {0} wurde gefunden"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "Schützt alle Inseln (Zeitaufwändig)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§cVersuche den \"Protect-all\" Task zu unterbrechen."
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4Sorry!§e Ein Protect-all läuft bereits. Warte bis es fertig ist oder "
+"breche es mit §9usb protectall §cstop $eab"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§eStarte ALLES-SCHÜTZEN. Das wird jetzt etwas dauern..."
+
+msgid "reload configuration from file."
+msgstr "Lade die Einstellungen von einer Datei."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eEInstellungen geladen von der Datei."
+
+msgid "manage islands"
+msgstr "Bearbeite die Inseln"
+
+msgid "protects the island"
+msgstr "Sichert die Insel"
+
+msgid "delete the island (removes the blocks)"
+msgstr "Löscht die Insel (Entfernt auch die Blöcke)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Löscht verlassene Insel an deiner aktuellen Position"
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4Die Insel an ihrem Standort hat Mitglieder!\n"
+"§eBenutze §9/usb island delete <name>§e um die Insel zu löschen."
+
+msgid "removes the player from the island"
+msgstr "Entfernt den Spieler von der Insel."
+
+msgid "adds the player to the island"
+msgstr "fügt den Spieler zur Insel hinzu"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d ist deiner Inselgruppe beigetreten."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4Kein Spieler namens {0} gefunden"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr "§4Keine gültige Insel angegeben. Stehe auf einer oder gib eine an."
+
+msgid "print out info about the island"
+msgstr "Zeige Informationen zu der Insel."
+
+msgid "sets the biome of the island"
+msgstr "Setzt das Biome einer Insel"
+
+msgid "§4That player has no island."
+msgstr "§4Dieser Spieler hat keine Insel."
+
+msgid "§4No valid island at your location"
+msgstr "§4Keine gültige Insel an deiner Position."
+
+msgid "purges the island"
+msgstr "löscht die Insel"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4Fehler! §9Keine gültige Insel zum löschen gefunden"
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cPURGE: §9Lösche Insel bei {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "ändert den Insel Ignorier Status"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cIgnoriert {0}s Insel auf der Top 10 Liste und löscht sie"
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr "§c{0}s Insel wird nun nicht länger ignoriert."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Kein Gültiger Spielername angegeben."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Entferne {0} von der Insel."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eJetzige Biome {0} der Insel, zu {1} gewechselt."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eBiome von {0} zu OZEAN gewechselt."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr ""
+"§aDu musst eventuell zum Spawn gehen oder dich neu einloggen um die "
+"Änderungen zu sehen."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} Hat ihr Biom geändert zu {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} Hat ihr Biom geändert zu OZEAN."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eEntferne {0}''s Insel."
+
+msgid "Error: That player does not have an island!"
+msgstr "Fehler: Dieser Spieler hat keine Insel!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§e{0}s Insel bei {1} ist nun geschützt"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4{0}s Insel bei {1} war schon geschützt"
+
+msgid "displays version information"
+msgstr "Zeige Versions Informationen"
+
+msgid "imports players and islands from other formats"
+msgstr "Importiere Spieler und Inseln aus anderen Formaten"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr "Zusätzliche Fähigkeiten {0}"
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "ändert die Sprache des Plugin und läd es neu"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aSprache wurde erfolgreich zu §e{0} §a geändert"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cSprache konnte nicht zu §e{0} geändert werden"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Unterstützte Sprachen:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cKonnte keine Sprachen finden"
+
+msgid "advanced command for getting island-data"
+msgstr "erweitertes Kommando für Insel Infos"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "Zeige Spieler Informationen"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4Deine Insel ist voll, oder du hast zu viele laufende Einladungen. Du "
+"kannst keinen mehr einladen."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4Dieser Spieler ist bereits Anführer einer anderen Insel."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr ""
+"§e{0}§e hat versucht dich einzuladen, aber du bist bereits in einer Gruppe."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr "§aEinladung an {0} $agesendet"
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e Hat dich auf seine Insel eingeladen"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr ""
+"§f/island [accept/reject]§e um die Einladung zu bestätigen oder abzulehnen."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4WARNUNG: Du verlierst deine Insel wenn du bestätigst!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d Eingeladen {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e Hat deine Einladung abgelehnt."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4Du kannst diesen Befehl im Moment nicht nutzen. Verlasse zuerst deine "
+"Gruppe."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§aDu bist einer Inselgruppe beigetreten. Benutze /island party um die "
+"anderen Mitglieder zu sehen."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§eDie Einladung für {0}§e wurde abgebrochen oder ist ausgelaufen"
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr ""
+"§eDie Einladung für {0}''s Insel wurde abgebrochen oder ist ausgelaufen."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§eDu hast die Inseleinladung angenommen."
+
+msgid "§4You haven't been invited."
+msgstr "§4Du wurdest nicht eingeladen."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eDu hast die Einladung einer Insel beizutreten abgelehnt."
+
+msgid "general island command"
+msgstr "Allgemeine Insel Befehle"
+
+msgid "allows user to bypass cooldowns"
+msgstr ""
+
+msgid "allows user to bypass visitor-protections"
+msgstr ""
+
+msgid "allows user to bypass teleport-delay"
+msgstr ""
+
+msgid "allows user to use [usb] signs"
+msgstr ""
+
+msgid "allows user to place [usb] signs"
+msgstr ""
+
+msgid "complete and list challenges"
+msgstr "vervollständige und zeige Aufgaben an"
+
+msgid "§cCommand only available for players."
+msgstr "§cDieses Kommando ist nur für Spieler verfügbar"
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eAufgaben wurden deaktiviert. Wende dich an einen Admin."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4Du kannst nur in der SkyBlock Welt Aufgaben erledigen."
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4Du kannst nur Aufgaben erledigen wenn du eine Insel besitzt."
+
+msgid "warp to another player''s island"
+msgstr "Warpt dich auf die Insel eines anderen Spielers"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr "§aDein Warp ist aktiv, Spieler können sich zu Deiner Insel warpen."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§aDein Warp ist inaktiv, Spieler können sich nicht zu Deiner Insel warpen."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr ""
+"§fSetze den Warp für die ankommenden Spieler mit §e/island setwarp §fan "
+"deine aktuelle Position."
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§fSchalte deinen Warp ein/aus mit  §e/island togglewarp§f."
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr ""
+"§4Du verfügst nicht über die Rechte einen Warp auf deiner Insel zu erstellen!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr ""
+"§fUm dich auf die Insel eines anderen Spielers zu Warpen nutze §e/island "
+"warp <player>§f."
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4Du hast keine Rechte um die auf andere Inseln zu Warpen!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cDeine Insel wird gerade erstellt. Du kannst dich noch nicht zu ihr warpen."
+
+msgid "§4That player does not exist!"
+msgstr "§4Dieser Spieler existiert nicht!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4Dieser Spieler besitzt keinen aktiven Warp."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§cDiese Insel wird gerade erstellt. Du kannst dich noch nicht dorthin warpen"
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cACHTUNG: §9{0}§e warpt sich zu deiner Insel!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4Dieser Spieler hat dir Verboten sich auf seine Insel zu Warpen."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4Keine Insel. §eBenutze §b/is create§e um eine zu starten"
+
+msgid "accept/reject an invitation."
+msgstr "An/-ablehnen einer Einladung."
+
+msgid "leave your party"
+msgstr "Verlasse deine Gruppe"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4Du kannst deine Insel nicht verlassen wenn du die einzige Person auf der "
+"Insel bist. Versuche /island restart falls du eine neue Insel möchtest."
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§eDir gehört die Insel, benutze anstelle /island remove <player>."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eDu hast die Insel verlassen und kommst zurück zum Spieler Spawn."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0} Hat deine Insel verlassen."
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4Du musst in der SkyBlock Welt sein um die Gruppe zu verlassen!"
+
+msgid "check your or anothers island level"
+msgstr "Zeige die Stufe deiner oder einer anderen Insel"
+
+msgid "allows user to query for others levels"
+msgstr ""
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eDu musst auf deiner Insel sein um den Befehl nutzen zu können."
+
+msgid "§4You do not have an island!"
+msgstr "§4Du hast keine Insel!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4Du hast keinen Zugriff auf diesen Befehl!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4Dieser Spieler ist ungültig oder hat keine Insel!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eInformationen über {0}''s Insel"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aDein Insel Level: {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9Stufe ist {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "Erstelle eine Insel"
+
+msgid "exempt player from create-cooldown"
+msgstr "schließt den Spieler vom Insel erstellen Cooldown aus"
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4Insel gefunden!§e Du besitzt bereits eine Insel. Willst du neu starten, "
+"gib§b /is restart§e ein."
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4Insel gefunden!§e Du bist Mitglied auf einr Insel. Um deine eigene zu "
+"starten gib§b /is leave§e ein."
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eDu kannst in {0,number,#} Sekunden eine neue Insel erstellen."
+
+msgid "invite a player to your island"
+msgstr "Läd einen anderen Spieler auf deine Insel ein."
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§eBenutze§f /island invite <playername>§eUm einen Spieler auf deine Insel "
+"einzuladen."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4Nur der Inselbesitzer kann andere einladen!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aDu kannst noch {0} Spieler einladen."
+
+msgid "§4You can't invite any more players."
+msgstr "§4Du kannst keine weiteren Spieler einladen."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4Du hast keine Rechte andere auf deine Insel einzuladen!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4Dieser Spieler ist entweder offline oder existiert nicht."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4Du kannst dich nicht selber einladen!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4Dieser Spieler ist der Anfüher auf deiner Insel!"
+
+msgid "lock your island to non-party members."
+msgstr "Sperrt deine Insel für nicht Mitglieder."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4Du hast nicht die Rechte um die Insel zu sperren!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4Du darfst diesen Befehl nicht ausführen!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4Du hast nicht die Rechte um die Insel zu entsperren!"
+
+msgid "display the top10 of islands"
+msgstr "Zeige die top 10 Inseln"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr ""
+
+msgid "remove a member from your island."
+msgstr "Entferne einen Spieler von deiner Insel."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4Du hast nicht die Rechte um andere Spieler von der Insel zu werfen!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4Du kannst den Anführer der Insel nicht entfernen!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4Hör auf dich selber raus zu werfen!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0} hat Dich von seiner Insel entfernt"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} wurde von der Insel entfernt."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4{0} hat versucht Dich von seiner Insel zu werfen."
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4{0} kann nicht rausgeworfen werden."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4{0} hat Dich von seiner Insel geworfen"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0} wurde von der Insel geschmissen."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr ""
+"§4Dieser Spieler ist nicht in deiner Inselgruppe und nicht auf deiner Insel!"
+
+msgid "teleport to the island home"
+msgstr "Teleportiert zum Insel Home"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§cDeine Insel wird gerade erstellt. Du kannst dich jetzt nicht auf sie "
+"teleportieren"
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4Dieser Befehl kann nur von Spielern ausgeführt werden"
+
+msgid "transfer leadership to another member"
+msgstr "Übertrage die Führerrolle zu einem anderen Spieler"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4Du kannst die Führerschaft nur auf Gruppenmitglieder übertragen!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e ist bereits der Anführer der Insel!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4Nur Anführer können die Führerschaft übertragen!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} hat versucht die Insel zu übernehmen!"
+
+msgid "show party information"
+msgstr "Zeige Gruppen Information"
+
+msgid "shows information about your party"
+msgstr "Zeigt Informationen über deine Gruppe"
+
+msgid "show pending invites"
+msgstr "Zeige ausstehende Einladungen"
+
+msgid "§eNo pending invites"
+msgstr "§eKeine ausstehenden Einladungen"
+
+msgid "withdraw an invite"
+msgstr "Ziehe eine Einladung zurück"
+
+# ???
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4Du hast keine Rechte um Insel Mitglieder zu entfernen"
+
+msgid "check your or another''s island info"
+msgstr "Prüfe deine oder die Inseldaten eines anderen Spielers"
+
+msgid "allows user to see others island info"
+msgstr "erlaubt den Spieler Infos von anderen Insel anzugucken"
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBlöcke von {0}s Insel (Seite {1,number} von {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Werte der Blöcke und deren Anzahl"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "Vertraue/Mistraue einen Spieler auf deiner Insel."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eDu vertraust den folgenden Spielern auf deiner Insel:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eDie folgenden Besitzer trauen dir:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr ""
+"§eUm einen Spieler zu Vertrauen/Mistrauen gib : „/island trust <player>“ ein."
+
+msgid "§4Members are already trusted!"
+msgstr "§4Mitgliedern wird bereits vertraut!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Unbekanter Spieler {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eDu darfst nun auf §4{0}''s §eInsel bauen"
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} hat {1} erlaubt auf seiner Insel zu bauen"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eDu kannst nun nicht mehr auf  §4{0}''s §eInsel bauen."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0} hat die Baurechte von {1} auf der Insel entzogen"
+
+msgid "delete your island and start a new one."
+msgstr "Löscht deine Insel und startet eine neue."
+
+msgid "exempt player from restart-cooldown"
+msgstr ""
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4Nur der Besitzer kann die Insel neustarten. Um deine eigene Starten zu "
+"können verlasse die Insel mit (/island leave)"
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eDu musst zuerst alle Spieler mit (/island kick <player>) von der Insel "
+"entfernen. Nutze (/island party) um zu sehen welche Spieler zu deine Insel "
+"gehören."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§cDu kanst Deine Insel in {0} Sekunden neustarten."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr ""
+"§cDeine Insel wird gerade erstellt. Du kannst sie jetzt nicht neustarten"
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr ""
+"§eHINWEIS: Deine komplette Insel und alle Errungenschaften werden "
+"zurückgesetzt!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "Teleportiert dich zum SkyBlock Spawn"
+
+msgid "change the biome of the island"
+msgstr "Ändere das Biome der Insel"
+
+msgid "exempt player from biome-cooldown"
+msgstr "dieser Spieler hat kein Biom-Cooldown"
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr "Lässt den Spieler sein Insel Biom zu {0} ändern"
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr ""
+"§cDu verfügst nicht über die Rechte um von deiner aktuellen Insel das Biom "
+"zu ändern."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4Du hast nicht die Rechte um das Biom der Insel zu ändern!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eDu musst auf deiner Insel sein um das Biom zu ändern."
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr "§cDies ist kein gültiger Biomname. Muss eins hiervon sein: {0}"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eDu kannst in {0,number,#} Minuten das Biom wieder ändern."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§cDu kannst Dein InselBiom nicht zu diesem Biom ändern."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr "§7Das Biom wird gerade zu §9{0}§7 geändert, hab Geduld."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr "§e{0} ist ein ungültiges Biom"
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aDu hast das Inselbiom zu {0} gewechselt"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} Wechselte das Inselbiom zu {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr "§aDu hast {0} Blöcke um dich herum zu {1} Biom geändert"
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr "{0} erstellte ein Gebiet mit {1} Biom"
+
+msgid "set your island''s warp location"
+msgstr "Setze dein Insel Warp Punkt."
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cDu hast keine Rechte um einen Insel Warppunkt zu setzen!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§cDu musst auf deiner eigenen Insel sein um den Warppunkt zu setzen!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d hat die Position des Warppunktes geändert."
+
+msgid "teleports you to your island (or create one)"
+msgstr "teleportiert Dich zu Deiner Insel (oder erstellt eine)"
+
+msgid "ban/unban a player from your island."
+msgstr "Banne/Entbanne Spieler von deiner Insel."
+
+msgid "exempts user from being banned"
+msgstr "schließt Spieler vom gebannt werden aus"
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§eDie folgenden Spieler dürfen sich nicht auf deine insel warpen:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr ""
+"§eUm einen Spieler von deiner Insel zu Bannen/Entbannen nutze: /island ban "
+"<player>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4Du kannst keine Mitglieder bannen. Entferne sie zuerst!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4Du hast nicht die Rechte dazu andere zu kicken/bannen."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§eKonnte den folgenden unbekannten Spieler nicht bannen: {0}"
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4{0} hat Dich versucht von seiner Insel zu bannen."
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4{0} kann nicht gebannt werden."
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr ""
+"§eDu hast §4{0}§e Verbannt. Diese(r) kann sich nicht mehr auf deine Insel "
+"warpen."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eDu wurdest von  {0}§e''s Insel §cGEBANNT§e."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr ""
+"§eDu hast §4{0}§e Entbannt. Diese(r) kann sich wieder auf deine Insel warpen."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eDu wurdest von {0}§e''s Insel §aENTBANNT§e."
+
+msgid "display log"
+msgstr "Log anzeigen"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "Setze dein Home"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "Aktiviere/Deaktiviere Warping zu deiner Insel."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4Deine Insel ist gesperrt. Du musst sie entsperren um das warpen freizu "
+"schalten."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d hat den Insel Warp aktiviert"
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr ""
+
+msgid "try to complete a challenge"
+msgstr "versucht eine Aufgabe abzuschliessen"
+
+msgid "show information about the challenge"
+msgstr "zeigt Informationen über die Aufgabe"
+
+msgid "§eRank: "
+msgstr "§eRang: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4Diese Aufgabe kannst du nicht wiederholen!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr ""
+"§4Du wirst alle benötigten Gegenstände zerstören wenn du die Aufgabe "
+"beendest."
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4Alle benötigten Items müssen in max {0} Blöcken Abstand von dir auf Deiner "
+"Insel platziert werden"
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§eUm diese Aufgabe abzuschliesse nutze §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4Ungültiger Aufgaben Name! Benutze /c für mehr Informationen."
+
+msgid "§eSending you to spawn."
+msgstr "§eDu wirst zum Spawn gesendet"
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§eDie Insel wurde §cGESPERRT§e."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4Es konnte kein sicherer Ort für dein Home gefunden werden!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§cWARNUNG: §eDu wirst in die Luft geportet."
+
+msgid "§aTeleporting you to your island."
+msgstr "§aDu wirst zu Deiner Insel teleportiert."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aDu wirst in {0} Sekunden Teleportiert."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Es ist nicht möglich Dich zu der Insel von dem Spieler zu Warpen!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aDu wirst zu {0}''s Insel teleportiert."
+
+msgid "§7Teleport cancelled"
+msgstr "§7Teleport abgebrochen"

--- a/uSkyBlock-Core/src/main/po/en_GB.po
+++ b/uSkyBlock-Core/src/main/po/en_GB.po
@@ -12,6 +12,30 @@ msgstr ""
 "X-Generator: Poedit 1.8.11\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+msgid "d"
+msgstr "d"
+
+msgid "h"
+msgstr "h"
+
+msgid "m"
+msgstr "m"
+
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§4* §7You do not have access (§4{0}§7)"
@@ -19,6 +43,15 @@ msgstr "§4* §7You do not have access (§4{0}§7)"
 #, java-format
 msgid "§eInvalid command: {0}"
 msgstr "§4* §7Invalid command: {0}"
+
+msgid "Command"
+msgstr "Command"
+
+msgid "Permission"
+msgstr "Permission"
+
+msgid "Description"
+msgstr "Description"
 
 #, java-format
 msgid "§7Usage: {0}"
@@ -43,1691 +76,12 @@ msgstr "§4* §7Wrote documentation to {0}"
 msgid "§4Error writing documentation: {0}"
 msgstr "§4* §7Error writing documentation: {0}"
 
-msgid "Command"
-msgstr "Command"
+msgid "§cWither Despawned!§e It wandered too far from your island."
+msgstr "§9* §7Wither §4despawned!§7 It wandered too far from your island."
 
-msgid "Permission"
-msgstr "Permission"
-
-msgid "Description"
-msgstr "Description"
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-msgid "d"
-msgstr "d"
-
-msgid "h"
-msgstr "h"
-
-msgid "m"
-msgstr "m"
-
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§4* §7Still the following blocks short: §4{0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr "§4You can complete this {0} more time(s)."
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§7Requirements will reset in §4{0} §7days."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§7Requirements will reset in §4{0} §7hours."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§7Requirements will reset in §4{0} §7minutes."
-
-msgid "§4This challenge is currently unavailable."
-msgstr "§a* §7This challenge is currently unavailable."
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr "§a* §7You can complete this again in {0} days."
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr "§a* §7You can complete this again in {0} hours."
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr "§a* §7You can complete this again in {0} minutes."
-
-msgid "§eThis challenge requires:"
-msgstr "§eThis challenge requires:"
-
-msgid "§7and more..."
-msgstr "§7and more..."
-
-msgid "§eItems will be traded for reward."
-msgstr "§eItems will be traded for reward."
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr "§a* §7Must be within {0} meters."
-
-msgid "§6Item Reward: §a"
-msgstr "§6Item Reward: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Currency Reward: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Exp Reward: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dTotal times completed: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr "§7Requires {0}"
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4* §7No challenge named §4{0} §7found"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4* §7You must be on your island to do that!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§a* §7The {0} challenge is §4not §7available yet!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4* §7The §a{0} §7challenge is not repeatable!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr "§a* §7You cannot complete the {0} challenge again yet!"
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§a* §7Trying to complete challenge §a{0}"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr ""
-"§4* §7You must be standing within §c{0} §7blocks of all required items."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4* §7Your island must be level §4{0} §7to complete this challenge!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4* §7Unknown type of challenge: §4{0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§4* §7Still the following entities short:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§a* §7You are the following items short:§4{0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§a* §7You have completed the §a{0} §7challenge!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§a* §6{0}§7 has completed the §a{1}§7 challenge!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§eItem reward(s): §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eExp reward: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§9* §7Your inventory is §4full§7. Items dropped on the ground."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§eClick to complete this challenge."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4You can't repeat this challenge."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Rank: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fComplete most challenges in"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fthis rank to unlock the next rank."
-
-msgid "§eClick here to show previous page"
-msgstr "§eClick here to show previous page"
-
-msgid "§eClick here to show next page"
-msgstr "§eClick here to show next page"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lLocked Challenge"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "§7Complete {0} more {1} §7challenges"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Complete §a{0}"
-
-msgid "to unlock this rank"
-msgstr "to unlock this rank"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "§7But you are ALLLLLLL ALOOOOONE!"
-
-msgid "But you are Yelling in the wind!"
-msgstr "§7But you are Yelling in the wind!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "§7But your fantasy friends are gone!"
-
-msgid "But you are Talking to your self!"
-msgstr "§7But you are Talking to your self!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§4* §7Sorry! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr ""
-"§6* §7Either send a message directly to your group, or toggle it on/off."
-
-msgid "party"
-msgstr "party"
-
-msgid "island"
-msgstr "island"
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§6* §7Toggled chat to {0} §aON"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§6* §7Repeat §9{0}§7 to toggle it §4OFF"
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§6* §7Toggled chat §4OFF§7 for {0}"
-
-msgid "§cCommand only available to players"
-msgstr "§4* §7Command only available to players"
-
-msgid "talk to players on your island"
-msgstr "talk to players on your island"
-
-msgid "talk to your island party"
-msgstr "talk to your island party"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§9* §7Player §6{0} §7has no island!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§4* §7Invalid player §6{0} §7supplied."
-
-msgid "Manage challenges for a player"
-msgstr "Manage challenges for a player"
-
-msgid "resets the challenge for the player"
-msgstr "resets the challenge for the player"
-
-msgid "§4Challenge has never been completed"
-msgstr "§a* §7Challenge has never been completed"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§a* §7challenge: §a{0} has been reset for §6{1}"
-
-msgid "resets all challenges for the player"
-msgstr "resets all challenges for the player"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§a* §6{0} §7has had all challenges reset."
-
-msgid "complete all challenges in the rank"
-msgstr "complete all challenges in the rank"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4* §7No player named §6{0} §7was found!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4Challenge {0} has already been completed"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§a& §7Challenge §a{0} §7has been completed for §6{1}"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4* §7No challenge named §a{0} §7was found!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4* §7No rank named §a{0} §7was found!"
-
-msgid "manage islands"
-msgstr "manage islands"
-
-msgid "protects the island"
-msgstr "protects the island"
-
-msgid "delete the island (removes the blocks)"
-msgstr "delete the island (removes the blocks)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9* §7Deleted abandoned island at your current location."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4* §7Island at this location has members!\n"
-"§4* §7Use §a/usb island delete <name>§7 to delete it."
-
-msgid "removes the player from the island"
-msgstr "removes the player from the island"
-
-msgid "adds the player to the island"
-msgstr "adds the player to the island"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§6{0} §7has joined your island group."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4* §7No player named §6{0} found!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-"§4* §7No valid island provided, either stand within one, or provide an "
-"island name"
-
-msgid "print out info about the island"
-msgstr "print out info about the island"
-
-msgid "sets the biome of the island"
-msgstr "sets the biome of the island"
-
-msgid "§4That player has no island."
-msgstr "§4* §7That player has no island."
-
-msgid "§4No valid island at your location"
-msgstr "§4* §7No valid island at your location"
-
-msgid "purges the island"
-msgstr "purges the island"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4* Error! §7No valid island found for purging."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§4* PURGE: §7Purged island at {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "toggles the islands ignore status"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§4* §7Set §4 {0}s §7island to be ignored on top-ten and purge."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§4* §7Removed ignore-flag of §4{0}s §7island, it will now show up on top-ten "
-"and purge."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4* §7No valid player-name supplied."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "§4* §7Removing §6{0} §7from island"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§9* §7Changed biome of §6{0}s §7island to {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§9* §7Changed biome of §6{0}s §7island to OCEAN."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr "§9* §7You may need to go to spawn, or relog, to see the changes."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§9* §6{0} §7has had their biome changed to {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§9* §6{0} §7has had their biome changed to OCEAN."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§4* §7Removing §6{0}''s §7island."
-
-msgid "Error: That player does not have an island!"
-msgstr "Error: That player does not have an island!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§4* §6{0}s §7island at {1} has been protected"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4* §6{0}s §7island at {1} was already protected"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "open GUI for config"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§4* §7Invalid configuration name"
-
-msgid "Controls player-cooldowns"
-msgstr "Controls player-cooldowns"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "clears the cooldown on a command (* = all)"
-
-msgid "§eThe player is not currently online"
-msgstr "§4* §7The player is not currently online"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Cleared cooldown on {0} for {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "No active cooldown on {0} for {1} detected!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Invalid command supplied, only restart and biome supported!"
-
-msgid "restarts the cooldown on the command"
-msgstr "restarts the cooldown on the command"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§4* §7Reset cooldown on {0} for {1}§7 to {2} seconds"
-
-msgid "lists all the active cooldowns"
-msgstr "lists all the active cooldowns"
-
-msgid "§eCmd Cooldown"
-msgstr "§9* §7Cmd Cooldown"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§4* §7No active cooldowns for §6{0}§7 found."
-
-msgid "control debugging"
-msgstr "control debugging"
-
-msgid "set debug-level"
-msgstr "set debug-level"
-
-msgid "toggle debug-logging"
-msgstr "toggle debug-logging"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4* §7Logging wasn't active, so you can't disable it!"
-
-msgid "flush current content of the logger to file."
-msgstr "flush current content of the logger to file."
-
-msgid "§eLog-file has been flushed."
-msgstr "§4* §7Log-file has been flushed."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4* §7Logging is not enabled, use §a/usb debug §7enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4* §7Invalid argument, try §eINFO§7, §6FINE§7, §cFINER§7, §4FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§4* §7Logging disabled!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "tries to fix the the area of flatland."
-
-msgid "§4No valid island found"
-msgstr "§4* §7No valid island found"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4* §7No flatland detected at §6{0}''s §7island!"
-
-msgid "flushes all caches to files"
-msgstr "flushes all caches to files"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-"§9* §7Flushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-
-msgid "manually update the top 10 list"
-msgstr "manually update the top 10 list"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§9* §7Generating the Top Ten list"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§4* §7Finished generation of the Top Ten list"
-
-msgid "advanced command for getting island-data"
-msgstr "advanced command for getting island-data"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§4* §7Current value for {0} is ''{1}''"
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§4* §7Unable to get state for {0}"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§4* §7Valid fields are {0}"
-
-msgid "teleport to another players island"
-msgstr "teleport to another players island"
-
-msgid "§4Only supported for players"
-msgstr "§4* §7Only supported for players"
-
-msgid "§4That player does not have an island!"
-msgstr "§4* §7That player does not have an island!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr "§9* §7Teleporting to {0}''s island."
-
-msgid "imports players and islands from other formats"
-msgstr "imports players and islands from other formats"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9* §7Job Statistics"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/job"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "act"
-
-msgid "time"
-msgstr "time"
-
-msgid "name"
-msgstr "name"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "changes the language of the plugin, and reloads"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§4* §7Successfully changed language to §4{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§4* §7Failed to change language to §4{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9* §7Supported Languages:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§4* §7Unable to locate any languages."
-
-msgid "transfer leadership to another player"
-msgstr "transfer leadership to another player"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4* §6Player {0} §7has no island to transfer!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§4* §7Player §6{0} §7already has an island. §7Use §a/usb island remove "
-"<name>§7 to remove him first."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§4* §7Leadership transferred by §4{0} §7to §a{1}"
-
-msgid "advanced info about NBT stuff"
-msgstr "§7advanced info about NBT stuff"
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "§7shows the NBTTag for the currently held item"
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§e* §7Info for §9{0}"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - name: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - nbttag: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§4* §7No item in hand!"
-
-msgid "§eCan only be executed as a player"
-msgstr "§4* §7Can only be executed as a player"
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "§7sets the NBTTag on the currently held item"
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "§e* §7Set §9{0}§e to §c{1}"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "§7adds the NBTTag on the currently held item"
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§e* §7Added §9{0}§e to §c{1}"
-
-msgid "manage orphans"
-msgstr "manage orphans"
-
-msgid "count orphans"
-msgstr "count orphans"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§4* §7{0} old island locations will be used before new ones."
-
-msgid "clear orphans"
-msgstr "clear orphans"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§4* §7Clearing all old (empty) island locations."
-
-msgid "list orphans"
-msgstr "list orphans"
-
-msgid "§eNo orphans currently registered."
-msgstr "§4* §7No orphans currently registered."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr "additional perks {0}"
-
-msgid "protects all islands (time consuming)"
-msgstr "protects all islands (time consuming)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§4* §7Trying to abort protect-all task."
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-"§4* Sorry!§7 A protect-all is already running. Let it complete first, or use "
-"§9/usb protectall §4stop"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§4* §7Starting a protect-all task. It will take a while."
-
-msgid "purges all abandoned islands"
-msgstr "purges all abandoned islands"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4* §7You must provide the age in days to purge!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr "§4* §7Trying to abort purge"
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr "§4* §7Starting purge..."
-
-msgid "region manipulations"
-msgstr "region manipulations"
-
-msgid "shows the borders of the current island"
-msgstr "shows the borders of the current island"
-
-msgid "§eNo island found at your current location"
-msgstr "§4* §7No island found at your current location"
-
-msgid "shows the borders of the current chunk"
-msgstr "shows the borders of the current chunk"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "shows the borders of the inner-chunks"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "shows the non-chunk-aligned borders"
-
-msgid "shows the borders of the outer-chunks"
-msgstr "shows the borders of the outer-chunks"
-
-msgid "hides the regions again"
-msgstr "hides the regions again"
-
-msgid "§eStopped displaying regions"
-msgstr "§4* §7Stopped displaying regions"
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§4* §7No currently shown regions for this player"
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§4* §7Animation-tick changed to {0}."
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§4* §7Animation-tick must be a valid integer."
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "set a player''s island to your location"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "reload configuration from file."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§4* §7Configuration reloaded from file."
-
-msgid "advanced command for setting island-data"
-msgstr "advanced command for setting island-data"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§4* §7{0} was set to ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§4* §7Unable to set field {0} to ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr "§4* §7Unable to set field {0} to ''{1}'', a number was expected"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§4* §7Invalid field {0}"
-
-msgid "toggles maintenance mode"
-msgstr "§9* §7toggles maintenance mode"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-"§4* MAINTENANCE: §aActivated§7, all uSkyBlock features currently disabled."
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-"§4* MAINTENANCE: §4Deactivated§7, all uSkyBlock features back to operational."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr "§4* §7Maintenance mode can only be changed from console!"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§4* ABORTED:§7 Protect-All was aborted!"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr "§e* §7Completed protect-all in {0}, {1} new regions were created!"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§4* §7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4* PURGE:§7 Scanning aborted."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4* PURGE:§7 Finished purging abandoned islands."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4* PURGE:§7 Aborted purging abandoned islands."
-
-msgid "displays version information"
-msgstr "displays version information"
-
-msgid "various WorldGuard utilities"
-msgstr "various WorldGuard utilities"
-
-msgid "refreshes the chunks around the player"
-msgstr "refreshes the chunks around the player"
-
-msgid "§eResending chunks to the client"
-msgstr "§4* §7Resending chunks to the client"
-
-msgid "load the region chunks"
-msgstr "load the region chunks"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§4* §7Loading chunks at {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§4* §7Unloading chunks at {0}"
-
-msgid "update the WG regions"
-msgstr "§4* §7update the WG regions"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§4* §7Island world-guard regions updated for {0}"
-
-msgid "§eNo island found at your location!"
-msgstr "§4* §7No island found at your location!"
-
-msgid "refreshes the chunk around the player"
-msgstr "§4* §7refreshes the chunk around the player"
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "show player-information"
-
-msgid "try to complete a challenge"
-msgstr "try to complete a challenge"
-
-msgid "§cCommand only available for players."
-msgstr "§4* §7Command only available for players."
-
-msgid "show information about the challenge"
-msgstr "show information about the challenge"
-
-msgid "§eRank: "
-msgstr "§eRank: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4This Challenge is not repeatable!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr ""
-"§4* §7You will lose all required items when you complete this challenge!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4* §7All required items must be placed on your island, within §c{0} "
-"§7blocks of you."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§a* §7To complete this challenge, use §a/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4* §7Invalid challenge name! Use §a/c §7help for more information"
-
-msgid "complete and list challenges"
-msgstr "complete and list challenges"
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§4* §7Challenges has been disabled. Contact an administrator."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4* §7You can only submit challenges in the skyblock world!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4* §7You can only submit challenges when you have an island!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4* §7Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4* §7That player is already leader on another island."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§9* §{0}§7 tried to invite you, but you are already in a party."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr "§9* §7Invite sent to {0}"
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "§9* §6{0} §7has invited you to join their island!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§9* §f/island [accept/reject]§7 to §aaccept or §4reject §7the invite."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4* WARNING§7: You will lose your current island if you accept!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "§6{0}§a invited §6{1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "§9* §6{0} §7has §4rejected §7the invitation."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4* §7You can't use that command right now. Leave your current party first."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§9* §7You have joined an island! Use §a/island party §7to see the other "
-"members."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§7Invitation for §6{0} §7has timed out or been cancelled."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr ""
-"§9* §7Invitation for §6{0}''s §7island has timed out or been cancelled."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§9* §7You have §aaccepted §7the invitation to join an island."
-
-msgid "§4You haven't been invited."
-msgstr "§9* §7You haven't been invited."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§9* §7You have §4rejected §7the invitation to join an island."
-
-msgid "accept/reject an invitation."
-msgstr "accept/reject an invitation."
-
-msgid "teleports you to your island (or create one)"
-msgstr "teleports you to your island (or create one)"
-
-msgid "ban/unban a player from your island."
-msgstr "ban/unban a player from your island."
-
-msgid "exempts user from being banned"
-msgstr "§4* §7exempts user from being banned"
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr ""
-"§4* §7The following players are §4banned §7from warping to your island:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr ""
-"§9* §7To §4ban§7/§aunban §7from your island, use §a/island ban <player>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4* §7You can't ban members. §4Remove §7them first!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4* §7You do not have permission to kick/ban players."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§e* §7Unable to ban unknown player {0}"
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4* §7{0} tried to §4ban §7you from their island!"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4* §7{0} is exempt from being banned."
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§4* §7You have banned §4{0}§7 from warping to your island."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§4* §7You have been §4BANNED§7 from §6{0}''s §7island."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§9* §7You have §aunbanned §6{0} §7from warping to your island."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§9* §7You have been §aUNBANNED§7 from §6{0}''s §7island."
-
-msgid "change the biome of the island"
-msgstr "change the biome of the island"
-
-msgid "exempt player from biome-cooldown"
-msgstr "§4* §7exempt player from biome-cooldown"
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr "§2* §7Let the player change their islands biome to {0}"
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr ""
-"§4* §7You do not have permission to change the biome of your current island."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4* §7You do not have permission to change the biome of this island!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§4* §7You must be on your island to change the biome!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr "§4* §7You have misspelled the biome name. Must be one of {0}"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§9* §7You can change your biome again in §c{0,number,#} §7minutes."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§4* §7You do not have permission to change your biome to that type."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-"§2* §7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-"§a* §7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr "§4* §7Invalid biome {0} supplied!"
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§9* §7You have changed your island''s biome to §a{0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "§2* §6{0} §7changed the island biome to §2{1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr "§2* §7You have changed §9{0} §7blocks around you to the §2{1} §7biome"
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr "§2* §7{0} created an area with §2{1} §7biome"
-
-msgid "create an island"
-msgstr "create an island"
-
-msgid "exempt player from create-cooldown"
-msgstr "§4* §7exempt player from create-cooldown"
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4* Island found!§7 You already have an island. If you want a fresh island, "
-"type§a /is restart§7 to get one"
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4* Island found!§7 You are already a member of an island. To start your "
-"own, first§a /is leave"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§9* §7You can create a new island in §c{0,number,#} §7seconds."
-
-msgid "teleport to the island home"
-msgstr "teleport to the island home"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§4 §7Your island is in the process of generating, you cannot teleport home "
-"right now."
-
-msgid "check your or another''s island info"
-msgstr "check your or another''s island info"
-
-msgid "allows user to see others island info"
-msgstr "§9* §7allows user to see others island info"
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4* §7Island level has been disabled, contact an administrator."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§4* §7You must be on your island to use this command."
-
-msgid "§4You do not have an island!"
-msgstr "§4* §7You do not have an island!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4* §7You do not have access to that command!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4* §7That player is invalid or does not have an island!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Score Count Block"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§9- §7Island level is §a{0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "invite a player to your island"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§9* §7Use§a /island invite <playername>§7 to invite a player to your island."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4* §7Only the island''s owner can invite!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§9* §7You can invite §c{0} §7more players."
-
-msgid "§4You can't invite any more players."
-msgstr "§4* §7You §4can't §7invite any more players."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4* §7You do not have permission to invite others to this island!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4* §7That player is offline or doesn't exist."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4* §7You can't invite yourself!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4* §7That player is the leader of your island!"
-
-msgid "remove a member from your island."
-msgstr "remove a member from your island."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4* §7You do §4not §7have permission to kick others from this island!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4* §7You can't remove the leader from the Island!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4* §7Stop kickin' yourself!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4* §6{0} §7has removed you from their island!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4* §6{0} §7has been removed from the island."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4* §7{0} tried to §4kick §7you from their island!"
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4* §6{0} §7is exempt from being kicked."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4* §7{0} has §4kicked §7you from their island!"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4* §6{0} §7has been §4kicked §7from the island."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr ""
-"§4* §7That player is not part of your island group, and not on your island!"
-
-msgid "leave your party"
-msgstr "leave your party"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4* §7You can't leave your island if you are the only person. Try using §a/"
-"island restart §7if you want a new one!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§9* §7You own this island, use §a/island remove <player> §7instead."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§9* §7You have left the island and returned to the player spawn."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§9* §6{0} §7has left your island!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4* §7You must be in the skyblock world to leave your party!"
-
-msgid "check your or anothers island level"
-msgstr "check your or anothers island level"
-
-msgid "allows user to query for others levels"
-msgstr "§9* §7allows user to query for others levels"
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§9* §7Information about §6{0}''s §7Island:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9- §7Rank is §9{0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "lock your island to non-party members."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4* §7You do not have permission to lock your island!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4* §7You don't have access to this command!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4* §7You do not have permission to unlock your island!"
-
-msgid "display log"
-msgstr "display log"
-
-msgid "transfer leadership to another member"
-msgstr "transfer leadership to another member"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4* §7You can only transfer ownership to party-members!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "§6{0}§7 is already leader of your island!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4* §7Only leader can transfer leadership!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "§c{0} §7tried to take over the island!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "show party information"
-
-msgid "shows information about your party"
-msgstr "shows information about your party"
-
-msgid "show pending invites"
-msgstr "show pending invites"
-
-msgid "§eNo pending invites"
-msgstr "§9* §7No pending invites"
-
-msgid "withdraw an invite"
-msgstr "withdraw an invite"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4* §7You don't have permissions to uninvite players."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4* §7This command can only be executed by a player"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4* No Island. §7Use §a/is create§7 to get one"
-
-msgid "changes a members island-permissions"
-msgstr "changes a members island-permissions"
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr "§9* §7Permissions for §6{0}§7:"
-
-msgid "§aON"
-msgstr "§aON"
-
-msgid "§cOFF"
-msgstr "§cOFF"
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr "§7 - §6{0}§7 : {1}"
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr "§4* §7Invalid permission {0}. Must be one of {1}"
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr "§9* §7Toggled permission §9{0}§7 for §9{1}§7 to {2}"
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr "§4* §7Unable to toggle permission §9{0}§7 for §9{1}"
-
-msgid "delete your island and start a new one."
-msgstr "delete your island and start a new one."
-
-msgid "exempt player from restart-cooldown"
-msgstr "§4* §7exempt player from restart-cooldown"
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4* §7Only the owner may restart this island. Leave this island in order to "
-"§7start your own (§a/island leave§7)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§4* §7You must remove all players from your island before you can restart it "
-"(§a/island kick <player>§7). See a list of players currently part of your "
-"island using §a/island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§4* §7You can restart your island in §c{0} §7seconds."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr ""
-"§4* §7Your island is in the process of generating, you cannot restart now."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§4NOTE: §7Your entire island and all your belongings will be §4RESET!"
-
-msgid "set the island-home"
-msgstr "set the island-home"
-
-msgid "set your island''s warp location"
-msgstr "set your island''s warp location"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§4* §7You do not have permission to set your island''s warp point!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§4* §7You need to be on your own island to set the warp!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§6{0}§7 changed the island warp location."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "teleports you to the skyblock spawn"
-
-msgid "enable/disable warping to your island."
-msgstr "enable/disable warping to your island."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4* §7Your island is §4locked§7. You must §aunlock §7it before enabling your "
-"warp."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§6{0}§a activated §7the island warp."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§6{0}§4 deactivated §7the island warp."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr ""
-"§4* §7You do not have permission to §aenable§7/§4disable §7your island''s "
-"warp!"
-
-msgid "display the top10 of islands"
-msgstr "display the top10 of islands"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr "§9* §7enables user to all-ways generate top-ten (no caching)"
-
-msgid "trust/untrust a player to help on your island."
-msgstr "trust/untrust a player to help on your island."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§9* §7The following players are §atrusted §7on your island:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§9* §7The following leaders §atrusts §7you:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr ""
-"§9* §7To §atrust§7/§4untrust §7from your island, use §a/island trust <player>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4* §7Members are already §atrusted§7!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4* §7Unknown player §6{0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§4* §7You are now §atrusted on §6{0}''s §7island."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§6{0} §atrusted §6{1} §7on the island"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§4* §7You are no longer §4trusted §7on §6{0}''s §7island."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§6{0} §crevoked §7trust in §6{1} §7on the island"
-
-msgid "warp to another player''s island"
-msgstr "warp to another player''s island"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr ""
-"§9* §7Your incoming warp is §aactive§7, players may warp to your island."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§9* §7Your incoming warp is §4inactive§7, players may not warp to your "
-"island."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr ""
-"§9* §7Set incoming warp to your current location using §a/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§9* §7Toggle your warp on/off using §a/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4* §7You do not have permission to create a warp on your island!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§9* §7Warp to another island using §a/island warp <player>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4* §7You do not have permission to warp to other islands!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§4* §7Your island is in the process of generating, you cannot warp to other "
-"players islands right now."
-
-msgid "§4That player does not exist!"
-msgstr "§4* §7That player does not exist!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4* §7That player does not have an active warp."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§4* §7That players island is in the process of generating, you cannot warp "
-"to it right now."
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§4* WARNING: §6{0}§7 is warping to your island!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4* §7That player has forbidden you from warping to their island."
-
-msgid "general island command"
-msgstr "general island command"
-
-msgid "allows user to bypass cooldowns"
-msgstr "§9* §7allows user to bypass cooldowns"
-
-msgid "allows user to bypass visitor-protections"
-msgstr "§9* §7allows user to bypass visitor-protections"
-
-msgid "allows user to bypass teleport-delay"
-msgstr "§9* §7allows user to bypass teleport-delay"
-
-msgid "allows user to use [usb] signs"
-msgstr "§9* §7allows user to use [usb] signs"
-
-msgid "allows user to place [usb] signs"
-msgstr "§9* §7allows user to place §9[usb] §7signs"
+msgid "{0}''s Wither"
+msgstr "{0}''s Wither"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr ""
@@ -1743,33 +97,6 @@ msgstr "§4* §7Riding is only allowed on your own island!"
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr "§4* §7You cannot break vehicles while being a visitor!"
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr "§9* §7Wither §4despawned!§7 It wandered too far from your island."
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "{0}''s Wither"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§9* §7Visitors can't drop items!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Owner: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "You cannot pick up other players' loot when you are a visitor!"
-
-msgid "Config:"
-msgstr "Config:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§4* No Access! §7You are trying to teleport to the roof of the §4NETHER§7, "
-"that is not allowed."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr "§4* §7You can only convert obsidian once every 10 seconds"
@@ -1814,19 +141,85 @@ msgstr "§9* §7You can only use spawn-eggs on your own island."
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§4* §7You have reached your spawn-limit for your island."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§9* §7Visitors can't drop items!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Owner: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "You cannot pick up other players' loot when you are a visitor!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§4* §lBanned§r§4:§7 You are banned from this island."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§4* Locked:§7 That island is §4locked! §7No entry allowed."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§4* §7Waiting for our turn §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "Something went wrong saving the island and/or party data!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr "§9* §7Converting data to UUID, this make take a while!"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§4* MAINTENANCE:§7 uSkyBlock is currently in maintenance mode"
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9* §7Creating island...§c{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§4* §7You do not have access to that island-schematic!"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4* §7Player is already assigned to this island!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4* §7You must be closer to your island to set your skyblock home!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§9* §7Your skyblock home has been set to your current location."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4* §7Your current location is not a safe home-location."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+"§a* §7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr ""
+"§4* §7Your island is in the process of generating, you cannot create now."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "§4* §7Could not create your Island. Please contact a server moderator."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+"§9* §7Getting your island ready, please be patient, it can take a while."
+
+msgid "§cCommand is currently disabled!"
+msgstr "§4* §7Command is currently disabled!"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§4* §7Still the following blocks short: §4{0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1839,9 +232,6 @@ msgid ""
 msgstr ""
 "§4* §7Doing §a{0}§7 is §4RISKY§7. Repeat the command within §4{1}§7 seconds "
 "to accept!"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4* §7You are entering a protected §4- but abandoned - §7island area."
@@ -1875,216 +265,33 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4* §7You must be the party leader to unlock your island!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§9* §7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§4* §7Waiting for our turn §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9* §7Creating island...§c{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lLocked Challenge"
+
+msgid "READY"
+msgstr "READY"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§9* §7PlayerDB: Filtered {0} names"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-"§9* §7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ "
-"{5,number,##}%), {6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§9* §7MojangAPI: Trying to fetch {0} players from Mojang"
-
-msgid "SUCCESS"
-msgstr "§e* §7SUCCESS"
-
-msgid "FAILED"
-msgstr "§4* §7FAILED"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§9* §7 - MojangAPI:§aCOMPLETED: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§9* §7 - MojangAPI:§cERROR: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-"§4e* §7Progress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:"
-"{5}) ~ {6}"
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4* §7No importer named §6{0}§7 found"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§e* §7Converted {0}/{1} files in {2}"
-
-msgid "The island has been created."
-msgstr "The island has been created."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§6{0} §4locked §7the island."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr ""
-"§4* §7Since your island is §4locked§7, your incoming warp has been "
-"§4deactivated§7."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§6{0}§a unlocked §7the island."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§4Sky §9Message §4: §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "{0}§7 has been removed from the island group."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9* §7Creating an island at your location"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9* §7Creating an island §9{0}§7 of you"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§a* §7The {0} challenge is §4not §7available yet!"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
-"§4* §7The island owning this piece of nether is being deleted! Sending you "
-"to spawn."
+"§4* WARNING:§7 Could not transfer all the required items to your inventory!"
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§4* §7The island you are on is being deleted! Sending you to spawn."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eWALL OF FAME (page {0} of {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr ""
-"§4* §7Top ten list is empty! Only islands above level §a{0} §7is considered."
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§9* §7Your rank is: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "UNKNOWN"
-
-msgid "ANIMAL"
-msgstr "ANIMAL"
-
-msgid "MONSTER"
-msgstr "MONSTER"
-
-msgid "VILLAGER"
-msgstr "VILLAGER"
-
-msgid "GOLEM"
-msgstr "GOLEM"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (max. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "§4* §7Unable to locate schematic §c{0}§7, contact a server-admin"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§9* Congratulations! §7Your island has appeared."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§4* Note:§7 Construction might still be ongoing."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "§9* §7Use §a/is h§7 or the §a/is§7 GUI menu to go there."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§4* Watchdog!§7 Unable to locate a chest within §4{0}§7, bailing out."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7Page {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr "§c{0,number,#}"
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr "§a+{0,number,#}"
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr "§a{0,number,#}"
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr "&aLeft:&7 Increment with {0}"
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr "&cRight-Click:&7 Set to {0}"
-
-msgid "Return"
-msgstr "Return"
-
-msgid "§9Integer Editor"
-msgstr "§4* §7Integer Editor"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§4* §7Configuration saved and reloaded."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§4* Error! §9Unable to save config file!"
-
-msgid "§3First Page"
-msgstr "§3First Page"
-
-msgid "§3Last Page"
-msgstr "§3Last Page"
-
-msgid "§cSave & Reload config"
-msgstr "§4* Save & Reload config"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§4Note: §7Use with care!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (readonly)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr "§4* §7Not enough items in chest to complete challenge!"
 
 msgid "true"
 msgstr "true"
@@ -2539,6 +746,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "§7Current page"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7Page {0}"
+
 msgid "§7First Page"
 msgstr "§7First Page"
 
@@ -2853,8 +1064,8 @@ msgstr "§cClick to leave"
 msgid "Island Restart Menu"
 msgstr "Island Restart Menu"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§4* §7You do not have access to that island-schematic!"
+msgid "Config:"
+msgstr "Config:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2870,115 +1081,122 @@ msgstr "§cClick within §9{0}§c to restart!"
 msgid "§aClick to restart!"
 msgstr "§aClick to restart!"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr "§c{0,number,#}"
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr "§a+{0,number,#}"
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr "§a{0,number,#}"
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr "&aLeft:&7 Increment with {0}"
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr "&cRight-Click:&7 Set to {0}"
+
+msgid "Return"
+msgstr "Return"
+
+msgid "§9Integer Editor"
+msgstr "§4* §7Integer Editor"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9Text Editor"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§4* §7Configuration saved and reloaded."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§4* Error! §9Unable to save config file!"
+
+msgid "§3First Page"
+msgstr "§3First Page"
+
+msgid "§3Last Page"
+msgstr "§3Last Page"
+
+msgid "§cSave & Reload config"
+msgstr "§4* Save & Reload config"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§4Note: §7Use with care!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (readonly)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+"§4e* §7Progress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:"
+"{5}) ~ {6}"
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4* §7No importer named §6{0}§7 found"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§e* §7Converted {0}/{1} files in {2}"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§9* §7PlayerDB: Filtering {0} players from uuid2name.yml"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§9* §7PlayerDB: Filtered {0} names"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§9* §7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ "
+"{5,number,##}%), {6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§9* §7MojangAPI: Trying to fetch {0} players from Mojang"
+
+msgid "SUCCESS"
+msgstr "§e* §7SUCCESS"
+
+msgid "FAILED"
+msgstr "§4* §7FAILED"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§9* §7 - MojangAPI:§aCOMPLETED: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§9* §7 - MojangAPI:§cERROR: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "§4* §7Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§9* §7Sending you to spawn."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§9* §7The island has been §4LOCKED§7."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§9* §7You will be teleported in §4{0} §7seconds."
-
-msgid "§7Teleport cancelled"
-msgstr "§4* §7Teleport cancelled"
-
-msgid "READY"
-msgstr "READY"
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-"§4* WARNING:§7 Could not transfer all the required items to your inventory!"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr "§4* §7Not enough items in chest to complete challenge!"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Something went wrong saving the island and/or party data!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr "§9* §7Converting data to UUID, this make take a while!"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§4* MAINTENANCE:§7 uSkyBlock is currently in maintenance mode"
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4* §7Player is already assigned to this island!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4* §7Unable to find a safe home-location on your island!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§4* WARNING: §7Teleporting you to mid-air."
-
-msgid "§aTeleporting you to your island."
-msgstr "§9* §7Teleporting you to your island."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Unable to warp you to that player''s island!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§9* §7Teleporting you to §6{0}''s §7island."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4* §7You must be closer to your island to set your skyblock home!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§9* §7Your skyblock home has been set to your current location."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4* §7Your current location is not a safe home-location."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr ""
-"§4* §7Your island is in the process of generating, you cannot create now."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "§4* §7Could not create your Island. Please contact a server moderator."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-"§9* §7Getting your island ready, please be patient, it can take a while."
-
-msgid "§cCommand is currently disabled!"
-msgstr "§4* §7Command is currently disabled!"
 
 msgid "North"
 msgstr "North"
@@ -3003,3 +1221,1781 @@ msgstr "West"
 
 msgid "North-West"
 msgstr "North-West"
+
+msgid "The island has been created."
+msgstr "The island has been created."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§6{0} §4locked §7the island."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr ""
+"§4* §7Since your island is §4locked§7, your incoming warp has been "
+"§4deactivated§7."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§6{0}§4 deactivated §7the island warp."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§6{0}§a unlocked §7the island."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§4Sky §9Message §4: §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "{0}§7 has been removed from the island group."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9* §7Creating an island at your location"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9* §7Creating an island §9{0}§7 of you"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§9* Congratulations! §7Your island has appeared."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§4* Note:§7 Construction might still be ongoing."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "§9* §7Use §a/is h§7 or the §a/is§7 GUI menu to go there."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "§4* §7Unable to locate schematic §c{0}§7, contact a server-admin"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§4* Watchdog!§7 Unable to locate a chest within §4{0}§7, bailing out."
+
+msgid "UNKNOWN"
+msgstr "UNKNOWN"
+
+msgid "ANIMAL"
+msgstr "ANIMAL"
+
+msgid "MONSTER"
+msgstr "MONSTER"
+
+msgid "VILLAGER"
+msgstr "VILLAGER"
+
+msgid "GOLEM"
+msgstr "GOLEM"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (max. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§4* §7The island owning this piece of nether is being deleted! Sending you "
+"to spawn."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§4* §7The island you are on is being deleted! Sending you to spawn."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eWALL OF FAME (page {0} of {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr ""
+"§4* §7Top ten list is empty! Only islands above level §a{0} §7is considered."
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4* §7Island level has been disabled, contact an administrator."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§9* §7Your rank is: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "§7Complete {0} more {1} §7challenges"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Complete §a{0}"
+
+msgid "to unlock this rank"
+msgstr "to unlock this rank"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr "§4You can complete this {0} more time(s)."
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§7Requirements will reset in §4{0} §7days."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§7Requirements will reset in §4{0} §7hours."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§7Requirements will reset in §4{0} §7minutes."
+
+msgid "§4This challenge is currently unavailable."
+msgstr "§a* §7This challenge is currently unavailable."
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr "§a* §7You can complete this again in {0} days."
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr "§a* §7You can complete this again in {0} hours."
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr "§a* §7You can complete this again in {0} minutes."
+
+msgid "§eThis challenge requires:"
+msgstr "§eThis challenge requires:"
+
+msgid "§7and more..."
+msgstr "§7and more..."
+
+msgid "§eItems will be traded for reward."
+msgstr "§eItems will be traded for reward."
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr "§a* §7Must be within {0} meters."
+
+msgid "§6Item Reward: §a"
+msgstr "§6Item Reward: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Currency Reward: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Exp Reward: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dTotal times completed: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr "§7Requires {0}"
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4* §7No challenge named §4{0} §7found"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4* §7You must be on your island to do that!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4* §7The §a{0} §7challenge is not repeatable!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr "§a* §7You cannot complete the {0} challenge again yet!"
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§a* §7Trying to complete challenge §a{0}"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr ""
+"§4* §7You must be standing within §c{0} §7blocks of all required items."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4* §7Your island must be level §4{0} §7to complete this challenge!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4* §7Unknown type of challenge: §4{0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§4* §7Still the following entities short:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§a* §7You are the following items short:§4{0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§a* §7You have completed the §a{0} §7challenge!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§a* §6{0}§7 has completed the §a{1}§7 challenge!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§eItem reward(s): §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eExp reward: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§9* §7Your inventory is §4full§7. Items dropped on the ground."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§eClick to complete this challenge."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4You can't repeat this challenge."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Rank: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fComplete most challenges in"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fthis rank to unlock the next rank."
+
+msgid "§eClick here to show previous page"
+msgstr "§eClick here to show previous page"
+
+msgid "§eClick here to show next page"
+msgstr "§eClick here to show next page"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "§7But you are ALLLLLLL ALOOOOONE!"
+
+msgid "But you are Yelling in the wind!"
+msgstr "§7But you are Yelling in the wind!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "§7But your fantasy friends are gone!"
+
+msgid "But you are Talking to your self!"
+msgstr "§7But you are Talking to your self!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§4* §7Sorry! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr ""
+"§6* §7Either send a message directly to your group, or toggle it on/off."
+
+msgid "party"
+msgstr "party"
+
+msgid "island"
+msgstr "island"
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§6* §7Toggled chat to {0} §aON"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§6* §7Repeat §9{0}§7 to toggle it §4OFF"
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§6* §7Toggled chat §4OFF§7 for {0}"
+
+msgid "§cCommand only available to players"
+msgstr "§4* §7Command only available to players"
+
+msgid "talk to your island party"
+msgstr "talk to your island party"
+
+msgid "talk to players on your island"
+msgstr "talk to players on your island"
+
+msgid "manually update the top 10 list"
+msgstr "manually update the top 10 list"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§9* §7Generating the Top Ten list"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§4* §7Finished generation of the Top Ten list"
+
+msgid "purges all abandoned islands"
+msgstr "purges all abandoned islands"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4* §7You must provide the age in days to purge!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr "§4* §7Trying to abort purge"
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr "§4* §7Starting purge..."
+
+msgid "Controls player-cooldowns"
+msgstr "Controls player-cooldowns"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "clears the cooldown on a command (* = all)"
+
+msgid "§eThe player is not currently online"
+msgstr "§4* §7The player is not currently online"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Cleared cooldown on {0} for {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "No active cooldown on {0} for {1} detected!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Invalid command supplied, only restart and biome supported!"
+
+msgid "restarts the cooldown on the command"
+msgstr "restarts the cooldown on the command"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§4* §7Reset cooldown on {0} for {1}§7 to {2} seconds"
+
+msgid "lists all the active cooldowns"
+msgstr "lists all the active cooldowns"
+
+msgid "§eCmd Cooldown"
+msgstr "§9* §7Cmd Cooldown"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§4* §7No active cooldowns for §6{0}§7 found."
+
+msgid "toggles maintenance mode"
+msgstr "§9* §7toggles maintenance mode"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+"§4* MAINTENANCE: §aActivated§7, all uSkyBlock features currently disabled."
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+"§4* MAINTENANCE: §4Deactivated§7, all uSkyBlock features back to operational."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr "§4* §7Maintenance mode can only be changed from console!"
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9* §7Job Statistics"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/job"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "act"
+
+msgid "time"
+msgstr "time"
+
+msgid "name"
+msgstr "name"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§9* §7Player §6{0} §7has no island!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§4* §7Invalid player §6{0} §7supplied."
+
+msgid "flushes all caches to files"
+msgstr "flushes all caches to files"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+"§9* §7Flushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+
+msgid "tries to fix the the area of flatland."
+msgstr "tries to fix the the area of flatland."
+
+msgid "§4No valid island found"
+msgstr "§4* §7No valid island found"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4* §7No flatland detected at §6{0}''s §7island!"
+
+msgid "manage orphans"
+msgstr "manage orphans"
+
+msgid "count orphans"
+msgstr "count orphans"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§4* §7{0} old island locations will be used before new ones."
+
+msgid "clear orphans"
+msgstr "clear orphans"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§4* §7Clearing all old (empty) island locations."
+
+msgid "list orphans"
+msgstr "list orphans"
+
+msgid "§eNo orphans currently registered."
+msgstr "§4* §7No orphans currently registered."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "transfer leadership to another player"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4* §6Player {0} §7has no island to transfer!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§4* §7Player §6{0} §7already has an island. §7Use §a/usb island remove "
+"<name>§7 to remove him first."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§4* §7Leadership transferred by §4{0} §7to §a{1}"
+
+msgid "open GUI for config"
+msgstr "open GUI for config"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§4* §7Invalid configuration name"
+
+msgid "teleport to another players island"
+msgstr "teleport to another players island"
+
+msgid "§4Only supported for players"
+msgstr "§4* §7Only supported for players"
+
+msgid "§4That player does not have an island!"
+msgstr "§4* §7That player does not have an island!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr "§9* §7Teleporting to {0}''s island."
+
+msgid "various WorldGuard utilities"
+msgstr "various WorldGuard utilities"
+
+msgid "refreshes the chunks around the player"
+msgstr "refreshes the chunks around the player"
+
+msgid "§eResending chunks to the client"
+msgstr "§4* §7Resending chunks to the client"
+
+msgid "load the region chunks"
+msgstr "load the region chunks"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§4* §7Loading chunks at {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§4* §7Unloading chunks at {0}"
+
+msgid "update the WG regions"
+msgstr "§4* §7update the WG regions"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§4* §7Island world-guard regions updated for {0}"
+
+msgid "§eNo island found at your location!"
+msgstr "§4* §7No island found at your location!"
+
+msgid "refreshes the chunk around the player"
+msgstr "§4* §7refreshes the chunk around the player"
+
+msgid "region manipulations"
+msgstr "region manipulations"
+
+msgid "shows the borders of the current island"
+msgstr "shows the borders of the current island"
+
+msgid "§eNo island found at your current location"
+msgstr "§4* §7No island found at your current location"
+
+msgid "§eCan only be executed as a player"
+msgstr "§4* §7Can only be executed as a player"
+
+msgid "shows the borders of the current chunk"
+msgstr "shows the borders of the current chunk"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "shows the borders of the inner-chunks"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "shows the non-chunk-aligned borders"
+
+msgid "shows the borders of the outer-chunks"
+msgstr "shows the borders of the outer-chunks"
+
+msgid "hides the regions again"
+msgstr "hides the regions again"
+
+msgid "§eStopped displaying regions"
+msgstr "§4* §7Stopped displaying regions"
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§4* §7No currently shown regions for this player"
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§4* §7Animation-tick changed to {0}."
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§4* §7Animation-tick must be a valid integer."
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4* PURGE:§7 Finished purging abandoned islands."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4* PURGE:§7 Aborted purging abandoned islands."
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§4* §7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4* PURGE:§7 Scanning aborted."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§4* ABORTED:§7 Protect-All was aborted!"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr "§e* §7Completed protect-all in {0}, {1} new regions were created!"
+
+msgid "control debugging"
+msgstr "control debugging"
+
+msgid "set debug-level"
+msgstr "set debug-level"
+
+msgid "toggle debug-logging"
+msgstr "toggle debug-logging"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4* §7Logging wasn't active, so you can't disable it!"
+
+msgid "flush current content of the logger to file."
+msgstr "flush current content of the logger to file."
+
+msgid "§eLog-file has been flushed."
+msgstr "§4* §7Log-file has been flushed."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4* §7Logging is not enabled, use §a/usb debug §7enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4* §7Invalid argument, try §eINFO§7, §6FINE§7, §cFINER§7, §4FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§4* §7Logging disabled!"
+
+msgid "advanced command for setting island-data"
+msgstr "advanced command for setting island-data"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§4* §7{0} was set to ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§4* §7Unable to set field {0} to ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr "§4* §7Unable to set field {0} to ''{1}'', a number was expected"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§4* §7Invalid field {0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§4* §7Current value for {0} is ''{1}''"
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§4* §7Unable to get state for {0}"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§4* §7Valid fields are {0}"
+
+msgid "set a player''s island to your location"
+msgstr "set a player''s island to your location"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr "§7advanced info about NBT stuff"
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "§7shows the NBTTag for the currently held item"
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§e* §7Info for §9{0}"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - name: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - nbttag: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§4* §7No item in hand!"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "§7sets the NBTTag on the currently held item"
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "§e* §7Set §9{0}§e to §c{1}"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "§7adds the NBTTag on the currently held item"
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§e* §7Added §9{0}§e to §c{1}"
+
+msgid "Manage challenges for a player"
+msgstr "Manage challenges for a player"
+
+msgid "resets the challenge for the player"
+msgstr "resets the challenge for the player"
+
+msgid "§4Challenge has never been completed"
+msgstr "§a* §7Challenge has never been completed"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§a* §7challenge: §a{0} has been reset for §6{1}"
+
+msgid "resets all challenges for the player"
+msgstr "resets all challenges for the player"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§a* §6{0} §7has had all challenges reset."
+
+msgid "complete all challenges in the rank"
+msgstr "complete all challenges in the rank"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4* §7No player named §6{0} §7was found!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4Challenge {0} has already been completed"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§a& §7Challenge §a{0} §7has been completed for §6{1}"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4* §7No challenge named §a{0} §7was found!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4* §7No rank named §a{0} §7was found!"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "protects all islands (time consuming)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§4* §7Trying to abort protect-all task."
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4* Sorry!§7 A protect-all is already running. Let it complete first, or use "
+"§9/usb protectall §4stop"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§4* §7Starting a protect-all task. It will take a while."
+
+msgid "reload configuration from file."
+msgstr "reload configuration from file."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§4* §7Configuration reloaded from file."
+
+msgid "manage islands"
+msgstr "manage islands"
+
+msgid "protects the island"
+msgstr "protects the island"
+
+msgid "delete the island (removes the blocks)"
+msgstr "delete the island (removes the blocks)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9* §7Deleted abandoned island at your current location."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4* §7Island at this location has members!\n"
+"§4* §7Use §a/usb island delete <name>§7 to delete it."
+
+msgid "removes the player from the island"
+msgstr "removes the player from the island"
+
+msgid "adds the player to the island"
+msgstr "adds the player to the island"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§6{0} §7has joined your island group."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4* §7No player named §6{0} found!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+"§4* §7No valid island provided, either stand within one, or provide an "
+"island name"
+
+msgid "print out info about the island"
+msgstr "print out info about the island"
+
+msgid "sets the biome of the island"
+msgstr "sets the biome of the island"
+
+msgid "§4That player has no island."
+msgstr "§4* §7That player has no island."
+
+msgid "§4No valid island at your location"
+msgstr "§4* §7No valid island at your location"
+
+msgid "purges the island"
+msgstr "purges the island"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4* Error! §7No valid island found for purging."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§4* PURGE: §7Purged island at {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "toggles the islands ignore status"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§4* §7Set §4 {0}s §7island to be ignored on top-ten and purge."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§4* §7Removed ignore-flag of §4{0}s §7island, it will now show up on top-ten "
+"and purge."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4* §7No valid player-name supplied."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "§4* §7Removing §6{0} §7from island"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§9* §7Changed biome of §6{0}s §7island to {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§9* §7Changed biome of §6{0}s §7island to OCEAN."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr "§9* §7You may need to go to spawn, or relog, to see the changes."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§9* §6{0} §7has had their biome changed to {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§9* §6{0} §7has had their biome changed to OCEAN."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§4* §7Removing §6{0}''s §7island."
+
+msgid "Error: That player does not have an island!"
+msgstr "Error: That player does not have an island!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§4* §6{0}s §7island at {1} has been protected"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4* §6{0}s §7island at {1} was already protected"
+
+msgid "displays version information"
+msgstr "displays version information"
+
+msgid "imports players and islands from other formats"
+msgstr "imports players and islands from other formats"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr "additional perks {0}"
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "changes the language of the plugin, and reloads"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§4* §7Successfully changed language to §4{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§4* §7Failed to change language to §4{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9* §7Supported Languages:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§4* §7Unable to locate any languages."
+
+msgid "advanced command for getting island-data"
+msgstr "advanced command for getting island-data"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "show player-information"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4* §7Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4* §7That player is already leader on another island."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§9* §{0}§7 tried to invite you, but you are already in a party."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr "§9* §7Invite sent to {0}"
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "§9* §6{0} §7has invited you to join their island!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§9* §f/island [accept/reject]§7 to §aaccept or §4reject §7the invite."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4* WARNING§7: You will lose your current island if you accept!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "§6{0}§a invited §6{1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "§9* §6{0} §7has §4rejected §7the invitation."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4* §7You can't use that command right now. Leave your current party first."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§9* §7You have joined an island! Use §a/island party §7to see the other "
+"members."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§7Invitation for §6{0} §7has timed out or been cancelled."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr ""
+"§9* §7Invitation for §6{0}''s §7island has timed out or been cancelled."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§9* §7You have §aaccepted §7the invitation to join an island."
+
+msgid "§4You haven't been invited."
+msgstr "§9* §7You haven't been invited."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§9* §7You have §4rejected §7the invitation to join an island."
+
+msgid "general island command"
+msgstr "general island command"
+
+msgid "allows user to bypass cooldowns"
+msgstr "§9* §7allows user to bypass cooldowns"
+
+msgid "allows user to bypass visitor-protections"
+msgstr "§9* §7allows user to bypass visitor-protections"
+
+msgid "allows user to bypass teleport-delay"
+msgstr "§9* §7allows user to bypass teleport-delay"
+
+msgid "allows user to use [usb] signs"
+msgstr "§9* §7allows user to use [usb] signs"
+
+msgid "allows user to place [usb] signs"
+msgstr "§9* §7allows user to place §9[usb] §7signs"
+
+msgid "complete and list challenges"
+msgstr "complete and list challenges"
+
+msgid "§cCommand only available for players."
+msgstr "§4* §7Command only available for players."
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§4* §7Challenges has been disabled. Contact an administrator."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4* §7You can only submit challenges in the skyblock world!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4* §7You can only submit challenges when you have an island!"
+
+msgid "warp to another player''s island"
+msgstr "warp to another player''s island"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr ""
+"§9* §7Your incoming warp is §aactive§7, players may warp to your island."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§9* §7Your incoming warp is §4inactive§7, players may not warp to your "
+"island."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr ""
+"§9* §7Set incoming warp to your current location using §a/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§9* §7Toggle your warp on/off using §a/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4* §7You do not have permission to create a warp on your island!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§9* §7Warp to another island using §a/island warp <player>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4* §7You do not have permission to warp to other islands!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§4* §7Your island is in the process of generating, you cannot warp to other "
+"players islands right now."
+
+msgid "§4That player does not exist!"
+msgstr "§4* §7That player does not exist!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4* §7That player does not have an active warp."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§4* §7That players island is in the process of generating, you cannot warp "
+"to it right now."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§4* WARNING: §6{0}§7 is warping to your island!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4* §7That player has forbidden you from warping to their island."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4* No Island. §7Use §a/is create§7 to get one"
+
+msgid "accept/reject an invitation."
+msgstr "accept/reject an invitation."
+
+msgid "leave your party"
+msgstr "leave your party"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4* §7You can't leave your island if you are the only person. Try using §a/"
+"island restart §7if you want a new one!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§9* §7You own this island, use §a/island remove <player> §7instead."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§9* §7You have left the island and returned to the player spawn."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§9* §6{0} §7has left your island!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4* §7You must be in the skyblock world to leave your party!"
+
+msgid "check your or anothers island level"
+msgstr "check your or anothers island level"
+
+msgid "allows user to query for others levels"
+msgstr "§9* §7allows user to query for others levels"
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§4* §7You must be on your island to use this command."
+
+msgid "§4You do not have an island!"
+msgstr "§4* §7You do not have an island!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4* §7You do not have access to that command!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4* §7That player is invalid or does not have an island!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§9* §7Information about §6{0}''s §7Island:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§9- §7Island level is §a{0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9- §7Rank is §9{0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "create an island"
+
+msgid "exempt player from create-cooldown"
+msgstr "§4* §7exempt player from create-cooldown"
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4* Island found!§7 You already have an island. If you want a fresh island, "
+"type§a /is restart§7 to get one"
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4* Island found!§7 You are already a member of an island. To start your "
+"own, first§a /is leave"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§9* §7You can create a new island in §c{0,number,#} §7seconds."
+
+msgid "invite a player to your island"
+msgstr "invite a player to your island"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§9* §7Use§a /island invite <playername>§7 to invite a player to your island."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4* §7Only the island''s owner can invite!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§9* §7You can invite §c{0} §7more players."
+
+msgid "§4You can't invite any more players."
+msgstr "§4* §7You §4can't §7invite any more players."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4* §7You do not have permission to invite others to this island!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4* §7That player is offline or doesn't exist."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4* §7You can't invite yourself!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4* §7That player is the leader of your island!"
+
+msgid "lock your island to non-party members."
+msgstr "lock your island to non-party members."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4* §7You do not have permission to lock your island!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4* §7You don't have access to this command!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4* §7You do not have permission to unlock your island!"
+
+msgid "display the top10 of islands"
+msgstr "display the top10 of islands"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr "§9* §7enables user to all-ways generate top-ten (no caching)"
+
+msgid "remove a member from your island."
+msgstr "remove a member from your island."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4* §7You do §4not §7have permission to kick others from this island!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4* §7You can't remove the leader from the Island!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4* §7Stop kickin' yourself!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4* §6{0} §7has removed you from their island!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4* §6{0} §7has been removed from the island."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4* §7{0} tried to §4kick §7you from their island!"
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4* §6{0} §7is exempt from being kicked."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4* §7{0} has §4kicked §7you from their island!"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4* §6{0} §7has been §4kicked §7from the island."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr ""
+"§4* §7That player is not part of your island group, and not on your island!"
+
+msgid "teleport to the island home"
+msgstr "teleport to the island home"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§4 §7Your island is in the process of generating, you cannot teleport home "
+"right now."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4* §7This command can only be executed by a player"
+
+msgid "transfer leadership to another member"
+msgstr "transfer leadership to another member"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4* §7You can only transfer ownership to party-members!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "§6{0}§7 is already leader of your island!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4* §7Only leader can transfer leadership!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "§c{0} §7tried to take over the island!"
+
+msgid "show party information"
+msgstr "show party information"
+
+msgid "shows information about your party"
+msgstr "shows information about your party"
+
+msgid "show pending invites"
+msgstr "show pending invites"
+
+msgid "§eNo pending invites"
+msgstr "§9* §7No pending invites"
+
+msgid "withdraw an invite"
+msgstr "withdraw an invite"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4* §7You don't have permissions to uninvite players."
+
+msgid "check your or another''s island info"
+msgstr "check your or another''s island info"
+
+msgid "allows user to see others island info"
+msgstr "§9* §7allows user to see others island info"
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Score Count Block"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "trust/untrust a player to help on your island."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§9* §7The following players are §atrusted §7on your island:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§9* §7The following leaders §atrusts §7you:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr ""
+"§9* §7To §atrust§7/§4untrust §7from your island, use §a/island trust <player>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4* §7Members are already §atrusted§7!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4* §7Unknown player §6{0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§4* §7You are now §atrusted on §6{0}''s §7island."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§6{0} §atrusted §6{1} §7on the island"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§4* §7You are no longer §4trusted §7on §6{0}''s §7island."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§6{0} §crevoked §7trust in §6{1} §7on the island"
+
+msgid "delete your island and start a new one."
+msgstr "delete your island and start a new one."
+
+msgid "exempt player from restart-cooldown"
+msgstr "§4* §7exempt player from restart-cooldown"
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4* §7Only the owner may restart this island. Leave this island in order to "
+"§7start your own (§a/island leave§7)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§4* §7You must remove all players from your island before you can restart it "
+"(§a/island kick <player>§7). See a list of players currently part of your "
+"island using §a/island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§4* §7You can restart your island in §c{0} §7seconds."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr ""
+"§4* §7Your island is in the process of generating, you cannot restart now."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§4NOTE: §7Your entire island and all your belongings will be §4RESET!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "teleports you to the skyblock spawn"
+
+msgid "change the biome of the island"
+msgstr "change the biome of the island"
+
+msgid "exempt player from biome-cooldown"
+msgstr "§4* §7exempt player from biome-cooldown"
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr "§2* §7Let the player change their islands biome to {0}"
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr ""
+"§4* §7You do not have permission to change the biome of your current island."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4* §7You do not have permission to change the biome of this island!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§4* §7You must be on your island to change the biome!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr "§4* §7You have misspelled the biome name. Must be one of {0}"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§9* §7You can change your biome again in §c{0,number,#} §7minutes."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§4* §7You do not have permission to change your biome to that type."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+"§2* §7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr "§4* §7Invalid biome {0} supplied!"
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§9* §7You have changed your island''s biome to §a{0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "§2* §6{0} §7changed the island biome to §2{1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr "§2* §7You have changed §9{0} §7blocks around you to the §2{1} §7biome"
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr "§2* §7{0} created an area with §2{1} §7biome"
+
+msgid "set your island''s warp location"
+msgstr "set your island''s warp location"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§4* §7You do not have permission to set your island''s warp point!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§4* §7You need to be on your own island to set the warp!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§6{0}§7 changed the island warp location."
+
+msgid "teleports you to your island (or create one)"
+msgstr "teleports you to your island (or create one)"
+
+msgid "ban/unban a player from your island."
+msgstr "ban/unban a player from your island."
+
+msgid "exempts user from being banned"
+msgstr "§4* §7exempts user from being banned"
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr ""
+"§4* §7The following players are §4banned §7from warping to your island:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr ""
+"§9* §7To §4ban§7/§aunban §7from your island, use §a/island ban <player>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4* §7You can't ban members. §4Remove §7them first!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4* §7You do not have permission to kick/ban players."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§e* §7Unable to ban unknown player {0}"
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4* §7{0} tried to §4ban §7you from their island!"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4* §7{0} is exempt from being banned."
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§4* §7You have banned §4{0}§7 from warping to your island."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§4* §7You have been §4BANNED§7 from §6{0}''s §7island."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§9* §7You have §aunbanned §6{0} §7from warping to your island."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§9* §7You have been §aUNBANNED§7 from §6{0}''s §7island."
+
+msgid "display log"
+msgstr "display log"
+
+msgid "changes a members island-permissions"
+msgstr "changes a members island-permissions"
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr "§9* §7Permissions for §6{0}§7:"
+
+msgid "§aON"
+msgstr "§aON"
+
+msgid "§cOFF"
+msgstr "§cOFF"
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr "§7 - §6{0}§7 : {1}"
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr "§4* §7Invalid permission {0}. Must be one of {1}"
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr "§9* §7Toggled permission §9{0}§7 for §9{1}§7 to {2}"
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr "§4* §7Unable to toggle permission §9{0}§7 for §9{1}"
+
+msgid "set the island-home"
+msgstr "set the island-home"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "enable/disable warping to your island."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4* §7Your island is §4locked§7. You must §aunlock §7it before enabling your "
+"warp."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§6{0}§a activated §7the island warp."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr ""
+"§4* §7You do not have permission to §aenable§7/§4disable §7your island''s "
+"warp!"
+
+msgid "try to complete a challenge"
+msgstr "try to complete a challenge"
+
+msgid "show information about the challenge"
+msgstr "show information about the challenge"
+
+msgid "§eRank: "
+msgstr "§eRank: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4This Challenge is not repeatable!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr ""
+"§4* §7You will lose all required items when you complete this challenge!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4* §7All required items must be placed on your island, within §c{0} "
+"§7blocks of you."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§a* §7To complete this challenge, use §a/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4* §7Invalid challenge name! Use §a/c §7help for more information"
+
+msgid "§eSending you to spawn."
+msgstr "§9* §7Sending you to spawn."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§9* §7The island has been §4LOCKED§7."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4* §7Unable to find a safe home-location on your island!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§4* WARNING: §7Teleporting you to mid-air."
+
+msgid "§aTeleporting you to your island."
+msgstr "§9* §7Teleporting you to your island."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§9* §7You will be teleported in §4{0} §7seconds."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Unable to warp you to that player''s island!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§9* §7Teleporting you to §6{0}''s §7island."
+
+msgid "§7Teleport cancelled"
+msgstr "§4* §7Teleport cancelled"

--- a/uSkyBlock-Core/src/main/po/es.po
+++ b/uSkyBlock-Core/src/main/po/es.po
@@ -13,12 +13,45 @@ msgstr ""
 "Plural-Forms: X-Generator: Poedit 1.8.6;\n"
 "X-Generator: Poedit 1.8.6\n"
 
+msgid "d"
+msgstr "d"
+
+msgid "h"
+msgstr "h"
+
+msgid "m"
+msgstr "m"
+
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}"
+msgstr ""
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr ""
 
 #, java-format
 msgid "§eInvalid command: {0}"
+msgstr ""
+
+msgid "Command"
+msgstr ""
+
+msgid "Permission"
+msgstr ""
+
+msgid "Description"
 msgstr ""
 
 #, java-format
@@ -44,1683 +77,11 @@ msgstr ""
 msgid "§4Error writing documentation: {0}"
 msgstr ""
 
-msgid "Command"
+msgid "§cWither Despawned!§e It wandered too far from your island."
 msgstr ""
 
-msgid "Permission"
-msgstr ""
-
-msgid "Description"
-msgstr ""
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}"
-msgstr ""
-
-msgid "d"
-msgstr "d"
-
-msgid "h"
-msgstr "h"
-
-msgid "m"
-msgstr "m"
-
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eTodavía faltan los siguientes bloques: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§74Los requerimientos se reiniciarán en {0} días."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4Los requerimientos se reiniciarán en {0} horas."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4§4Los requerimientos se reiniciarán en {0} minutos."
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr ""
-
-msgid "§7and more..."
-msgstr ""
-
-msgid "§eItems will be traded for reward."
-msgstr ""
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr ""
-
-msgid "§6Item Reward: §a"
-msgstr "§6Recompensa de Items: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Recompensa de Dinero: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Recompensa de XP: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dCantidad de veces completado: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4¡Ningún reto llamado {0} fue encontrado!"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4¡Tienes que estar en tu isla para hacer eso!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr ""
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4¡El reto {0} no es repetible!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr ""
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr ""
-"§4Tienes que estar parado a menos de {0} bloques de todos los items "
-"requeridos."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4¡Tu isla tiene que ser nivel {0} para completar este reto!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Tipo de reto desconocido: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§eTodavía faltan las siguientes entidades:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eTodavía te faltan los siguientes items:{0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§a¡Has completado el reto {0}!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9¡{0}§1 ha completado el reto {1}!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§eRecompensa de Item(s): §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eRecompensa de XP: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eRecompensa de dinero: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eTu inventario está §4lleno§e. Los items fueron tirados al suelo."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lClick para completar este reto."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lNo puedes repetir este reto."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Rango: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fCompleta la mayoría de los retos en"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§feste rango para desbloquear el siguiente rango."
-
-msgid "§eClick here to show previous page"
-msgstr "§eClick aquí para mostrar la página anterior"
-
-msgid "§eClick here to show next page"
-msgstr "§eClick aquí para mostrar la siguiente página"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lReto bloqueado"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr ""
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Completa el reto {0}"
-
-msgid "to unlock this rank"
-msgstr "para desbloquear este rango"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "¡Pero estas solo!"
-
-msgid "But you are Yelling in the wind!"
-msgstr "¡Pero estas gritando al viento!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "¡Pero todos tus amigos de fantasía se fueron!"
-
-msgid "But you are Talking to your self!"
-msgstr "¡Pero te hablas a ti mismo!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§c¡Perdón! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr ""
-
-msgid "party"
-msgstr ""
-
-msgid "island"
-msgstr ""
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr ""
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr ""
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr ""
-
-msgid "§cCommand only available to players"
-msgstr ""
-
-msgid "talk to players on your island"
-msgstr "hablar a los jugadores de tu isla"
-
-msgid "talk to your island party"
-msgstr "hablar al grupo de tu isla"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§e¡El jugador {0} no tiene isla!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eJugador  {0} inválido."
-
-msgid "Manage challenges for a player"
-msgstr "Administrar retos para un jugador"
-
-msgid "resets the challenge for the player"
-msgstr "reinicia el reto para el jugador"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4El reto nunca ha sido completado"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§ereto: {0} ha sido reiniciado para {1}"
-
-msgid "resets all challenges for the player"
-msgstr "reinicia todos los retos para un jugador"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§eSe le han reiniciado todos los retos a {0} ."
-
-msgid "complete all challenges in the rank"
-msgstr ""
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4¡Ningún jugador llamado {0} fue encontrado!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr ""
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§§4¡Ningún reto llamado {0} fue encontrado!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr ""
-
-msgid "manage islands"
-msgstr "administra islas"
-
-msgid "protects the island"
-msgstr "proteje la isla"
-
-msgid "delete the island (removes the blocks)"
-msgstr "borra la isla (quita los bloques)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Isla abandonada borrada en tu ubicación actual."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"4¡La isla en esta ubicación tiene miembros!\n"
-"§eUsa §b/usb island delete <name>§e para borrarla."
-
-msgid "removes the player from the island"
-msgstr "quita a un jugador de la isla"
-
-msgid "adds the player to the island"
-msgstr "añade al jugador a la isla"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d se ha unido a tu grupo de isla."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4¡Ningún jugador llamado {0} fue encontrado!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-"§4No se proporcionó una isla válida, párate sobre una o proporciona el "
-"nombre de una isla."
-
-msgid "print out info about the island"
-msgstr "muestra información sobre la isla"
-
-msgid "sets the biome of the island"
-msgstr "establece el bioma de la isla"
-
-msgid "§4That player has no island."
-msgstr "§4Ese jugador no tiene isla."
-
-msgid "§4No valid island at your location"
-msgstr "§4No hay una isla válida en tu ubicación"
-
-msgid "purges the island"
-msgstr "purga la isla"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4¡Error! §9No se encontró isla válida para purgar."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cPURGA: §9Purgada isla en {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "alterna el estado de ignoración de la isla"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§aEstablecida la isla de {0} a ser ignorada en el top-ten y purgación."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§cYa no se ignora la isla de {0}, ahora se mostrará en el top-ten y en la "
-"purga."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Nombre de jugador inválido."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Quitando a {0} de la isla"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eCambiado el bioma de la isla de {0} a {1}"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eCambiado el bioma de la isla de {0} a OCÉANO."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr "§aQuízás tengas que ir al spawn, o reloguear, para notar los cambios."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§eSe cambió el bioma de la isla de {0} a {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§eSe cambió el bioma de la isla de {0} a OCÉANO."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eQuitando la isla de {0}"
-
-msgid "Error: That player does not have an island!"
-msgstr "Error: ¡Ese jugador no tiene una isla!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§eLa isla de {0} en {1} ha sido protegida."
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4La isla de {0} en {1} ya estaba protegida."
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "abrir el menú para configuración"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr ""
-
-msgid "Controls player-cooldowns"
-msgstr "Controla los cooldowns de jugadores"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "limpia el cooldown en un comando (* = todos)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eEl jugador no está actualmente conectado"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Limpiado el cooldown de {0} para {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "¡No hay cooldowns activos de {0} para {1} detectados!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Comando introducido inválido, ¡sólo restart y biome soportados!"
-
-msgid "restarts the cooldown on the command"
-msgstr "reinicia el cooldown en el comando"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eReiniciar el cooldown de {0} para {1}§e a {2} segundos"
-
-msgid "lists all the active cooldowns"
-msgstr "lista todos los cooldowns activos"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCmd Cooldown"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eNo se encontraron cooldowns activos para §9{0}§e."
-
-msgid "control debugging"
-msgstr "controlar la depuración"
-
-msgid "set debug-level"
-msgstr "establecer el nivel de depuración"
-
-msgid "toggle debug-logging"
-msgstr "alternar el registro de depuración"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4El registro no estaba activo, ¡por lo que no lo puedes deshabilitar!"
-
-msgid "flush current content of the logger to file."
-msgstr "pasar el actual contenido del registrador al archivo."
-
-msgid "§eLog-file has been flushed."
-msgstr "§eEl archivo de registro ha sido pasado."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4El registro no está activado, usa §d/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Argumento inválido, intenta INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§e¡Registro desactivado!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "intenta reparar un area de terreno plano."
-
-msgid "§4No valid island found"
-msgstr "§4No se encontró una isla válida"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4¡No se detecto terreno plano en la isla de {0}!"
-
-msgid "flushes all caches to files"
-msgstr "pasa todo el caché a archivos"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr "§ePasadas §a{0} islas§e, §b{1} jugadores y §6{2} retos completados."
-
-msgid "manually update the top 10 list"
-msgstr "actualiza manualmente la lista de top 10"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eGenerando la lista de Top Ten"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eFinalizada la generación de la lista de Top Ten"
-
-msgid "advanced command for getting island-data"
-msgstr ""
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr ""
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr ""
-
-msgid "teleport to another players island"
-msgstr "teletransportarse a la isla de otros jugadores"
-
-msgid "§4Only supported for players"
-msgstr "§4sólo soportado para jugadores"
-
-msgid "§4That player does not have an island!"
-msgstr "§4¡Ese jugador no tiene una isla!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr ""
-
-msgid "imports players and islands from other formats"
-msgstr "importa jugadores e islas de otros formatos"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Estadísticas de trabajos"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/trabajo"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "act"
-
-msgid "time"
-msgstr "tiempo"
-
-msgid "name"
-msgstr "nombre"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "cambia el lenguaje del plugin, y hace una recarga."
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aEl lenguaje ha sido satisfactoriamente cambiado a §e{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cFalló el cambio de lenguaje a §e{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Lenguajes soportados: \n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 por {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cIncapaz de localizar algún lenguaje."
-
-msgid "transfer leadership to another player"
-msgstr "transfiere el liderazgo a otro jugador"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4¡El jugador {0} no tiene isla que transferir!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§eEl jugador §d{0}§e ya tiene una isla. §eUsa §b/usb island remove "
-"<nombre>§e para quitarlo primero."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§dLiderazgo transferido por {0}§b a {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr ""
-
-msgid "shows the NBTTag for the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr ""
-
-msgid "§cNo item in hand!"
-msgstr ""
-
-msgid "§eCan only be executed as a player"
-msgstr ""
-
-msgid "sets the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "adds the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "manage orphans"
-msgstr "administrar islas huérfanos"
-
-msgid "count orphans"
-msgstr "contar islas huérfanas"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§e{0} localizaciones antiguas de islas serán usadas para islas nuevas."
-
-msgid "clear orphans"
-msgstr "limpiar islas huérfanas"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eLimpiando todas las localizaciones antiguas (vacías) de islas."
-
-msgid "list orphans"
-msgstr "listar las islas huérfanas"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eNo hay islas huérfanas actualmente registradas."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr ""
-
-msgid "protects all islands (time consuming)"
-msgstr "protege todas las islas (consume tiempo)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr ""
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§eComenzando una tarea de proteger-todo. Tomará un rato."
-
-msgid "purges all abandoned islands"
-msgstr "purga todas las islas abandonadas"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4¡Debes proporcionar la edad en días para purgar!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr ""
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr ""
-
-msgid "region manipulations"
-msgstr ""
-
-msgid "shows the borders of the current island"
-msgstr ""
-
-msgid "§eNo island found at your current location"
-msgstr ""
-
-msgid "shows the borders of the current chunk"
-msgstr ""
-
-msgid "shows the borders of the inner-chunks"
-msgstr ""
-
-msgid "shows the non-chunk-aligned borders"
-msgstr ""
-
-msgid "shows the borders of the outer-chunks"
-msgstr ""
-
-msgid "hides the regions again"
-msgstr ""
-
-msgid "§eStopped displaying regions"
-msgstr ""
-
-msgid "§eNo currently shown regions for this player"
-msgstr ""
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr ""
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr ""
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "establece la isla de un jugador a tu localización"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "recargar la configuración de archivo."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eConfiguración recargada de archivo."
-
-msgid "advanced command for setting island-data"
-msgstr ""
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr ""
-
-msgid "toggles maintenance mode"
-msgstr ""
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr ""
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr ""
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr ""
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr ""
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4PURGA:§9 Terminado de purgar las islas abandonadas."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr ""
-
-msgid "displays version information"
-msgstr "muestra información de la versión"
-
-msgid "various WorldGuard utilities"
-msgstr "varias utilidades de WorldGuard"
-
-msgid "refreshes the chunks around the player"
-msgstr "actualiza los chunks alrededor del jugador"
-
-msgid "§eResending chunks to the client"
-msgstr "§eReenviando los chunks al cliente"
-
-msgid "load the region chunks"
-msgstr "cargar los chunks de la region"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eCargando los chunks en {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eDescargando los chunks en {0}"
-
-msgid "update the WG regions"
-msgstr "actualiza las regiones de WG"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§eRegiones de isla de WorldGuard actualizadas para {0}"
-
-msgid "§eNo island found at your location!"
-msgstr "§eNo se encontro isla en tu localización!"
-
-msgid "refreshes the chunk around the player"
-msgstr ""
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "mostrar información del jugador"
-
-msgid "try to complete a challenge"
-msgstr ""
-
-msgid "§cCommand only available for players."
-msgstr ""
-
-msgid "show information about the challenge"
-msgstr ""
-
-msgid "§eRank: "
-msgstr "§eRango: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4¡Este reto no es repetible!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr "§4¡Perderás todos los items requeridos cuando completes este reto!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4Todos los items requeridos tienen que estar puestos en tu isla, dentro de "
-"un rango de {0} bloques alrededor tuyo."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§ePara completar este reto, usa §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4¡Nombre de reto inválido! Usa  §b/c help §b4 para más información."
-
-msgid "complete and list challenges"
-msgstr ""
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eLos retos han sido deshabilitados. Contacta un administrador."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4¡sólo puedes completar los retos en el mundo de islas!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4¡No puedes completar los retos si no tienes una isla!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4Tu isla está llena, o tienes muchas invitaciones pendientes. No puedes "
-"invitar a nadie más."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4Ese jugador ya es el líder de otra isla."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e intentó invitarte, pero ya estas en un grupo."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "§e¡§e{0}§e te ha invitado a unirse a su isla!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§bUsa /island [accept/reject]§e para aceptar o rechazar la invitación."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4ADVERTENCIA: ¡Perderás tu isla actual si aceptas!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d invitó a {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e ha rechazado la invitación."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4No puedes usar ese comando ahora mismo. Deja tu grupo actual primero."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§a¡Te has unido a una isla! Usa §b/island grupo§a para ver los otros "
-"miembros."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§eLa invitación para {0}§e ha vencido o ha sido cancelada."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§eLa invitación para la isla de {0} ha vencido o ha sido cancelada."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§eHas aceptado la invitación de unirte a una isla."
-
-msgid "§4You haven't been invited."
-msgstr "§4No has sido invitado."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eHas rechazado la invitación de unirte a una isla."
-
-msgid "accept/reject an invitation."
-msgstr "aceptar/rechazar una invitación."
-
-msgid "teleports you to your island (or create one)"
-msgstr ""
-
-msgid "ban/unban a player from your island."
-msgstr "bannea/desbannea a un jugador de tu isla."
-
-msgid "exempts user from being banned"
-msgstr ""
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr ""
-"§eLos siguientes jugadores estan banneados de teletransportarse a tu isla:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr ""
-"§ePara bannear/desbannear a alguien de tu isla, usa §b/island ban <player>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4No puedes bannear a miembros. ¡Quítalos primero!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4No tienes permiso para kickear/bannear jugadores."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr ""
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr ""
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eHas banneado a §4{0}§e de teletransportarse a tu isla."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eHas sido §cBANNEADO§e de la isla de {0}§e."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§eHas desbanneado a §a{0}§e de teletransportarse a tu isla."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eHas sido §aDESBANNEADO§e de la isla de {0}§e"
-
-msgid "change the biome of the island"
-msgstr "cambia el bioma de la isla"
-
-msgid "exempt player from biome-cooldown"
-msgstr ""
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr ""
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr "§cNo tienes permiso para cambiar el bioma de esa isla."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4¡No tienes permiso para cambiar el bioma de tu isla!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§e¡Debes estar en tu isla para cambiar el bioma!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr ""
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§ePodrás cambiar el bioma de tu isla de nuevo en {0,number,#} minutos."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§No tienes permiso para cambiar a ese bioma."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr ""
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aHas cambiado el bioma de tu isla a {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} cambio el bioma de la isla a {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr ""
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr ""
-
-msgid "create an island"
-msgstr "crear una isla"
-
-msgid "exempt player from create-cooldown"
-msgstr ""
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4¡Isla encontrada!§e Ya tienes una isla. Si quieres una isla nueva, escribe "
-"§b/is restart§e para obetener una"
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4¡Isla encontrada!§e Ya eres miembro de una isla. Para empezar por tu "
-"cuenta, primero usa §b/is leave"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§ePodrás crear una nueva isla en {0,number,#} segundos."
-
-msgid "teleport to the island home"
-msgstr "teletransportarse a tu isla"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§cTu isla está en proceso de generación, no puedes teletransportarte a ella "
-"ahora."
-
-msgid "check your or another''s island info"
-msgstr "verifica información de tu isla o la de otros"
-
-msgid "allows user to see others island info"
-msgstr ""
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4El nivel de isla ha sido deshabilitado, contacta un administrador."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eTienes que estar en tu isla para usar este comando."
-
-msgid "§4You do not have an island!"
-msgstr "§4¡No tienes una isla!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4¡No tienes acceso a ese comando!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4¡Ese jugador es inválido o no tiene una isla!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBloques en la isla de {0} (página {1,number} de {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Recuento de Puntuación de Bloques"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aEl nivel de tu isla es {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "invitar a un jugador a tu isla"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§eUsa§b /island invite <nombre del jugador>§e para invitar a un jugador a tu "
-"isla."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4¡sólo el dueño de la isla puede invitar!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aPuedes invitar a {0} jugadores más."
-
-msgid "§4You can't invite any more players."
-msgstr "§4No puedes invitar a más jugadores."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4¡No tienes permiso para invitar a otros a esta isla!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4Ese jugador no está conectado o no existe."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4¡No puedes invitarte a ti mismo!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4¡Ese jugador es el líder de tu isla!"
-
-msgid "remove a member from your island."
-msgstr "quita a un miembro de tu isla"
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4¡No tienes permiso para echar a otros de esta isla!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4¡No puedes quitar al líder de la isla!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4¡No puedes echarte a ti mismo!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4¡{0} te ha quitado de su isla!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} ha sido quitado de la isla."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr ""
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0} ha sido echado de la isla."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr "§4¡Ese jugador no es parte del grupo de tu isla, ni está en tu isla!"
-
-msgid "leave your party"
-msgstr "dejar tu grupo"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4No puedes dejar tu isla si eres la única persona en ella. ¡Usa §b/island "
-"restart§4 si quieres una nueva!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr ""
-"§eTu eres el dueño de esta isla, usa en cambio §b/island remove <player>§e."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eHas dejado la isla y vuelto al spawn."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4¡{0} ha dejado tu isla!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4¡Tienes que estar en el mundo de islas para dejar tu grupo!"
-
-msgid "check your or anothers island level"
-msgstr "verifica el nivel de tu isla o la de otros"
-
-msgid "allows user to query for others levels"
-msgstr ""
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eInformación sobre la isla de {0}:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr ""
-"§9Tu posición en el Top es {0} §7(Puede no estar actualizado, usa /is top)"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "bloquea tu isla a los no miembros de tu grupo"
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4¡No tienes permiso para bloquear tu isla!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4¡No tienes acceso a este comando!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4¡No tienes permiso para desbloquear tu isla!"
-
-msgid "display log"
-msgstr "muestra el registro"
-
-msgid "transfer leadership to another member"
-msgstr "transfiere el liderazgo a otro jugador"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr ""
-"§4¡sólo puedes transferir la propiedad de la isla a los miembros de tu grupo!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "§e¡§r{0}§e ya es el líder de tu isla!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4¡sólo el líder puede transferir su liderazgo!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "¡{0} intentó tomar el control de la isla!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "muestra información de el grupo"
-
-msgid "shows information about your party"
-msgstr "muestra información sobre tu grupo"
-
-msgid "show pending invites"
-msgstr "muestra las invitaciones pendientes"
-
-msgid "§eNo pending invites"
-msgstr "§eNo hay invitaciones pendientes"
-
-msgid "withdraw an invite"
-msgstr "retira una invitación"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4No tienes permiso para des-invitar jugadores."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4Este comando sólo puede ser ejecutado por un jugador"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4¡No tienes isla! §eUsa §b/is create§e para obtener una"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "borra tu isla y empieza una nueva."
-
-msgid "exempt player from restart-cooldown"
-msgstr ""
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4sólo el dueño puede reiniciar esta isla. Para empezar una por tu cuenta "
-"deja esta isla (§b/island leave§4)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eDebes quitar a todos los jugadores de tu isla antes de que puedas "
-"reiniciarla (§b/island kick <player>§e). Mira una lista de los jugadores que "
-"actualmente son parte de tu isla con §b/island grupo§e."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§ePodrás reiniciar tu isla en {0} segundos."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§cTu isla está en proceso de generación, no puedes reiniciar ahora."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eNOTA: ¡Tu isla entera y todas tus pertenencias se reiniciarán!"
-
-msgid "set the island-home"
-msgstr "establece el hogar de la isla"
-
-msgid "set your island''s warp location"
-msgstr "establece la localización del teletransporte de la isla"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§c¡No tienes el permiso para establecer el teletransporte de tu isla!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr ""
-"§c¡Necesitas estar en tu propia isla para establecer el teletransporte!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d cambió la ubicación del teletransporte de la isla."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "te teletransporta al spawn"
-
-msgid "enable/disable warping to your island."
-msgstr "habilita/deshabilita el teletransporte de tu isla."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4Tu isla está bloqueada. Debes desbloquearla antes de activar el "
-"teletransporte."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d activó el teletransporte de la isla."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d desactivó el teletransporte de la isla."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr ""
-
-msgid "display the top10 of islands"
-msgstr "muestra el Top 10 de islas"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr ""
-
-msgid "trust/untrust a player to help on your island."
-msgstr "confía/desconfía en un jugador para ayudar en tu isla."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eLos siguientes jugadores están confiados en tu isla:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eLos siguientes lideres confían en ti en sus islas:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr ""
-"§ePara confiar/desconfiar en alguien para construir en tu isla, usa §b/"
-"island trust <jugador>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4¡Los miembros ya estan confiados en la isla!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Jugador desconocido {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eAhora estás confiado en la isla de §4{0}§e."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} confió en {1} para construir en la isla"
-
 #, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eYa no estas confiado en la isla de §4{0}§e."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0} quitó la confianza de {1} en la isla"
-
-msgid "warp to another player''s island"
-msgstr "teletransportarse a la isla de otro jugador"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr ""
-"§aTu teletransporte está activo, cualquier jugador puede teletransportarse a "
-"tu isla."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§4Tu teletransporte está inactivo, los jugadores no se teletransportarán a "
-"tu isla."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr ""
-"§fEstablece el punto de teletransporte a tu actual ubicación usando §b/"
-"island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr ""
-"§fEnciende/apaga el teletransporte de tu isla usando §b/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4¡No tienes permiso para crear un teletransporte en tu isla!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§fUsa el teletransporte de otra isla con §b/island warp <jugador>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4¡No tienes permiso para usar el teletransporte de otra isla!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§cTu isla está en proceso de generación, no puedes usar el teletransporte de "
-"otras islas ahora."
-
-msgid "§4That player does not exist!"
-msgstr "§4¡Ese jugador no existe!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4Ese jugador no tiene un teletransporte activo."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§cLa isla de ese jugador está en proceso de generación, no puedes "
-"teletransportarte a ella ahora."
-
-#, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cADVERTENCIA: §e¡§9{0}§e ha usado el teletransporte a tu isla!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4Ese jugador te prohibió el uso del teletransporte de su isla."
-
-msgid "general island command"
-msgstr "comando de isla general"
-
-msgid "allows user to bypass cooldowns"
-msgstr ""
-
-msgid "allows user to bypass visitor-protections"
-msgstr ""
-
-msgid "allows user to bypass teleport-delay"
-msgstr ""
-
-msgid "allows user to use [usb] signs"
-msgstr ""
-
-msgid "allows user to place [usb] signs"
+msgid "{0}''s Wither"
 msgstr ""
 
 msgid "§eYou can not use another island''s portals!"
@@ -1737,33 +98,6 @@ msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr ""
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr ""
-
-msgid "§eVisitors can't drop items!"
-msgstr "§e¡Los visitantes no pueden tirar ítems!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Dueño: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "¡No puedes recoger los ítems de otra isla cuando eres un visitante!"
-
-msgid "Config:"
-msgstr "Configuración:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§c¡No tienes acceso! §eEstás intentando teletransportarte al techo del "
-"§cINFIERNO§e, eso no está permitido."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr ""
@@ -1807,19 +141,82 @@ msgstr "§4¡sólo puedes usar huevos de spawn en tu propia isla!"
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§eHas alcanzado tu límite de spawn para tu isla."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§e¡Los visitantes no pueden tirar ítems!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Dueño: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "¡No puedes recoger los ítems de otra isla cuando eres un visitante!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cBanneado: §eEstás banneado de esta isla."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cBloqueo:§e Esa isla está bloqueada! No se permite la entrada."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eEsperando nuestro turno §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "¡Algo salió mal al guardar la isla y/o los datos del grupo!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr ""
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr ""
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Creando isla...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr ""
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr ""
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4¡Ese jugador ya tiene una isla asignada!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr ""
+"§4¡Tienes que estar más cerca de tu isla para establecer el punto de hogar!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aEl hogar de tu isla ha sido establecido a tu ubicación actual."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4La actual localización de tu hogar no es segura."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr "§cTu isla está en proceso de generación, no puedes crear ahora."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "No se pudo crear tu isla. Por favor contacta con alguien del staff."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+"§eDejando tu isla lista, por favor sé paciente, esto puede tomar un rato."
+
+msgid "§cCommand is currently disabled!"
+msgstr ""
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eTodavía faltan los siguientes bloques: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1832,9 +229,6 @@ msgid ""
 msgstr ""
 "§eHacer §9{0}§e es §cARRIESGADO§e. ¡Repite el comando antes de §a{1}§e "
 "segundos para aceptar!"
-
-msgid "N/A"
-msgstr ""
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** Estás entrando al área de una protegida - pero abandonada - isla."
@@ -1868,210 +262,32 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4¡Tienes que ser el líder de tu grupo para desbloquear tu isla!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eEsperando nuestro turno §c{0,number,###}%"
+
+#, java-format
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Creando isla...§e{0,number,###}%"
+
+msgid "N/A"
+msgstr ""
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lReto bloqueado"
+
+msgid "READY"
 msgstr ""
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr ""
-
-#, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr ""
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr ""
-
-msgid "SUCCESS"
-msgstr ""
-
-msgid "FAILED"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4No se encontró importador llamado §e{0}§4"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr ""
-
-msgid "The island has been created."
-msgstr "La isla ha sido creada"
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d bloqueó la isla."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§4Como tu isla está bloqueada, tu teletransporte ha sido desactivado."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d desbloqueó la isla."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cSkyBlock §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§4{0}§4 ha sido quitado del grupo de la isla."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr ""
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
+msgid "§4The {0} challenge is not available yet!"
 msgstr ""
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
-msgstr ""
-"§c¡La isla que tenía esta pieza del nether está siendo borrada! Has sido "
-"enviado al spawn."
-
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr ""
-"§c¡La isla en la que estabas está siendo borrada! Has sido enviado al spawn."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eTop de Islas (página {0} de {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
 
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eTu posición es: §f{0}"
-
-msgid "UNKNOWN"
+msgid "§cNot enough items in chest to complete challenge!"
 msgstr ""
-
-msgid "ANIMAL"
-msgstr ""
-
-msgid "MONSTER"
-msgstr ""
-
-msgid "VILLAGER"
-msgstr ""
-
-msgid "GOLEM"
-msgstr ""
-
-#, java-format
-msgid "§c{0}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr ""
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr ""
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aEnhorabuena! §eTu isla ha aparecido!"
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cNota:§e Es posible que la construcción siga en proceso."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Usa §9/is h§r o el menú de §9/is§r para ir allí."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§9Incapaz de localizar un cofre en {0} bloques."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr ""
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr ""
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr ""
-
-msgid "Return"
-msgstr "Volver"
-
-msgid "§9Integer Editor"
-msgstr "§9Editor de Enteros"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eConfiguración guardada y recargada."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cError! §9Incapaz de guardar el archivo de configuración!"
-
-msgid "§3First Page"
-msgstr ""
-
-msgid "§3Last Page"
-msgstr ""
-
-msgid "§cSave & Reload config"
-msgstr "§cGuarda & Recarga la configuración"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Guarda los ajustes a\n"
-"§7un archivo & recarga.\n"
-"§cNota: §7Usar con cuidado!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (sólo lectura)"
 
 msgid "true"
 msgstr "verdadero"
@@ -2507,6 +723,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr ""
 
+#, java-format
+msgid "§7Page {0}"
+msgstr ""
+
 msgid "§7First Page"
 msgstr ""
 
@@ -2800,8 +1020,8 @@ msgstr ""
 msgid "Island Restart Menu"
 msgstr ""
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr ""
+msgid "Config:"
+msgstr "Configuración:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2817,112 +1037,117 @@ msgstr ""
 msgid "§aClick to restart!"
 msgstr ""
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr ""
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr ""
+
+msgid "Return"
+msgstr "Volver"
+
+msgid "§9Integer Editor"
+msgstr "§9Editor de Enteros"
+
 msgid "Caps On"
 msgstr "Mayúsculas Encendidas"
 
 msgid "§9Text Editor"
 msgstr "§9Editor de Texto"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eConfiguración guardada y recargada."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cError! §9Incapaz de guardar el archivo de configuración!"
+
+msgid "§3First Page"
+msgstr ""
+
+msgid "§3Last Page"
+msgstr ""
+
+msgid "§cSave & Reload config"
+msgstr "§cGuarda & Recarga la configuración"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Guarda los ajustes a\n"
+"§7un archivo & recarga.\n"
+"§cNota: §7Usar con cuidado!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (sólo lectura)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4No se encontró importador llamado §e{0}§4"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr ""
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr ""
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr ""
+
+msgid "SUCCESS"
+msgstr ""
+
+msgid "FAILED"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr ""
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
-msgstr ""
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§eEnviándote al spawn."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr ""
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aSerás teletransportado en {0} segundos."
-
-msgid "§7Teleport cancelled"
-msgstr ""
-
-msgid "READY"
-msgstr ""
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr ""
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "¡Algo salió mal al guardar la isla y/o los datos del grupo!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr ""
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr ""
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr ""
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4¡Ese jugador ya tiene una isla asignada!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr ""
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr ""
-
-msgid "§aTeleporting you to your island."
-msgstr "§aTeletransportándote a tu isla."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4¡Incapaz de teletransportarte a la isla de ese jugador!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aTeletransportándote a la isla de {0}§a."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr ""
-"§4¡Tienes que estar más cerca de tu isla para establecer el punto de hogar!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aEl hogar de tu isla ha sido establecido a tu ubicación actual."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4La actual localización de tu hogar no es segura."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cTu isla está en proceso de generación, no puedes crear ahora."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "No se pudo crear tu isla. Por favor contacta con alguien del staff."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-"§eDejando tu isla lista, por favor sé paciente, esto puede tomar un rato."
-
-msgid "§cCommand is currently disabled!"
 msgstr ""
 
 msgid "North"
@@ -2947,4 +1172,1775 @@ msgid "West"
 msgstr ""
 
 msgid "North-West"
+msgstr ""
+
+msgid "The island has been created."
+msgstr "La isla ha sido creada"
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d bloqueó la isla."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§4Como tu isla está bloqueada, tu teletransporte ha sido desactivado."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d desactivó el teletransporte de la isla."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d desbloqueó la isla."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cSkyBlock §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§4{0}§4 ha sido quitado del grupo de la isla."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr ""
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr ""
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aEnhorabuena! §eTu isla ha aparecido!"
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cNota:§e Es posible que la construcción siga en proceso."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Usa §9/is h§r o el menú de §9/is§r para ir allí."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr ""
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§9Incapaz de localizar un cofre en {0} bloques."
+
+msgid "UNKNOWN"
+msgstr ""
+
+msgid "ANIMAL"
+msgstr ""
+
+msgid "MONSTER"
+msgstr ""
+
+msgid "VILLAGER"
+msgstr ""
+
+msgid "GOLEM"
+msgstr ""
+
+#, java-format
+msgid "§c{0}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr ""
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§c¡La isla que tenía esta pieza del nether está siendo borrada! Has sido "
+"enviado al spawn."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr ""
+"§c¡La isla en la que estabas está siendo borrada! Has sido enviado al spawn."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eTop de Islas (página {0} de {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr ""
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4El nivel de isla ha sido deshabilitado, contacta un administrador."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eTu posición es: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr ""
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Completa el reto {0}"
+
+msgid "to unlock this rank"
+msgstr "para desbloquear este rango"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§74Los requerimientos se reiniciarán en {0} días."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Los requerimientos se reiniciarán en {0} horas."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4§4Los requerimientos se reiniciarán en {0} minutos."
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr ""
+
+msgid "§7and more..."
+msgstr ""
+
+msgid "§eItems will be traded for reward."
+msgstr ""
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr ""
+
+msgid "§6Item Reward: §a"
+msgstr "§6Recompensa de Items: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Recompensa de Dinero: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Recompensa de XP: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dCantidad de veces completado: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4¡Ningún reto llamado {0} fue encontrado!"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4¡Tienes que estar en tu isla para hacer eso!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4¡El reto {0} no es repetible!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr ""
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr ""
+"§4Tienes que estar parado a menos de {0} bloques de todos los items "
+"requeridos."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4¡Tu isla tiene que ser nivel {0} para completar este reto!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Tipo de reto desconocido: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§eTodavía faltan las siguientes entidades:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eTodavía te faltan los siguientes items:{0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§a¡Has completado el reto {0}!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9¡{0}§1 ha completado el reto {1}!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§eRecompensa de Item(s): §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eRecompensa de XP: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eRecompensa de dinero: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eTu inventario está §4lleno§e. Los items fueron tirados al suelo."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lClick para completar este reto."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lNo puedes repetir este reto."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Rango: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fCompleta la mayoría de los retos en"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§feste rango para desbloquear el siguiente rango."
+
+msgid "§eClick here to show previous page"
+msgstr "§eClick aquí para mostrar la página anterior"
+
+msgid "§eClick here to show next page"
+msgstr "§eClick aquí para mostrar la siguiente página"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "¡Pero estas solo!"
+
+msgid "But you are Yelling in the wind!"
+msgstr "¡Pero estas gritando al viento!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "¡Pero todos tus amigos de fantasía se fueron!"
+
+msgid "But you are Talking to your self!"
+msgstr "¡Pero te hablas a ti mismo!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§c¡Perdón! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr ""
+
+msgid "party"
+msgstr ""
+
+msgid "island"
+msgstr ""
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr ""
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr ""
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr ""
+
+msgid "§cCommand only available to players"
+msgstr ""
+
+msgid "talk to your island party"
+msgstr "hablar al grupo de tu isla"
+
+msgid "talk to players on your island"
+msgstr "hablar a los jugadores de tu isla"
+
+msgid "manually update the top 10 list"
+msgstr "actualiza manualmente la lista de top 10"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eGenerando la lista de Top Ten"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eFinalizada la generación de la lista de Top Ten"
+
+msgid "purges all abandoned islands"
+msgstr "purga todas las islas abandonadas"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4¡Debes proporcionar la edad en días para purgar!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr ""
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr ""
+
+msgid "Controls player-cooldowns"
+msgstr "Controla los cooldowns de jugadores"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "limpia el cooldown en un comando (* = todos)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eEl jugador no está actualmente conectado"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Limpiado el cooldown de {0} para {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "¡No hay cooldowns activos de {0} para {1} detectados!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Comando introducido inválido, ¡sólo restart y biome soportados!"
+
+msgid "restarts the cooldown on the command"
+msgstr "reinicia el cooldown en el comando"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eReiniciar el cooldown de {0} para {1}§e a {2} segundos"
+
+msgid "lists all the active cooldowns"
+msgstr "lista todos los cooldowns activos"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCmd Cooldown"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eNo se encontraron cooldowns activos para §9{0}§e."
+
+msgid "toggles maintenance mode"
+msgstr ""
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr ""
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Estadísticas de trabajos"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/trabajo"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "act"
+
+msgid "time"
+msgstr "tiempo"
+
+msgid "name"
+msgstr "nombre"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§e¡El jugador {0} no tiene isla!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eJugador  {0} inválido."
+
+msgid "flushes all caches to files"
+msgstr "pasa todo el caché a archivos"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr "§ePasadas §a{0} islas§e, §b{1} jugadores y §6{2} retos completados."
+
+msgid "tries to fix the the area of flatland."
+msgstr "intenta reparar un area de terreno plano."
+
+msgid "§4No valid island found"
+msgstr "§4No se encontró una isla válida"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4¡No se detecto terreno plano en la isla de {0}!"
+
+msgid "manage orphans"
+msgstr "administrar islas huérfanos"
+
+msgid "count orphans"
+msgstr "contar islas huérfanas"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§e{0} localizaciones antiguas de islas serán usadas para islas nuevas."
+
+msgid "clear orphans"
+msgstr "limpiar islas huérfanas"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eLimpiando todas las localizaciones antiguas (vacías) de islas."
+
+msgid "list orphans"
+msgstr "listar las islas huérfanas"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eNo hay islas huérfanas actualmente registradas."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "transfiere el liderazgo a otro jugador"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4¡El jugador {0} no tiene isla que transferir!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eEl jugador §d{0}§e ya tiene una isla. §eUsa §b/usb island remove "
+"<nombre>§e para quitarlo primero."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§dLiderazgo transferido por {0}§b a {1}"
+
+msgid "open GUI for config"
+msgstr "abrir el menú para configuración"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr ""
+
+msgid "teleport to another players island"
+msgstr "teletransportarse a la isla de otros jugadores"
+
+msgid "§4Only supported for players"
+msgstr "§4sólo soportado para jugadores"
+
+msgid "§4That player does not have an island!"
+msgstr "§4¡Ese jugador no tiene una isla!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr ""
+
+msgid "various WorldGuard utilities"
+msgstr "varias utilidades de WorldGuard"
+
+msgid "refreshes the chunks around the player"
+msgstr "actualiza los chunks alrededor del jugador"
+
+msgid "§eResending chunks to the client"
+msgstr "§eReenviando los chunks al cliente"
+
+msgid "load the region chunks"
+msgstr "cargar los chunks de la region"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eCargando los chunks en {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eDescargando los chunks en {0}"
+
+msgid "update the WG regions"
+msgstr "actualiza las regiones de WG"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§eRegiones de isla de WorldGuard actualizadas para {0}"
+
+msgid "§eNo island found at your location!"
+msgstr "§eNo se encontro isla en tu localización!"
+
+msgid "refreshes the chunk around the player"
+msgstr ""
+
+msgid "region manipulations"
+msgstr ""
+
+msgid "shows the borders of the current island"
+msgstr ""
+
+msgid "§eNo island found at your current location"
+msgstr ""
+
+msgid "§eCan only be executed as a player"
+msgstr ""
+
+msgid "shows the borders of the current chunk"
+msgstr ""
+
+msgid "shows the borders of the inner-chunks"
+msgstr ""
+
+msgid "shows the non-chunk-aligned borders"
+msgstr ""
+
+msgid "shows the borders of the outer-chunks"
+msgstr ""
+
+msgid "hides the regions again"
+msgstr ""
+
+msgid "§eStopped displaying regions"
+msgstr ""
+
+msgid "§eNo currently shown regions for this player"
+msgstr ""
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr ""
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr ""
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4PURGA:§9 Terminado de purgar las islas abandonadas."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr ""
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr ""
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr ""
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr ""
+
+msgid "control debugging"
+msgstr "controlar la depuración"
+
+msgid "set debug-level"
+msgstr "establecer el nivel de depuración"
+
+msgid "toggle debug-logging"
+msgstr "alternar el registro de depuración"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4El registro no estaba activo, ¡por lo que no lo puedes deshabilitar!"
+
+msgid "flush current content of the logger to file."
+msgstr "pasar el actual contenido del registrador al archivo."
+
+msgid "§eLog-file has been flushed."
+msgstr "§eEl archivo de registro ha sido pasado."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4El registro no está activado, usa §d/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Argumento inválido, intenta INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§e¡Registro desactivado!"
+
+msgid "advanced command for setting island-data"
+msgstr ""
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr ""
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr ""
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr ""
+
+msgid "set a player''s island to your location"
+msgstr "establece la isla de un jugador a tu localización"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr ""
+
+msgid "shows the NBTTag for the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr ""
+
+msgid "§cNo item in hand!"
+msgstr ""
+
+msgid "sets the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "adds the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "Manage challenges for a player"
+msgstr "Administrar retos para un jugador"
+
+msgid "resets the challenge for the player"
+msgstr "reinicia el reto para el jugador"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4El reto nunca ha sido completado"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§ereto: {0} ha sido reiniciado para {1}"
+
+msgid "resets all challenges for the player"
+msgstr "reinicia todos los retos para un jugador"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§eSe le han reiniciado todos los retos a {0} ."
+
+msgid "complete all challenges in the rank"
+msgstr ""
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4¡Ningún jugador llamado {0} fue encontrado!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr ""
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§§4¡Ningún reto llamado {0} fue encontrado!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr ""
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "protege todas las islas (consume tiempo)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr ""
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§eComenzando una tarea de proteger-todo. Tomará un rato."
+
+msgid "reload configuration from file."
+msgstr "recargar la configuración de archivo."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eConfiguración recargada de archivo."
+
+msgid "manage islands"
+msgstr "administra islas"
+
+msgid "protects the island"
+msgstr "proteje la isla"
+
+msgid "delete the island (removes the blocks)"
+msgstr "borra la isla (quita los bloques)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Isla abandonada borrada en tu ubicación actual."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"4¡La isla en esta ubicación tiene miembros!\n"
+"§eUsa §b/usb island delete <name>§e para borrarla."
+
+msgid "removes the player from the island"
+msgstr "quita a un jugador de la isla"
+
+msgid "adds the player to the island"
+msgstr "añade al jugador a la isla"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d se ha unido a tu grupo de isla."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4¡Ningún jugador llamado {0} fue encontrado!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+"§4No se proporcionó una isla válida, párate sobre una o proporciona el "
+"nombre de una isla."
+
+msgid "print out info about the island"
+msgstr "muestra información sobre la isla"
+
+msgid "sets the biome of the island"
+msgstr "establece el bioma de la isla"
+
+msgid "§4That player has no island."
+msgstr "§4Ese jugador no tiene isla."
+
+msgid "§4No valid island at your location"
+msgstr "§4No hay una isla válida en tu ubicación"
+
+msgid "purges the island"
+msgstr "purga la isla"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4¡Error! §9No se encontró isla válida para purgar."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cPURGA: §9Purgada isla en {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "alterna el estado de ignoración de la isla"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§aEstablecida la isla de {0} a ser ignorada en el top-ten y purgación."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cYa no se ignora la isla de {0}, ahora se mostrará en el top-ten y en la "
+"purga."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Nombre de jugador inválido."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Quitando a {0} de la isla"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eCambiado el bioma de la isla de {0} a {1}"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eCambiado el bioma de la isla de {0} a OCÉANO."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr "§aQuízás tengas que ir al spawn, o reloguear, para notar los cambios."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§eSe cambió el bioma de la isla de {0} a {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§eSe cambió el bioma de la isla de {0} a OCÉANO."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eQuitando la isla de {0}"
+
+msgid "Error: That player does not have an island!"
+msgstr "Error: ¡Ese jugador no tiene una isla!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§eLa isla de {0} en {1} ha sido protegida."
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4La isla de {0} en {1} ya estaba protegida."
+
+msgid "displays version information"
+msgstr "muestra información de la versión"
+
+msgid "imports players and islands from other formats"
+msgstr "importa jugadores e islas de otros formatos"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr ""
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "cambia el lenguaje del plugin, y hace una recarga."
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aEl lenguaje ha sido satisfactoriamente cambiado a §e{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cFalló el cambio de lenguaje a §e{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Lenguajes soportados: \n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 por {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cIncapaz de localizar algún lenguaje."
+
+msgid "advanced command for getting island-data"
+msgstr ""
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "mostrar información del jugador"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4Tu isla está llena, o tienes muchas invitaciones pendientes. No puedes "
+"invitar a nadie más."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4Ese jugador ya es el líder de otra isla."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e intentó invitarte, pero ya estas en un grupo."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "§e¡§e{0}§e te ha invitado a unirse a su isla!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§bUsa /island [accept/reject]§e para aceptar o rechazar la invitación."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4ADVERTENCIA: ¡Perderás tu isla actual si aceptas!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d invitó a {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e ha rechazado la invitación."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4No puedes usar ese comando ahora mismo. Deja tu grupo actual primero."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§a¡Te has unido a una isla! Usa §b/island grupo§a para ver los otros "
+"miembros."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§eLa invitación para {0}§e ha vencido o ha sido cancelada."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§eLa invitación para la isla de {0} ha vencido o ha sido cancelada."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§eHas aceptado la invitación de unirte a una isla."
+
+msgid "§4You haven't been invited."
+msgstr "§4No has sido invitado."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eHas rechazado la invitación de unirte a una isla."
+
+msgid "general island command"
+msgstr "comando de isla general"
+
+msgid "allows user to bypass cooldowns"
+msgstr ""
+
+msgid "allows user to bypass visitor-protections"
+msgstr ""
+
+msgid "allows user to bypass teleport-delay"
+msgstr ""
+
+msgid "allows user to use [usb] signs"
+msgstr ""
+
+msgid "allows user to place [usb] signs"
+msgstr ""
+
+msgid "complete and list challenges"
+msgstr ""
+
+msgid "§cCommand only available for players."
+msgstr ""
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eLos retos han sido deshabilitados. Contacta un administrador."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4¡sólo puedes completar los retos en el mundo de islas!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4¡No puedes completar los retos si no tienes una isla!"
+
+msgid "warp to another player''s island"
+msgstr "teletransportarse a la isla de otro jugador"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr ""
+"§aTu teletransporte está activo, cualquier jugador puede teletransportarse a "
+"tu isla."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§4Tu teletransporte está inactivo, los jugadores no se teletransportarán a "
+"tu isla."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr ""
+"§fEstablece el punto de teletransporte a tu actual ubicación usando §b/"
+"island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr ""
+"§fEnciende/apaga el teletransporte de tu isla usando §b/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4¡No tienes permiso para crear un teletransporte en tu isla!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§fUsa el teletransporte de otra isla con §b/island warp <jugador>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4¡No tienes permiso para usar el teletransporte de otra isla!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cTu isla está en proceso de generación, no puedes usar el teletransporte de "
+"otras islas ahora."
+
+msgid "§4That player does not exist!"
+msgstr "§4¡Ese jugador no existe!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4Ese jugador no tiene un teletransporte activo."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§cLa isla de ese jugador está en proceso de generación, no puedes "
+"teletransportarte a ella ahora."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cADVERTENCIA: §e¡§9{0}§e ha usado el teletransporte a tu isla!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4Ese jugador te prohibió el uso del teletransporte de su isla."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4¡No tienes isla! §eUsa §b/is create§e para obtener una"
+
+msgid "accept/reject an invitation."
+msgstr "aceptar/rechazar una invitación."
+
+msgid "leave your party"
+msgstr "dejar tu grupo"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4No puedes dejar tu isla si eres la única persona en ella. ¡Usa §b/island "
+"restart§4 si quieres una nueva!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr ""
+"§eTu eres el dueño de esta isla, usa en cambio §b/island remove <player>§e."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eHas dejado la isla y vuelto al spawn."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4¡{0} ha dejado tu isla!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4¡Tienes que estar en el mundo de islas para dejar tu grupo!"
+
+msgid "check your or anothers island level"
+msgstr "verifica el nivel de tu isla o la de otros"
+
+msgid "allows user to query for others levels"
+msgstr ""
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eTienes que estar en tu isla para usar este comando."
+
+msgid "§4You do not have an island!"
+msgstr "§4¡No tienes una isla!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4¡No tienes acceso a ese comando!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4¡Ese jugador es inválido o no tiene una isla!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eInformación sobre la isla de {0}:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aEl nivel de tu isla es {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr ""
+"§9Tu posición en el Top es {0} §7(Puede no estar actualizado, usa /is top)"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "crear una isla"
+
+msgid "exempt player from create-cooldown"
+msgstr ""
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4¡Isla encontrada!§e Ya tienes una isla. Si quieres una isla nueva, escribe "
+"§b/is restart§e para obetener una"
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4¡Isla encontrada!§e Ya eres miembro de una isla. Para empezar por tu "
+"cuenta, primero usa §b/is leave"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§ePodrás crear una nueva isla en {0,number,#} segundos."
+
+msgid "invite a player to your island"
+msgstr "invitar a un jugador a tu isla"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§eUsa§b /island invite <nombre del jugador>§e para invitar a un jugador a tu "
+"isla."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4¡sólo el dueño de la isla puede invitar!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aPuedes invitar a {0} jugadores más."
+
+msgid "§4You can't invite any more players."
+msgstr "§4No puedes invitar a más jugadores."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4¡No tienes permiso para invitar a otros a esta isla!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4Ese jugador no está conectado o no existe."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4¡No puedes invitarte a ti mismo!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4¡Ese jugador es el líder de tu isla!"
+
+msgid "lock your island to non-party members."
+msgstr "bloquea tu isla a los no miembros de tu grupo"
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4¡No tienes permiso para bloquear tu isla!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4¡No tienes acceso a este comando!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4¡No tienes permiso para desbloquear tu isla!"
+
+msgid "display the top10 of islands"
+msgstr "muestra el Top 10 de islas"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr ""
+
+msgid "remove a member from your island."
+msgstr "quita a un miembro de tu isla"
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4¡No tienes permiso para echar a otros de esta isla!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4¡No puedes quitar al líder de la isla!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4¡No puedes echarte a ti mismo!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4¡{0} te ha quitado de su isla!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} ha sido quitado de la isla."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr ""
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0} ha sido echado de la isla."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr "§4¡Ese jugador no es parte del grupo de tu isla, ni está en tu isla!"
+
+msgid "teleport to the island home"
+msgstr "teletransportarse a tu isla"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§cTu isla está en proceso de generación, no puedes teletransportarte a ella "
+"ahora."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4Este comando sólo puede ser ejecutado por un jugador"
+
+msgid "transfer leadership to another member"
+msgstr "transfiere el liderazgo a otro jugador"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr ""
+"§4¡sólo puedes transferir la propiedad de la isla a los miembros de tu grupo!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "§e¡§r{0}§e ya es el líder de tu isla!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4¡sólo el líder puede transferir su liderazgo!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "¡{0} intentó tomar el control de la isla!"
+
+msgid "show party information"
+msgstr "muestra información de el grupo"
+
+msgid "shows information about your party"
+msgstr "muestra información sobre tu grupo"
+
+msgid "show pending invites"
+msgstr "muestra las invitaciones pendientes"
+
+msgid "§eNo pending invites"
+msgstr "§eNo hay invitaciones pendientes"
+
+msgid "withdraw an invite"
+msgstr "retira una invitación"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4No tienes permiso para des-invitar jugadores."
+
+msgid "check your or another''s island info"
+msgstr "verifica información de tu isla o la de otros"
+
+msgid "allows user to see others island info"
+msgstr ""
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBloques en la isla de {0} (página {1,number} de {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Recuento de Puntuación de Bloques"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "confía/desconfía en un jugador para ayudar en tu isla."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eLos siguientes jugadores están confiados en tu isla:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eLos siguientes lideres confían en ti en sus islas:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr ""
+"§ePara confiar/desconfiar en alguien para construir en tu isla, usa §b/"
+"island trust <jugador>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4¡Los miembros ya estan confiados en la isla!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Jugador desconocido {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eAhora estás confiado en la isla de §4{0}§e."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} confió en {1} para construir en la isla"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eYa no estas confiado en la isla de §4{0}§e."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0} quitó la confianza de {1} en la isla"
+
+msgid "delete your island and start a new one."
+msgstr "borra tu isla y empieza una nueva."
+
+msgid "exempt player from restart-cooldown"
+msgstr ""
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4sólo el dueño puede reiniciar esta isla. Para empezar una por tu cuenta "
+"deja esta isla (§b/island leave§4)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eDebes quitar a todos los jugadores de tu isla antes de que puedas "
+"reiniciarla (§b/island kick <player>§e). Mira una lista de los jugadores que "
+"actualmente son parte de tu isla con §b/island grupo§e."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§ePodrás reiniciar tu isla en {0} segundos."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr "§cTu isla está en proceso de generación, no puedes reiniciar ahora."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§eNOTA: ¡Tu isla entera y todas tus pertenencias se reiniciarán!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "te teletransporta al spawn"
+
+msgid "change the biome of the island"
+msgstr "cambia el bioma de la isla"
+
+msgid "exempt player from biome-cooldown"
+msgstr ""
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr ""
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr "§cNo tienes permiso para cambiar el bioma de esa isla."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4¡No tienes permiso para cambiar el bioma de tu isla!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§e¡Debes estar en tu isla para cambiar el bioma!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr ""
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§ePodrás cambiar el bioma de tu isla de nuevo en {0,number,#} minutos."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§No tienes permiso para cambiar a ese bioma."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr ""
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aHas cambiado el bioma de tu isla a {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} cambio el bioma de la isla a {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr ""
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr ""
+
+msgid "set your island''s warp location"
+msgstr "establece la localización del teletransporte de la isla"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§c¡No tienes el permiso para establecer el teletransporte de tu isla!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr ""
+"§c¡Necesitas estar en tu propia isla para establecer el teletransporte!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d cambió la ubicación del teletransporte de la isla."
+
+msgid "teleports you to your island (or create one)"
+msgstr ""
+
+msgid "ban/unban a player from your island."
+msgstr "bannea/desbannea a un jugador de tu isla."
+
+msgid "exempts user from being banned"
+msgstr ""
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr ""
+"§eLos siguientes jugadores estan banneados de teletransportarse a tu isla:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr ""
+"§ePara bannear/desbannear a alguien de tu isla, usa §b/island ban <player>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4No puedes bannear a miembros. ¡Quítalos primero!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4No tienes permiso para kickear/bannear jugadores."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr ""
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr ""
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eHas banneado a §4{0}§e de teletransportarse a tu isla."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eHas sido §cBANNEADO§e de la isla de {0}§e."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§eHas desbanneado a §a{0}§e de teletransportarse a tu isla."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eHas sido §aDESBANNEADO§e de la isla de {0}§e"
+
+msgid "display log"
+msgstr "muestra el registro"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "establece el hogar de la isla"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "habilita/deshabilita el teletransporte de tu isla."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4Tu isla está bloqueada. Debes desbloquearla antes de activar el "
+"teletransporte."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d activó el teletransporte de la isla."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr ""
+
+msgid "try to complete a challenge"
+msgstr ""
+
+msgid "show information about the challenge"
+msgstr ""
+
+msgid "§eRank: "
+msgstr "§eRango: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4¡Este reto no es repetible!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr "§4¡Perderás todos los items requeridos cuando completes este reto!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4Todos los items requeridos tienen que estar puestos en tu isla, dentro de "
+"un rango de {0} bloques alrededor tuyo."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§ePara completar este reto, usa §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4¡Nombre de reto inválido! Usa  §b/c help §b4 para más información."
+
+msgid "§eSending you to spawn."
+msgstr "§eEnviándote al spawn."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr ""
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr ""
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr ""
+
+msgid "§aTeleporting you to your island."
+msgstr "§aTeletransportándote a tu isla."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aSerás teletransportado en {0} segundos."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4¡Incapaz de teletransportarte a la isla de ese jugador!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aTeletransportándote a la isla de {0}§a."
+
+msgid "§7Teleport cancelled"
 msgstr ""

--- a/uSkyBlock-Core/src/main/po/fr.po
+++ b/uSkyBlock-Core/src/main/po/fr.po
@@ -16,12 +16,45 @@ msgstr ""
 "X-Loco-Parser: loco_parse_po\n"
 "X-Loco-Target-Locale: fr_FR\n"
 
+msgid "d"
+msgstr "j"
+
+msgid "h"
+msgstr "h"
+
+msgid "m"
+msgstr "m"
+
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§eVous n''y avez pas accès (§4{0}§e)"
 
 #, java-format
 msgid "§eInvalid command: {0}"
+msgstr ""
+
+msgid "Command"
+msgstr ""
+
+msgid "Permission"
+msgstr ""
+
+msgid "Description"
 msgstr ""
 
 #, java-format
@@ -47,1656 +80,12 @@ msgstr ""
 msgid "§4Error writing documentation: {0}"
 msgstr ""
 
-msgid "Command"
-msgstr ""
+msgid "§cWither Despawned!§e It wandered too far from your island."
+msgstr "§cWither retiré ! Il partirait trop loin de votre île."
 
-msgid "Permission"
-msgstr ""
-
-msgid "Description"
-msgstr ""
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-msgid "d"
-msgstr "j"
-
-msgid "h"
-msgstr "h"
-
-msgid "m"
-msgstr "m"
-
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr " §f{0}x §7{1}"
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eIl vous manque ces blocs : {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4Conditions remis à zéro dans {0} jours."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4Conditions remis à zéro dans {0} heures."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4Conditions remis à zéro dans {0} minutes."
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr ""
-
-msgid "§7and more..."
-msgstr "§7et plus..."
-
-msgid "§eItems will be traded for reward."
-msgstr ""
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr ""
-
-msgid "§6Item Reward: §a"
-msgstr "§6Item reçu : §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Argent reçu : §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Expérience reçu : §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dComplétés : §f{0} fois"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4Aucun défi nommé {0} trouvé"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4Vous devez être sur votre île pour faire ça !"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§4Le challenge {0} n'est pas disponible !"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4Le challenge {0} ne peut être refait !"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§eVous avez essayer de compléter le challenge §a{0}"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr ""
-"§4Vous devez êtres dans les alentours de {0} blocks de tout les items requis."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4Votre ile doit être niveau {0} pour compléter ce challenge !"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Type de challenge inconnu : {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§eIl vous manque ces entités:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eIl vous manque les éléments suivants: {0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aVous avez complété le challenge {0} !"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "{0} a complété le challenge {1} !"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§eItem(s) reçu(s): §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eExpérience reçu: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eArgent reçu : §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eVotre invetaire est §4complet§e. Les items ont étés droppés au sol."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lCliquez ici pour compléter le challenge."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lVous ne pouvez refaire le challenge."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Rang: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fCompletez la plupart des challenges dans"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fce rang pour débloquer le rang suivant."
-
-msgid "§eClick here to show previous page"
-msgstr "§eCliquez ici pour voir la page précédente"
-
-msgid "§eClick here to show next page"
-msgstr "§eCliquez ici pour voir la page suivante"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§4Challenge vérouillé"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "§7Remplis {0} en plus du challenge {1}"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Completez {0}"
-
-msgid "to unlock this rank"
-msgstr "pour débloquer ce rang"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "Mais vous êtes tout seul !"
-
-msgid "But you are Yelling in the wind!"
-msgstr "Mais vous criez dans le vent !"
-
-msgid "But your fantasy friends are gone!"
-msgstr "Mais vos amis fantastiques sont partis !"
-
-msgid "But you are Talking to your self!"
-msgstr "Mais vous parlez à vous-même !"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cDésolé ! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr "Envoyez directement un message à votre groupe, ou désactiver/activer le."
-
-msgid "party"
-msgstr "groupe"
-
-msgid "island"
-msgstr "île"
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§cChat activé pour {0}"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§cRépétez §9{0}§c pour le désactiver"
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§cChat désactivé pour {0}"
-
-msgid "§cCommand only available to players"
-msgstr "§cCommande disponible uniquement pour les joueurs"
-
-msgid "talk to players on your island"
-msgstr "parler aux membres de votre île"
-
-msgid "talk to your island party"
-msgstr "parler aux membres de votre groupe"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§eLe joueur {0} n'a pas d'île !"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eLe joueur {0} est invalide."
-
-msgid "Manage challenges for a player"
-msgstr "Gérer les challenges pour un joueur"
-
-msgid "resets the challenge for the player"
-msgstr "réinitialise le challenge pour le joueur"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4Le challenge n'a jamais été réalisé"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§echallenge: {0} a été rénitialisé pour {1}"
-
-msgid "resets all challenges for the player"
-msgstr "rénitialise tous les challenges pour le joueur"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0} a eu tous les challenges réinitialisés."
-
-msgid "complete all challenges in the rank"
-msgstr "complète tout les challenges dans le rang"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4Aucun joueur nommé {0} a été trouvé !"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4Le challenge {0} a déjà été complété"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§eLe challenge {0} a été complété pour {1}"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4Aucun challenge nommé {0} a été trouvé !"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4Aucun rang nommé {0} a été trouvé !"
-
-msgid "manage islands"
-msgstr "gérer les îles"
-
-msgid "protects the island"
-msgstr "protéger les îles"
-
-msgid "delete the island (removes the blocks)"
-msgstr "supprimer l'île (supprimer les blocks)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§eSupprimer une île abandonée à votre position actuelle."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4L'île à cette position possède des membres !\n"
-"§eUtilise §/usb island delete <nom> §epour là supprimer."
-
-msgid "removes the player from the island"
-msgstr "supprimer le joueur de votre île"
-
-msgid "adds the player to the island"
-msgstr "ajouter le joueur à votre île"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d a rejoint votre île."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4Aucun joueur nommé {0} trouvé !"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island name"
-msgstr "§4Aucune île indiquée. Essayez de fournir un nom d'île"
-
-msgid "print out info about the island"
-msgstr "afficher les informations à propos de l'île"
-
-msgid "sets the biome of the island"
-msgstr "définir le biome de l'île"
-
-msgid "§4That player has no island."
-msgstr "§4Ce joueur n'a pas d'île."
-
-msgid "§4No valid island at your location"
-msgstr "§4Ile invalide à votre position"
-
-msgid "purges the island"
-msgstr "nettoyer l'île"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Erreur ! §9Aucune île valide à nettoyer."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cNETTOYAGE : §9Ile nettoyé à {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "activer"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cMettre l''île de {0} à ignorer sur le top dix et la nettoyer."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and purge."
-msgstr ""
-"§cRetirer le flag ignoré de l''île de {0}, elle apparaitra maintenant sur le top "
-"dix et le nettoyage."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Aucun pseudo valide fourni."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Suppression de {0} de l'ile"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eChangé le biome de l''île de {0} en {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eLe biome de l''île de {0} a été changé en OCEAN."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr ""
-"§aVous avez besoin d'aller au spawn, ou se reconnecter, pour voir les changements."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} a eu son biome changé en {1}"
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} a eu son biome changé en OCEAN."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eL''île de {0} a été retiré."
-
-msgid "Error: That player does not have an island!"
-msgstr "Erreur : Ce joueur n'a pas d'île !"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§eL''île de {0} à {1} a été protégé"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4L''île de {0} à {1} est déjà protégé"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "ouvrir l'interface pour la config"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§eNom de configuration invalide"
-
-msgid "Controls player-cooldowns"
-msgstr "Gérer le cooldown (délai) des joueurs"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "supprimer le délai pour une commande (* = all)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eLe joueur n'est actuellement pas en ligne."
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Supprimé le cooldown de {0} pour {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Aucun cooldown actif de {0} pour {1} trouvé !"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Commande invalide fourni, uniquement restart et biome supporté !"
-
-msgid "restarts the cooldown on the command"
-msgstr "réinitialiser le cooldown(délai) pour la commande"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eReinitialiser le délai de {0} pour {1}§e pour {2} secondes"
-
-msgid "lists all the active cooldowns"
-msgstr "liste de tout les cooldowns(délais) actifs"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCommande cooldown(délai)"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eAucun cooldown(délai) actif pour §9{0}§e trouvé."
-
-msgid "control debugging"
-msgstr "gérer le debugging"
-
-msgid "set debug-level"
-msgstr "activer le debug-level"
-
-msgid "toggle debug-logging"
-msgstr "activer le debug-logging"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4Le logging n'est pas activé, donc vous ne pouvez pas le désactivé !"
-
-msgid "flush current content of the logger to file."
-msgstr "contenu actuel dans le fichier logger."
-
-msgid "§eLog-file has been flushed."
-msgstr "§eLe fichier log a été néttoyé."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4Le logging est désactivé, utilise §d/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Argument invalide , essayez INFO,FINE,FINER,FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eLogging désactivé !"
-
-msgid "tries to fix the the area of flatland."
-msgstr "tenter de fixer le domaine de la plaine."
-
-msgid "§4No valid island found"
-msgstr "§4Ile non valide trouvé"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4Aucun terrain plat détecté sur l''île de {0} !"
-
-msgid "flushes all caches to files"
-msgstr "débusquer tout les fichiers cachés"
-
-#, java-format
-msgid "§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr "§eDébusqué §a{0} îles§e, §b{1} joueurs et §6{2} challenges complétés."
-
-msgid "manually update the top 10 list"
-msgstr "rafraishir manuellement le top 10"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eGénération de la top liste"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eGénération du top 10 terminée"
-
-msgid "advanced command for getting island-data"
-msgstr "commandes avancées pour obtenir les données de l'île"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§eLa valeur actuelle pour {0} est \"{1}\""
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§cImpossible d'obtenir l'état pour {0}"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§eLes champs valides sont {0}"
-
-msgid "teleport to another players island"
-msgstr "se téleporter sur l'île d'un autre joueur"
-
-msgid "§4Only supported for players"
-msgstr "§4Uniquement supporté par les joueurs"
-
-msgid "§4That player does not have an island!"
-msgstr "§4Ce joueur n'a pas d'île !"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr ""
-
-msgid "imports players and islands from other formats"
-msgstr "importer les joueurs et les îles depuis un autre format"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Statistiques métier"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/job"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "action"
-
-msgid "time"
-msgstr "temps"
-
-msgid "name"
-msgstr "nom"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "changer le langage du plugin, et le recharger"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aLangage changé avec succès en §e{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cLe langage n''a pas pu être changé en §e{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Langues supportés:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 par {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cImpossible de trouver toutes les langues."
-
-msgid "transfer leadership to another player"
-msgstr "transferer le chef vers un autre joueur"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4Le joueur {0} n'a pas d'île à transférer !"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e to "
-"remove him first."
-msgstr ""
-"§eLe joueur §d{0}§e a déjà une île.§e Utilise §d/usb island remove <nom>§e pour là "
-"supprimer en premier."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bLe chef a été transféré par {0}§b à {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr "infos avancées à propos du stuff NBT"
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "voir le NBTTag pour l'item tenu dans la main"
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§eInfo pour  §9{0}"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - nom: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - nbttag: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§cAucun item dans la main !"
-
-msgid "§eCan only be executed as a player"
-msgstr "§ePeut être exécuté uniquement par un joueur"
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "mettre le NBTTag sur l'item tenu dans la main"
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "§eMis §9{0}§e sur §c{1}"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "ajouter le NBTTag sur l'item tenu dans la main"
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§eAjouté §9{0}§e sur §c{1}"
-
-msgid "manage orphans"
-msgstr "gérer les orphans"
-
-msgid "count orphans"
-msgstr "compter les orphans"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§eLes anciens emplacements de l''île {0} seront utilisés avant les nouveaux."
-
-msgid "clear orphans"
-msgstr "supprimer des orphans"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eSupprimer toutes les anciennes (vides) locations des îles."
-
-msgid "list orphans"
-msgstr "liste des orphan"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eAucun orphans actuellement enregistré."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr ""
-
-msgid "protects all islands (time consuming)"
-msgstr "protéger toutes les îles (temps)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§cEssayer d'annuler toutes les tâches de protection."
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use §9usb "
-"protectall §cstop"
-msgstr ""
-"§4Désolé !§e Une protection total est déjà en cours. Laissez le se terminer, ou "
-"utilisez §9usb protectall §cstop"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr ""
-"§eDémarrage d'une protection complète. Cela risque de prendre un certain temps."
-
-msgid "purges all abandoned islands"
-msgstr "nettoyer toutes les îles abandonnés"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4Vous devez fournir un nombre en jour pour nettoyer !"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below level "
-"{1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr "§4Essayer d'interrompre la purge"
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr "§4Commencement de la purge..."
-
-msgid "region manipulations"
-msgstr "manipulations des régions"
-
-msgid "shows the borders of the current island"
-msgstr "voir les bordures de l'île actuelle"
-
-msgid "§eNo island found at your current location"
-msgstr "§eAucune île trouvé à votre position actuelle"
-
-msgid "shows the borders of the current chunk"
-msgstr "voir les bordures du chunk actuel"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "voir les bordures du chunk interne"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "voir les bordures des chunks non alignés"
-
-msgid "shows the borders of the outer-chunks"
-msgstr "voir les bordures des chunks extérieurs"
-
-msgid "hides the regions again"
-msgstr "cacher de nouveau les régions"
-
-msgid "§eStopped displaying regions"
-msgstr "§eStopper l'affichage des régions"
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§eActuellement aucun régions à afficher pour ce joueur"
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§eAnimation des ticks changés en {0}."
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§eAnimation-tick doit être un nombre entier valide."
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "fixer l'île d'un joueur à votre position"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "recharher la configuration à partir du fichier."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eConfiguration rechargé depuis le fichier."
-
-msgid "advanced command for setting island-data"
-msgstr "commandes avancés pour la configurations des données de l'île"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§c{0} a été modifié en ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§cImpossible de modifier le champs {0} en \"{1}\""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr "§cImpossible de modifier le champs {0} en \"{1}\", un nombre est attendu"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§cChamp invalide {0}"
-
-msgid "toggles maintenance mode"
-msgstr "activer/désactiver le mode maintenance"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-"§cMAINTENANCE: §aActivée§e Toutes les fonctionnalités du skyblock sont désactivés."
-
-msgid "§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-"§cMAINTENANCE: §4Désactivée§e Toutes les fonctionnalités du skyblock sont de "
-"retour."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr "§cLe mode maintenance peut être changé uniquement depuis la console !"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§cINTERROMPU:§e La protection totale a été interrompu !"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr "§cProtection totale complété dans {0}, {1} nouvelles régions ont été crées !"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§7- Scan: {0,number,##}% ({1}/{2} échoués: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4NETTOYAGE :§9 Scan interrompu."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid "- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4NETTOYAGE : Finit , îles abandonnés nétoyés."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4NETTOYAGE :§9 Purge annulée des îles abandonnées."
-
-msgid "displays version information"
-msgstr "afficher les informations sur la version"
-
-msgid "various WorldGuard utilities"
-msgstr "différent services de WorldGuard"
-
-msgid "refreshes the chunks around the player"
-msgstr "rafraichir les chunks autour du joueur"
-
-msgid "§eResending chunks to the client"
-msgstr "§eRenvoyer les chunks au client"
-
-msgid "load the region chunks"
-msgstr "charger les chunks de la région"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eChunks chargés à {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eChunks déchargés à {0}"
-
-msgid "update the WG regions"
-msgstr "mettre à jour les regions WG"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§eLes régions world guard des îles mit à jour pour {0}"
-
-msgid "§eNo island found at your location!"
-msgstr "§eAucune île trouvé à votre position !"
-
-msgid "refreshes the chunk around the player"
-msgstr ""
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate Skyblock Admin"
-
-msgid "show player-information"
-msgstr "voir les informations des joueurs"
-
-msgid "try to complete a challenge"
-msgstr "essayer de completer un challenge"
-
-msgid "§cCommand only available for players."
-msgstr "§cCommande disponible uniquement pour les joueurs."
-
-msgid "show information about the challenge"
-msgstr "voir les informations à propos du challenge"
-
-msgid "§eRank: "
-msgstr "§eRang : "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4Ce challenge ne peut être refait !"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr ""
-"§eVous perdrez tous les éléments nécessaires lorsque vous remplirez ce challenge !"
-
-#, java-format
-msgid "§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4Tous les élements requis doivent être placés sur votre île, dans {0} blocs "
-"autour de vous."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§ePour compléter le challenge, utilise §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4Nom de challenge invalide ! Utilise /c help pour plus d'informations"
-
-msgid "complete and list challenges"
-msgstr "liste des challenges"
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eChallenge désactivé. Contactez un administrateur."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4Vous devez être dans le monde Skyblock pour compléter les challenges !"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4Vous devez avoir une île pour compléter les challenges !"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't invite "
-"anyone else."
-msgstr ""
-"§4Votre île est pleine, ou vous avez trop d'invitations en attente. Vous ne pouvez "
-"pas inviter quelqu'un d'autre."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4Ce joueur est déjà le chef d'une autre île."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e veut vous inviter, mais vous êtes déjà dans un groupe."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e vous invite à rejoindre son île !"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§f/island [accept/reject]§e pour accepter ou rejeter l'invitation."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4ATTENTION: Vous perdrez votre île si vous acceptez !"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d a invité {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e a rejeté l'invitation."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4Vous ne pouvez pas utiliser cette commande en ce moment. Quittez votre premier "
-"groupe actuel."
-
-msgid "§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§aVous avez rejoint une îe ! Utiliser /island party pour voir les autres membres."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§eL''invitation pour {0}§e a expiré ou a été annulé."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§eL'invitation pour l'île de {0} a expiré ou a été annulé."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§eVous avez accepté l'invitation pour rejoindre l'île."
-
-msgid "§4You haven't been invited."
-msgstr "§4Vous n'avez pas été invité."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eVous avez rejeté l'invitation pour rejoindre l'île."
-
-msgid "accept/reject an invitation."
-msgstr "accepter/rejeter une invitation."
-
-msgid "teleports you to your island (or create one)"
-msgstr "vous téléporte sur votre île (ou en crée une)"
-
-msgid "ban/unban a player from your island."
-msgstr "bannir/débannir un joueur de votre île."
-
-msgid "exempts user from being banned"
-msgstr ""
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§eLes joueurs bannis du warp de votre île :"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr "§ePour bannir/debannir un joueur de votre île, /island ban <pseudo>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4Vous ne pouvez pas bannir de joueur. Retirer les de l'île d'abord !"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4Vous n'avez pas la permission pour exclure/bannir des joueurs."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§eImpossible de ban ce joueur (joueur inconnu) {0}"
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4{0} a essayé de vous bannir de leur île !"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4{0} est excepté du bannissement."
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eVous avez banni §4{0}§e du warp de votre île."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eVous avez été §cBANNI§e de l''île de {0}."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§eVous avez débanni §a{0}§e du warp de votre île."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eVous avez été §aDEBANNI§e de l''île de {0}."
-
-msgid "change the biome of the island"
-msgstr "changer le biome de votre île"
-
-msgid "exempt player from biome-cooldown"
-msgstr ""
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr ""
-
-msgid "§cYou do not have permission to change the biome of your current island."
-msgstr "§cVous n'avez pas la permission de changer le biome de l'île actuelle."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4Vous n'avez pas la permission de changer le biome de l'île !"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eVous devez être sur votre île pour changer le biome !"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr ""
-"§cVous avez mal orthographié le nom du biome. Doit faire parti de cette liste : {0}"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eVous ne pouvez pas changer le biome avant {0,number,#} minutes."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cVous n'êtes pas autorisé à changer votre biome vers ce type."
-
-#, java-format
-msgid "§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, be "
-"patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be patient."
-msgstr ""
-"§7Les pixels sont occupés à changer le biome de votre île en §9{0}§7, soyez "
-"patient."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr ""
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aVous avez changé le biome de l''île en {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} a changé le biome de l''île en {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr ""
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr ""
-
-msgid "create an island"
-msgstr "créer une île"
-
-msgid "exempt player from create-cooldown"
-msgstr ""
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, type§b /"
-"is restart§e to get one"
-msgstr ""
-"§4Ile trouvé !§e Vous avez déjà une île. Si vous voulez une nouvelle île, tape§b /"
-"is restart§e pour en avoir une nouvelle"
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr "§4Ile trouvé! §e Vous êtes déjà"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eVous pouvez créer une île dans {0,number,#} secondes."
-
-msgid "teleport to the island home"
-msgstr "téléporter au home de l'île"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home right now."
-msgstr "§cVotre île génére, vous ne pouvez vous téléporter maintenant."
-
-msgid "check your or another''s island info"
-msgstr "vérifier les informations d'une autre île"
-
-msgid "allows user to see others island info"
-msgstr ""
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4Le niveaus des îles ont été désactivé, contacté un administrateur."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eVous devez être sur votre île pour utiliser cette commande."
-
-msgid "§4You do not have an island!"
-msgstr "§4Vous n'avez pas d'île !"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4Vous n'avez pas accès à cette commande !"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4Joueur invalide ou le joueur n'a pas d'île !"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBlocks sur l''île de {0} (page {1,number} of {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Nombre de blocks"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aLe niveau de votre île est {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "inviter un joueur sur votre île"
-
-msgid "§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§eUtiliser§f /island invite <pseudo> §e pour inviter un joueur sur votre île."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4Seul le propriétaire de l'île peut inviter !"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aVous pouvez inviter maximum {0} joueurs."
-
-msgid "§4You can't invite any more players."
-msgstr "§4Vous ne pouvez pas inviter plus de joueurs."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4Vous n'avez pas la permission pour inviter d'autres joueur sur l'île !"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4Ce joueur est hors-ligne ou n'éxiste pas."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4Vous ne pouvez pas vous inviter vous même !"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4Ce joueur est le chef de votre île !"
-
-msgid "remove a member from your island."
-msgstr "retirer un membre de votre île."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4Vous n'avez pas la permission pour virer d'autres joueurs de l'île !"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4Vous ne pouvez pas exclurer le chef de l'île !"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4Vous ne pouvez pas vous exclure vous même !"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0} vous a retiré de l'île !"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} a été retiré de l'île."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0} a essayé de vous kick de son île !"
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4{0} est excepté du kick de l'île."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4{0} vous a kické de son île !"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0} a été kické de l'île."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr "§4Ce joueur n'est pas dans votre groupe, ni dans votre île !"
-
-msgid "leave your party"
-msgstr "quitter votre groupe"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4Vous ne pouvez pas quitter votre île quand vous êtes tout seul. Essayez /island "
-"restart si vous en voulez une nouvelle !"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr ""
-"§eVous êtes le propriétaire de l'île, utiliser /island remove <joueur> à la place."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eVos avez quitté l'île et vous êtes retourné au spawn des joueurs."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0} a quitté votre île !"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4Vous devez être dans le monde skyblock pour quitter l'île !"
-
-msgid "check your or anothers island level"
-msgstr "vérifier le niveau des autres îles"
-
-msgid "allows user to query for others levels"
-msgstr ""
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eInformations à propos de l''île de {0}:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9Votre rang est {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "vérrouiller votre île aux non-membres de votre île."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4Vous n'avez pas la permission pour vérrouillé votre île !"
-
-msgid "§4You don't have access to this command!"
-msgstr "§eVous n'avez pas accés à cette commande !"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4Vous n'avez pas la permission pour dévérouille votre île !"
-
-msgid "display log"
-msgstr "afficher les logs"
-
-msgid "transfer leadership to another member"
-msgstr "transférer le chef à un autre membre"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4Seul un membre de votre île peut devenir chef !"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e est déjà le chef de l'île !"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4Seul le chef peut transférer le rang de chef !"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} a essayé de reprendre l'île !"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "voir les informations de votre île"
-
-msgid "shows information about your party"
-msgstr "voir les informations à propos de votre île"
-
-msgid "show pending invites"
-msgstr "voir les invitations en attente"
-
-msgid "§eNo pending invites"
-msgstr "§eAucunes invitations en attente"
-
-msgid "withdraw an invite"
-msgstr "retirer une invitation"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4Vous n'avez pas la permission pour inviter des joueurs."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§Cette commande ne peut être exécuter que par un joueur"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4Aucun île. §eUtilise §b/is create§e pour en avoir une"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "supprimer votre île et créer une nouvelle."
-
-msgid "exempt player from restart-cooldown"
-msgstr ""
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to start your "
-"own (/island leave)."
-msgstr ""
-"§4Uniquement le chef de l'île peut remettre à zéro l'île. Quittez l'île pour créer "
-"la votre (/island leave)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/island "
-"kick <player>). See a list of players currently part of your island using /island "
-"party."
-msgstr ""
-"§eVous devez enlever tout les joueurs de votre île avant de le remettre à zéro (/"
-"island kick <joueur>. Pour voir les membres de votre île faites /island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§cVous pouvez remettre à zéro votre île dans {0} secondes."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§cVotre île est en génération, vous ne pouvez la remettre à zéro maintenant."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eRAPPEL: La totalité de votre île et tous vos biens seront remis à zéro !"
-
-msgid "set the island-home"
-msgstr "modifier le home de l'île"
-
-msgid "set your island''s warp location"
-msgstr "modifier la position du point de spawn du warp"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr ""
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§cVous devez être le chef de l'île pour modifier le warp !"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d a changé la position du warp de l'île."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "téléporter au spawn du skyblock"
-
-msgid "enable/disable warping to your island."
-msgstr "activer/désactiver le warp à votre île."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4Votre île est vérrouillé. Vous devez la dévérouilleé pour activer votre warp."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d a activé le warp de l'île."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d a désactivé le warp de l'île."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr ""
-
-msgid "display the top10 of islands"
-msgstr "afficher le top 10 des îles"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr ""
-
-msgid "trust/untrust a player to help on your island."
-msgstr "ajouter/retirer un joueur pour vous aider sur votre île."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eLes membres auxquels vous faites confiance:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eLes chefs auxquels vous faites confiance:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr "§ePour ajouter/retirer des membres de confiances, /island trust <joueur>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4Membre déjà ajouté !"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Joueur inconnu {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eVous avez ajouté §4{0}§e comme joueur de confiance sur l'île."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} a ajouté {1} comme membre de confiance sur l'île"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eVous n'êtes plus un joueur de confiance sur l'île de §4{0}."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0}a retiré le joueur {1} comme membre de confiance sur l'île"
-
-msgid "warp to another player''s island"
-msgstr "utiliser le warp d'une autre île"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr "§aVotre warp est actif, les joueurs peuvent utiliser votre warp."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr "§4Votre warp est inactif, les joueurs ne peuvent utiliser votre warp."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr "§fDéfinir le warp à votre position §e/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§fActivé/Désactivé le warp §e/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4Vous n'avez pas la permission de créer un warp sur votre île !"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§fUtiliser le warp d'une autre île §e/island warp <joueur>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4You n'avez pas la permission utiliser le warp de d'autres îles !"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other players "
-"islands right now."
-msgstr ""
-"§cVotre île est en géneration, vous ne pouvez pas vous téléporter sur d'autres îles."
-
-msgid "§4That player does not exist!"
-msgstr "§4Ce joueur n'éxiste pas !"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4Ce joueur n'a pas de warp actif."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it right "
-"now."
-msgstr "§cL'île du joueur se genère, vous ne pouvez pas vous y téléporter."
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cATTENTION: §9{0}§e a été téléporte à votre île !"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4Ce jour vous a interdit de vous téléporter à son île."
-
-msgid "general island command"
-msgstr "commandes générales"
-
-msgid "allows user to bypass cooldowns"
-msgstr ""
-
-msgid "allows user to bypass visitor-protections"
-msgstr ""
-
-msgid "allows user to bypass teleport-delay"
-msgstr ""
-
-msgid "allows user to use [usb] signs"
-msgstr ""
-
-msgid "allows user to place [usb] signs"
-msgstr ""
+msgid "{0}''s Wither"
+msgstr "Wither de {0}"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr ""
@@ -1713,37 +102,9 @@ msgstr ""
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
 
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr "§cWither retiré ! Il partirait trop loin de votre île."
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "Wither de {0}"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eLes visiteurs ne peuvent pas lancer d'items !"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Chef: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr ""
-"Vous ne pouvez pas prendre le loot des autres joueurs lorsque vous êtes un "
-"visiteur!"
-
-msgid "Config:"
-msgstr "Config:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, that is "
-"not allowed."
-msgstr ""
-"§cAccés interdit !§e Vous avez essayé de vous téléporter sur le toît du "
-"§cNETHER§c, ce n'est pas autorisé."
-
 msgid "§4You can only convert obsidian once every 10 seconds"
-msgstr "§4Vous ne pouvez convertir l'obsidienne qu'une fois toutes les 10 secondes."
+msgstr ""
+"§4Vous ne pouvez convertir l'obsidienne qu'une fois toutes les 10 secondes."
 
 msgid "§eChanging your obsidian back into lava. Be careful!"
 msgstr "§eObsidienne changé en lave ! Soyez prudent !"
@@ -1765,8 +126,8 @@ msgstr "§4Cette île est §cvérrouillé.§e Impossible de s'y téléporter."
 
 #, java-format
 msgid ""
-"§4{0} is limited. §eScanning your island to see if you are allowed to place more, "
-"please be patient"
+"§4{0} is limited. §eScanning your island to see if you are allowed to place "
+"more, please be patient"
 msgstr ""
 
 msgid "§e... Scanning complete, you can try again"
@@ -1774,8 +135,8 @@ msgstr ""
 
 #, java-format
 msgid ""
-"§4You''ve hit the {0} limit!§e You can''t have more of that type on your island!§9 "
-"Max: {1,number}"
+"§4You''ve hit the {0} limit!§e You can''t have more of that type on your "
+"island!§9 Max: {1,number}"
 msgstr ""
 
 msgid "§eYou can only use spawn-eggs on your own island."
@@ -1784,19 +145,90 @@ msgstr "§eVous pouvez uniquement utiliser les oeufs de spawn sur votre île."
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§cVous avez atteint la limite de spawn de votre île."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eLes visiteurs ne peuvent pas lancer d'items !"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Chef: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr ""
+"Vous ne pouvez pas prendre le loot des autres joueurs lorsque vous êtes un "
+"visiteur!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cBanni:§e Vous êtes banni de cette île."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cVérrouilé:§c Cette île est vérrouillé ! Aucune entrée autorisée."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§9Création de l''île....§e{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr ""
+"Quelque chose a mal sauvegardé les données de l'île et/ou de la partie !"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr "Conversion des données en UUID, cela peut prendre un certain temps !"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§cMAINTENANCE :§e uSkyBlock est actuellement en mode maintenance"
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Création de l''île....§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"§buSkyBlock§e dépend de §9{0}§e >= §av{1}§e mais seulement §cv{2}§e a été "
+"trouvé !\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e dépend de §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§eVous n'avez pas accès à ce type d'île !"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4Ce joueur est déjà assigné à une île !"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4Vous devez être plus proche de votre île pour modifier le home !"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aVotre home a été modifié à votre position actuelle."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4Votre position actuelle n'est pas un home protégé."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+"§7Les pixels sont occupés à changer le biome de votre île en §9{0}§7, soyez "
+"patient."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr ""
+"§cVotre île est en cours de génération, vous ne pouvez pas créer maintenant."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "Vous ne pouvez pas créer d'île. Contactez un administrateur."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+"§eVotre île est bientôt prête, soyez patient cela peut prendre un certain "
+"temps..."
+
+msgid "§cCommand is currently disabled!"
+msgstr "§cLa commande est actuellement désactivée !"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr " §f{0}x §7{1}"
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eIl vous manque ces blocs : {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1804,13 +236,11 @@ msgstr "§9{0}§7 timed out"
 
 #, java-format
 msgid ""
-"§eDoing §9{0}§e is §cRISKY§e. Repeat the command within §a{1}§e seconds to accept!"
+"§eDoing §9{0}§e is §cRISKY§e. Repeat the command within §a{1}§e seconds to "
+"accept!"
 msgstr ""
-"§eFaire ceci §9{0}§e est §cDANGEREUX§e. Répeter la commande avant §a{1}§e secondes "
-"pour confirmer !"
-
-msgid "N/A"
-msgstr "N/A"
+"§eFaire ceci §9{0}§e est §cDANGEREUX§e. Répeter la commande avant §a{1}§e "
+"secondes pour confirmer !"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** Vous entrez sur sur une île abandonné mais protégée."
@@ -1827,225 +257,51 @@ msgid "§d** You are leaving §b{0}''s §disland."
 msgstr "§d** Vous quittez l''île de §b{0}."
 
 msgid "§eYour island is now locked. Only your party members may enter."
-msgstr "§eVotre île est maintenant vérrouillé. Seuls vos membres peuvent y entrer."
+msgstr ""
+"§eVotre île est maintenant vérrouillé. Seuls vos membres peuvent y entrer."
 
 msgid "§4You must be the party leader to lock your island!"
 msgstr "§4Tu dois être le chef de l'île pour pouvoir la verrouiller !"
 
 msgid ""
-"§eYour island is unlocked and anyone may enter, however only you and your party "
-"members may build or remove blocks."
+"§eYour island is unlocked and anyone may enter, however only you and your "
+"party members may build or remove blocks."
 msgstr ""
-"§eVotre île est dévérrouillé et n'importe qui peut y entrer , mais seulement les "
-"membres peuvent construire ou casser des blocs."
+"§eVotre île est dévérrouillé et n'importe qui peut y entrer , mais seulement "
+"les membres peuvent construire ou casser des blocs."
 
 msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4Vous devez être le chef de l'île pour là dévérouillé !"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§7PlayerDB: Filtration de {0} joueurs depuis uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§9Création de l''île....§e{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Création de l''île....§e{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§4Challenge vérouillé"
+
+msgid "READY"
+msgstr "PRÊT"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§7PlayerDB: Filtré {0} noms"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), {6}"
-msgstr ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, échoués:{3} ~ {5,number,##}%), {6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§7MojangAPI: Essaye de rapporter {0} joueurs depuis Mojang"
-
-msgid "SUCCESS"
-msgstr "SUCCÈS"
-
-msgid "FAILED"
-msgstr "ÉCHOUÉ"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§7 - MojangAPI:§aCOMPLETE: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§7 - MojangAPI:§cERREUR: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) ~ {6}"
-msgstr ""
-"§eProgression: {0,number,##}% ({1}/{2} - réussis:{3}, échoués:{4}, passés:{5}) ~ "
-"{6}"
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4Aucun importeur nommé §e{0} trouvé"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§eConverti {0}/{1} fichier en {2}"
-
-msgid "The island has been created."
-msgstr "L'île a bien été crée."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d a vérouillé l'île."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§4Comme votre île est vérrouillé, la warp a été désactivé."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d a déverrouillé l'île."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cSKY §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d a été retiré de votre île."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9Création d'une île à votre position"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9Créer une île §7{0}§9 pour vous"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§4Le challenge {0} n'est pas disponible !"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to spawn."
-msgstr "§cL'île a été supprimé. Téléportation au spawn."
-
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§cL'île sur laquelle vous êtes a été supprimé ! Retour au spawn."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eTableau des meilleurs joueurs (page {0} de {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
-"§4Le top 10 est vide ! Seulement les îles au dessus du niveau {0} est pris en "
-"compte."
+"§cATTENTION :§e Impossible de transférer tout les items nécessaires dans "
+"votreinventaire !"
 
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eVotre rang est: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "INCONNU"
-
-msgid "ANIMAL"
-msgstr "ANIMAUX"
-
-msgid "MONSTER"
-msgstr "MONSTRES"
-
-msgid "VILLAGER"
-msgstr "VILLAGEOIS"
-
-msgid "GOLEM"
-msgstr "GOLEM"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (max. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "Impossible de localiser la schematic {0}, contactez un administrateur"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aFélicitation ! §eVotre île est apparu."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cNote:§e La création peut être encore en cours."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Utilise §9/is h§r ou le menu §9/is§r pour y aller."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§cOh! §9 Impossible de localiser un coffre dans les {0}."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7Page {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr ""
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr ""
-
-msgid "Return"
-msgstr "Retour"
-
-msgid "§9Integer Editor"
-msgstr "§9Editeur de nombre"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eConfiguration sauvegardé et rechargé."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cErreure ! §9Impossible de sauvegarder le fichier de config !"
-
-msgid "§3First Page"
-msgstr "§3Première page"
-
-msgid "§3Last Page"
-msgstr "§3Dernière page"
-
-msgid "§cSave & Reload config"
-msgstr "§cSauvegarder et recharger la config"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Sauvegarder les configuration des\n"
-"§7fichiers & les recharger.\n"
-"§cNote: §7A utiliser avec précaution!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (lecture uniquement)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr "§cPas assez d'items dans le coffre pour compléter le challenge !"
 
 msgid "true"
 msgstr "vrai"
@@ -2455,6 +711,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "§7Page actuelle"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7Page {0}"
+
 msgid "§7First Page"
 msgstr "§7Première page"
 
@@ -2752,8 +1012,8 @@ msgstr "§cCliquez pour quitter"
 msgid "Island Restart Menu"
 msgstr "Menu de redémarrage de l'île"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§eVous n'avez pas accès à ce type d'île !"
+msgid "Config:"
+msgstr "Config:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2769,114 +1029,122 @@ msgstr "§cCliquez dans §9{0}§c pour redémarrer !"
 msgid "§aClick to restart!"
 msgstr "§aCliquez pour redémarrer !"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr ""
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr ""
+
+msgid "Return"
+msgstr "Retour"
+
+msgid "§9Integer Editor"
+msgstr "§9Editeur de nombre"
+
 msgid "Caps On"
 msgstr "Majuscule activé"
 
 msgid "§9Text Editor"
 msgstr "§9Éditeur de texte"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eConfiguration sauvegardé et rechargé."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cErreure ! §9Impossible de sauvegarder le fichier de config !"
+
+msgid "§3First Page"
+msgstr "§3Première page"
+
+msgid "§3Last Page"
+msgstr "§3Dernière page"
+
+msgid "§cSave & Reload config"
+msgstr "§cSauvegarder et recharger la config"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Sauvegarder les configuration des\n"
+"§7fichiers & les recharger.\n"
+"§cNote: §7A utiliser avec précaution!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (lecture uniquement)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+"§eProgression: {0,number,##}% ({1}/{2} - réussis:{3}, échoués:{4}, passés:"
+"{5}) ~ {6}"
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4Aucun importeur nommé §e{0} trouvé"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§eConverti {0}/{1} fichier en {2}"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§7PlayerDB: Filtration de {0} joueurs depuis uuid2name.yml"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§7PlayerDB: Filtré {0} noms"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, échoués:{3} ~ {5,number,##}%), "
+"{6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§7MojangAPI: Essaye de rapporter {0} joueurs depuis Mojang"
+
+msgid "SUCCESS"
+msgstr "SUCCÈS"
+
+msgid "FAILED"
+msgstr "ÉCHOUÉ"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§7 - MojangAPI:§aCOMPLETE: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§7 - MojangAPI:§cERREUR: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "Trop de requêtes pour l''API Mojang ({0} within {1}), sleeping {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr "§9Vous n'êtes pas vraiment patient, n'est-ce pas ?"
-
-msgid "§9Be patient, young padawan"
-msgstr "§9Soyez patient, jeune padawan"
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr "§9Jeune padawan, la patience tu DOIS avoir"
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§aTéléportation au spawn."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§eL'île a été §cVÉRROUILLÉ§e."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aVous serez téléporté dans {0} secondes."
-
-msgid "§7Teleport cancelled"
-msgstr "§7Téléportation annulée"
-
-msgid "READY"
-msgstr "PRÊT"
-
-msgid "§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-"§cATTENTION :§e Impossible de transférer tout les items nécessaires dans votre"
-"inventaire !"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr "§cPas assez d'items dans le coffre pour compléter le challenge !"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Quelque chose a mal sauvegardé les données de l'île et/ou de la partie !"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr "Conversion des données en UUID, cela peut prendre un certain temps !"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§cMAINTENANCE :§e uSkyBlock est actuellement en mode maintenance"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"§buSkyBlock§e dépend de §9{0}§e >= §av{1}§e mais seulement §cv{2}§e a été "
-"trouvé !\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e dépend de §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4Ce joueur est déjà assigné à une île !"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4Impossible de trouver un endroit sécurisé sur votre île !"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§cATTENTION : §eTéléportation en plein air."
-
-msgid "§aTeleporting you to your island."
-msgstr "§aTéléportation à votre île."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Impossible d'utiliser le warp de cette île !"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aTéléporté à l''île de {0}."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4Vous devez être plus proche de votre île pour modifier le home !"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aVotre home a été modifié à votre position actuelle."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4Votre position actuelle n'est pas un home protégé."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cVotre île est en cours de génération, vous ne pouvez pas créer maintenant."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "Vous ne pouvez pas créer d'île. Contactez un administrateur."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-"§eVotre île est bientôt prête, soyez patient cela peut prendre un certain temps..."
-
-msgid "§cCommand is currently disabled!"
-msgstr "§cLa commande est actuellement désactivée !"
 
 msgid "North"
 msgstr "Nord"
@@ -2901,3 +1169,1774 @@ msgstr "Ouest"
 
 msgid "North-West"
 msgstr "Nord-Ouest"
+
+msgid "The island has been created."
+msgstr "L'île a bien été crée."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d a vérouillé l'île."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§4Comme votre île est vérrouillé, la warp a été désactivé."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d a désactivé le warp de l'île."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d a déverrouillé l'île."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cSKY §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d a été retiré de votre île."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9Création d'une île à votre position"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9Créer une île §7{0}§9 pour vous"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aFélicitation ! §eVotre île est apparu."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cNote:§e La création peut être encore en cours."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Utilise §9/is h§r ou le menu §9/is§r pour y aller."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "Impossible de localiser la schematic {0}, contactez un administrateur"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§cOh! §9 Impossible de localiser un coffre dans les {0}."
+
+msgid "UNKNOWN"
+msgstr "INCONNU"
+
+msgid "ANIMAL"
+msgstr "ANIMAUX"
+
+msgid "MONSTER"
+msgstr "MONSTRES"
+
+msgid "VILLAGER"
+msgstr "VILLAGEOIS"
+
+msgid "GOLEM"
+msgstr "GOLEM"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (max. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr "§cL'île a été supprimé. Téléportation au spawn."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§cL'île sur laquelle vous êtes a été supprimé ! Retour au spawn."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eTableau des meilleurs joueurs (page {0} de {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr ""
+"§4Le top 10 est vide ! Seulement les îles au dessus du niveau {0} est pris "
+"en compte."
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4Le niveaus des îles ont été désactivé, contacté un administrateur."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eVotre rang est: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "§7Remplis {0} en plus du challenge {1}"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Completez {0}"
+
+msgid "to unlock this rank"
+msgstr "pour débloquer ce rang"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Conditions remis à zéro dans {0} jours."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Conditions remis à zéro dans {0} heures."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4Conditions remis à zéro dans {0} minutes."
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr ""
+
+msgid "§7and more..."
+msgstr "§7et plus..."
+
+msgid "§eItems will be traded for reward."
+msgstr ""
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr ""
+
+msgid "§6Item Reward: §a"
+msgstr "§6Item reçu : §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Argent reçu : §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Expérience reçu : §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dComplétés : §f{0} fois"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4Aucun défi nommé {0} trouvé"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4Vous devez être sur votre île pour faire ça !"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4Le challenge {0} ne peut être refait !"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§eVous avez essayer de compléter le challenge §a{0}"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr ""
+"§4Vous devez êtres dans les alentours de {0} blocks de tout les items requis."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4Votre ile doit être niveau {0} pour compléter ce challenge !"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Type de challenge inconnu : {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§eIl vous manque ces entités:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eIl vous manque les éléments suivants: {0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aVous avez complété le challenge {0} !"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "{0} a complété le challenge {1} !"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§eItem(s) reçu(s): §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eExpérience reçu: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eArgent reçu : §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eVotre invetaire est §4complet§e. Les items ont étés droppés au sol."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lCliquez ici pour compléter le challenge."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lVous ne pouvez refaire le challenge."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Rang: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fCompletez la plupart des challenges dans"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fce rang pour débloquer le rang suivant."
+
+msgid "§eClick here to show previous page"
+msgstr "§eCliquez ici pour voir la page précédente"
+
+msgid "§eClick here to show next page"
+msgstr "§eCliquez ici pour voir la page suivante"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "Mais vous êtes tout seul !"
+
+msgid "But you are Yelling in the wind!"
+msgstr "Mais vous criez dans le vent !"
+
+msgid "But your fantasy friends are gone!"
+msgstr "Mais vos amis fantastiques sont partis !"
+
+msgid "But you are Talking to your self!"
+msgstr "Mais vous parlez à vous-même !"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cDésolé ! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr ""
+"Envoyez directement un message à votre groupe, ou désactiver/activer le."
+
+msgid "party"
+msgstr "groupe"
+
+msgid "island"
+msgstr "île"
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§cChat activé pour {0}"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§cRépétez §9{0}§c pour le désactiver"
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§cChat désactivé pour {0}"
+
+msgid "§cCommand only available to players"
+msgstr "§cCommande disponible uniquement pour les joueurs"
+
+msgid "talk to your island party"
+msgstr "parler aux membres de votre groupe"
+
+msgid "talk to players on your island"
+msgstr "parler aux membres de votre île"
+
+msgid "manually update the top 10 list"
+msgstr "rafraishir manuellement le top 10"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eGénération de la top liste"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eGénération du top 10 terminée"
+
+msgid "purges all abandoned islands"
+msgstr "nettoyer toutes les îles abandonnés"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4Vous devez fournir un nombre en jour pour nettoyer !"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr "§4Essayer d'interrompre la purge"
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr "§4Commencement de la purge..."
+
+msgid "Controls player-cooldowns"
+msgstr "Gérer le cooldown (délai) des joueurs"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "supprimer le délai pour une commande (* = all)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eLe joueur n'est actuellement pas en ligne."
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Supprimé le cooldown de {0} pour {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Aucun cooldown actif de {0} pour {1} trouvé !"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Commande invalide fourni, uniquement restart et biome supporté !"
+
+msgid "restarts the cooldown on the command"
+msgstr "réinitialiser le cooldown(délai) pour la commande"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eReinitialiser le délai de {0} pour {1}§e pour {2} secondes"
+
+msgid "lists all the active cooldowns"
+msgstr "liste de tout les cooldowns(délais) actifs"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCommande cooldown(délai)"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eAucun cooldown(délai) actif pour §9{0}§e trouvé."
+
+msgid "toggles maintenance mode"
+msgstr "activer/désactiver le mode maintenance"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+"§cMAINTENANCE: §aActivée§e Toutes les fonctionnalités du skyblock sont "
+"désactivés."
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+"§cMAINTENANCE: §4Désactivée§e Toutes les fonctionnalités du skyblock sont de "
+"retour."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr "§cLe mode maintenance peut être changé uniquement depuis la console !"
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Statistiques métier"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/job"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "action"
+
+msgid "time"
+msgstr "temps"
+
+msgid "name"
+msgstr "nom"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§eLe joueur {0} n'a pas d'île !"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eLe joueur {0} est invalide."
+
+msgid "flushes all caches to files"
+msgstr "débusquer tout les fichiers cachés"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr "§eDébusqué §a{0} îles§e, §b{1} joueurs et §6{2} challenges complétés."
+
+msgid "tries to fix the the area of flatland."
+msgstr "tenter de fixer le domaine de la plaine."
+
+msgid "§4No valid island found"
+msgstr "§4Ile non valide trouvé"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4Aucun terrain plat détecté sur l''île de {0} !"
+
+msgid "manage orphans"
+msgstr "gérer les orphans"
+
+msgid "count orphans"
+msgstr "compter les orphans"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr ""
+"§eLes anciens emplacements de l''île {0} seront utilisés avant les nouveaux."
+
+msgid "clear orphans"
+msgstr "supprimer des orphans"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eSupprimer toutes les anciennes (vides) locations des îles."
+
+msgid "list orphans"
+msgstr "liste des orphan"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eAucun orphans actuellement enregistré."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "transferer le chef vers un autre joueur"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4Le joueur {0} n'a pas d'île à transférer !"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eLe joueur §d{0}§e a déjà une île.§e Utilise §d/usb island remove <nom>§e "
+"pour là supprimer en premier."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bLe chef a été transféré par {0}§b à {1}"
+
+msgid "open GUI for config"
+msgstr "ouvrir l'interface pour la config"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§eNom de configuration invalide"
+
+msgid "teleport to another players island"
+msgstr "se téleporter sur l'île d'un autre joueur"
+
+msgid "§4Only supported for players"
+msgstr "§4Uniquement supporté par les joueurs"
+
+msgid "§4That player does not have an island!"
+msgstr "§4Ce joueur n'a pas d'île !"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr ""
+
+msgid "various WorldGuard utilities"
+msgstr "différent services de WorldGuard"
+
+msgid "refreshes the chunks around the player"
+msgstr "rafraichir les chunks autour du joueur"
+
+msgid "§eResending chunks to the client"
+msgstr "§eRenvoyer les chunks au client"
+
+msgid "load the region chunks"
+msgstr "charger les chunks de la région"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eChunks chargés à {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eChunks déchargés à {0}"
+
+msgid "update the WG regions"
+msgstr "mettre à jour les regions WG"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§eLes régions world guard des îles mit à jour pour {0}"
+
+msgid "§eNo island found at your location!"
+msgstr "§eAucune île trouvé à votre position !"
+
+msgid "refreshes the chunk around the player"
+msgstr ""
+
+msgid "region manipulations"
+msgstr "manipulations des régions"
+
+msgid "shows the borders of the current island"
+msgstr "voir les bordures de l'île actuelle"
+
+msgid "§eNo island found at your current location"
+msgstr "§eAucune île trouvé à votre position actuelle"
+
+msgid "§eCan only be executed as a player"
+msgstr "§ePeut être exécuté uniquement par un joueur"
+
+msgid "shows the borders of the current chunk"
+msgstr "voir les bordures du chunk actuel"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "voir les bordures du chunk interne"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "voir les bordures des chunks non alignés"
+
+msgid "shows the borders of the outer-chunks"
+msgstr "voir les bordures des chunks extérieurs"
+
+msgid "hides the regions again"
+msgstr "cacher de nouveau les régions"
+
+msgid "§eStopped displaying regions"
+msgstr "§eStopper l'affichage des régions"
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§eActuellement aucun régions à afficher pour ce joueur"
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§eAnimation des ticks changés en {0}."
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§eAnimation-tick doit être un nombre entier valide."
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4NETTOYAGE : Finit , îles abandonnés nétoyés."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4NETTOYAGE :§9 Purge annulée des îles abandonnées."
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§7- Scan: {0,number,##}% ({1}/{2} échoués: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4NETTOYAGE :§9 Scan interrompu."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§cINTERROMPU:§e La protection totale a été interrompu !"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr ""
+"§cProtection totale complété dans {0}, {1} nouvelles régions ont été crées !"
+
+msgid "control debugging"
+msgstr "gérer le debugging"
+
+msgid "set debug-level"
+msgstr "activer le debug-level"
+
+msgid "toggle debug-logging"
+msgstr "activer le debug-logging"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4Le logging n'est pas activé, donc vous ne pouvez pas le désactivé !"
+
+msgid "flush current content of the logger to file."
+msgstr "contenu actuel dans le fichier logger."
+
+msgid "§eLog-file has been flushed."
+msgstr "§eLe fichier log a été néttoyé."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4Le logging est désactivé, utilise §d/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Argument invalide , essayez INFO,FINE,FINER,FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eLogging désactivé !"
+
+msgid "advanced command for setting island-data"
+msgstr "commandes avancés pour la configurations des données de l'île"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§c{0} a été modifié en ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§cImpossible de modifier le champs {0} en \"{1}\""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr ""
+"§cImpossible de modifier le champs {0} en \"{1}\", un nombre est attendu"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§cChamp invalide {0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§eLa valeur actuelle pour {0} est \"{1}\""
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§cImpossible d'obtenir l'état pour {0}"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§eLes champs valides sont {0}"
+
+msgid "set a player''s island to your location"
+msgstr "fixer l'île d'un joueur à votre position"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr "infos avancées à propos du stuff NBT"
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "voir le NBTTag pour l'item tenu dans la main"
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§eInfo pour  §9{0}"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - nom: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - nbttag: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§cAucun item dans la main !"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "mettre le NBTTag sur l'item tenu dans la main"
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "§eMis §9{0}§e sur §c{1}"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "ajouter le NBTTag sur l'item tenu dans la main"
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§eAjouté §9{0}§e sur §c{1}"
+
+msgid "Manage challenges for a player"
+msgstr "Gérer les challenges pour un joueur"
+
+msgid "resets the challenge for the player"
+msgstr "réinitialise le challenge pour le joueur"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4Le challenge n'a jamais été réalisé"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§echallenge: {0} a été rénitialisé pour {1}"
+
+msgid "resets all challenges for the player"
+msgstr "rénitialise tous les challenges pour le joueur"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0} a eu tous les challenges réinitialisés."
+
+msgid "complete all challenges in the rank"
+msgstr "complète tout les challenges dans le rang"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4Aucun joueur nommé {0} a été trouvé !"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4Le challenge {0} a déjà été complété"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§eLe challenge {0} a été complété pour {1}"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4Aucun challenge nommé {0} a été trouvé !"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4Aucun rang nommé {0} a été trouvé !"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "protéger toutes les îles (temps)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§cEssayer d'annuler toutes les tâches de protection."
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4Désolé !§e Une protection total est déjà en cours. Laissez le se terminer, "
+"ou utilisez §9usb protectall §cstop"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr ""
+"§eDémarrage d'une protection complète. Cela risque de prendre un certain "
+"temps."
+
+msgid "reload configuration from file."
+msgstr "recharher la configuration à partir du fichier."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eConfiguration rechargé depuis le fichier."
+
+msgid "manage islands"
+msgstr "gérer les îles"
+
+msgid "protects the island"
+msgstr "protéger les îles"
+
+msgid "delete the island (removes the blocks)"
+msgstr "supprimer l'île (supprimer les blocks)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§eSupprimer une île abandonée à votre position actuelle."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4L'île à cette position possède des membres !\n"
+"§eUtilise §/usb island delete <nom> §epour là supprimer."
+
+msgid "removes the player from the island"
+msgstr "supprimer le joueur de votre île"
+
+msgid "adds the player to the island"
+msgstr "ajouter le joueur à votre île"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d a rejoint votre île."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4Aucun joueur nommé {0} trouvé !"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr "§4Aucune île indiquée. Essayez de fournir un nom d'île"
+
+msgid "print out info about the island"
+msgstr "afficher les informations à propos de l'île"
+
+msgid "sets the biome of the island"
+msgstr "définir le biome de l'île"
+
+msgid "§4That player has no island."
+msgstr "§4Ce joueur n'a pas d'île."
+
+msgid "§4No valid island at your location"
+msgstr "§4Ile invalide à votre position"
+
+msgid "purges the island"
+msgstr "nettoyer l'île"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4Erreur ! §9Aucune île valide à nettoyer."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cNETTOYAGE : §9Ile nettoyé à {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "activer"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cMettre l''île de {0} à ignorer sur le top dix et la nettoyer."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cRetirer le flag ignoré de l''île de {0}, elle apparaitra maintenant sur le "
+"top dix et le nettoyage."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Aucun pseudo valide fourni."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Suppression de {0} de l'ile"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eChangé le biome de l''île de {0} en {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eLe biome de l''île de {0} a été changé en OCEAN."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr ""
+"§aVous avez besoin d'aller au spawn, ou se reconnecter, pour voir les "
+"changements."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} a eu son biome changé en {1}"
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} a eu son biome changé en OCEAN."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eL''île de {0} a été retiré."
+
+msgid "Error: That player does not have an island!"
+msgstr "Erreur : Ce joueur n'a pas d'île !"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§eL''île de {0} à {1} a été protégé"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4L''île de {0} à {1} est déjà protégé"
+
+msgid "displays version information"
+msgstr "afficher les informations sur la version"
+
+msgid "imports players and islands from other formats"
+msgstr "importer les joueurs et les îles depuis un autre format"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr ""
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "changer le langage du plugin, et le recharger"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aLangage changé avec succès en §e{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cLe langage n''a pas pu être changé en §e{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Langues supportés:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 par {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cImpossible de trouver toutes les langues."
+
+msgid "advanced command for getting island-data"
+msgstr "commandes avancées pour obtenir les données de l'île"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate Skyblock Admin"
+
+msgid "show player-information"
+msgstr "voir les informations des joueurs"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4Votre île est pleine, ou vous avez trop d'invitations en attente. Vous ne "
+"pouvez pas inviter quelqu'un d'autre."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4Ce joueur est déjà le chef d'une autre île."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e veut vous inviter, mais vous êtes déjà dans un groupe."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e vous invite à rejoindre son île !"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§f/island [accept/reject]§e pour accepter ou rejeter l'invitation."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4ATTENTION: Vous perdrez votre île si vous acceptez !"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d a invité {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e a rejeté l'invitation."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4Vous ne pouvez pas utiliser cette commande en ce moment. Quittez votre "
+"premier groupe actuel."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§aVous avez rejoint une îe ! Utiliser /island party pour voir les autres "
+"membres."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§eL''invitation pour {0}§e a expiré ou a été annulé."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§eL'invitation pour l'île de {0} a expiré ou a été annulé."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§eVous avez accepté l'invitation pour rejoindre l'île."
+
+msgid "§4You haven't been invited."
+msgstr "§4Vous n'avez pas été invité."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eVous avez rejeté l'invitation pour rejoindre l'île."
+
+msgid "general island command"
+msgstr "commandes générales"
+
+msgid "allows user to bypass cooldowns"
+msgstr ""
+
+msgid "allows user to bypass visitor-protections"
+msgstr ""
+
+msgid "allows user to bypass teleport-delay"
+msgstr ""
+
+msgid "allows user to use [usb] signs"
+msgstr ""
+
+msgid "allows user to place [usb] signs"
+msgstr ""
+
+msgid "complete and list challenges"
+msgstr "liste des challenges"
+
+msgid "§cCommand only available for players."
+msgstr "§cCommande disponible uniquement pour les joueurs."
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eChallenge désactivé. Contactez un administrateur."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr ""
+"§4Vous devez être dans le monde Skyblock pour compléter les challenges !"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4Vous devez avoir une île pour compléter les challenges !"
+
+msgid "warp to another player''s island"
+msgstr "utiliser le warp d'une autre île"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr "§aVotre warp est actif, les joueurs peuvent utiliser votre warp."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr "§4Votre warp est inactif, les joueurs ne peuvent utiliser votre warp."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr "§fDéfinir le warp à votre position §e/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§fActivé/Désactivé le warp §e/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4Vous n'avez pas la permission de créer un warp sur votre île !"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§fUtiliser le warp d'une autre île §e/island warp <joueur>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4You n'avez pas la permission utiliser le warp de d'autres îles !"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cVotre île est en géneration, vous ne pouvez pas vous téléporter sur "
+"d'autres îles."
+
+msgid "§4That player does not exist!"
+msgstr "§4Ce joueur n'éxiste pas !"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4Ce joueur n'a pas de warp actif."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr "§cL'île du joueur se genère, vous ne pouvez pas vous y téléporter."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cATTENTION: §9{0}§e a été téléporte à votre île !"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4Ce jour vous a interdit de vous téléporter à son île."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4Aucun île. §eUtilise §b/is create§e pour en avoir une"
+
+msgid "accept/reject an invitation."
+msgstr "accepter/rejeter une invitation."
+
+msgid "leave your party"
+msgstr "quitter votre groupe"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4Vous ne pouvez pas quitter votre île quand vous êtes tout seul. Essayez /"
+"island restart si vous en voulez une nouvelle !"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr ""
+"§eVous êtes le propriétaire de l'île, utiliser /island remove <joueur> à la "
+"place."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eVos avez quitté l'île et vous êtes retourné au spawn des joueurs."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0} a quitté votre île !"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4Vous devez être dans le monde skyblock pour quitter l'île !"
+
+msgid "check your or anothers island level"
+msgstr "vérifier le niveau des autres îles"
+
+msgid "allows user to query for others levels"
+msgstr ""
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eVous devez être sur votre île pour utiliser cette commande."
+
+msgid "§4You do not have an island!"
+msgstr "§4Vous n'avez pas d'île !"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4Vous n'avez pas accès à cette commande !"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4Joueur invalide ou le joueur n'a pas d'île !"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eInformations à propos de l''île de {0}:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aLe niveau de votre île est {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9Votre rang est {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "créer une île"
+
+msgid "exempt player from create-cooldown"
+msgstr ""
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4Ile trouvé !§e Vous avez déjà une île. Si vous voulez une nouvelle île, "
+"tape§b /is restart§e pour en avoir une nouvelle"
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr "§4Ile trouvé! §e Vous êtes déjà"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eVous pouvez créer une île dans {0,number,#} secondes."
+
+msgid "invite a player to your island"
+msgstr "inviter un joueur sur votre île"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§eUtiliser§f /island invite <pseudo> §e pour inviter un joueur sur votre île."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4Seul le propriétaire de l'île peut inviter !"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aVous pouvez inviter maximum {0} joueurs."
+
+msgid "§4You can't invite any more players."
+msgstr "§4Vous ne pouvez pas inviter plus de joueurs."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr ""
+"§4Vous n'avez pas la permission pour inviter d'autres joueur sur l'île !"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4Ce joueur est hors-ligne ou n'éxiste pas."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4Vous ne pouvez pas vous inviter vous même !"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4Ce joueur est le chef de votre île !"
+
+msgid "lock your island to non-party members."
+msgstr "vérrouiller votre île aux non-membres de votre île."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4Vous n'avez pas la permission pour vérrouillé votre île !"
+
+msgid "§4You don't have access to this command!"
+msgstr "§eVous n'avez pas accés à cette commande !"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4Vous n'avez pas la permission pour dévérouille votre île !"
+
+msgid "display the top10 of islands"
+msgstr "afficher le top 10 des îles"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr ""
+
+msgid "remove a member from your island."
+msgstr "retirer un membre de votre île."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4Vous n'avez pas la permission pour virer d'autres joueurs de l'île !"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4Vous ne pouvez pas exclurer le chef de l'île !"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4Vous ne pouvez pas vous exclure vous même !"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0} vous a retiré de l'île !"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} a été retiré de l'île."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4{0} a essayé de vous kick de son île !"
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4{0} est excepté du kick de l'île."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4{0} vous a kické de son île !"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0} a été kické de l'île."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr "§4Ce joueur n'est pas dans votre groupe, ni dans votre île !"
+
+msgid "teleport to the island home"
+msgstr "téléporter au home de l'île"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr "§cVotre île génére, vous ne pouvez vous téléporter maintenant."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§Cette commande ne peut être exécuter que par un joueur"
+
+msgid "transfer leadership to another member"
+msgstr "transférer le chef à un autre membre"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4Seul un membre de votre île peut devenir chef !"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e est déjà le chef de l'île !"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4Seul le chef peut transférer le rang de chef !"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} a essayé de reprendre l'île !"
+
+msgid "show party information"
+msgstr "voir les informations de votre île"
+
+msgid "shows information about your party"
+msgstr "voir les informations à propos de votre île"
+
+msgid "show pending invites"
+msgstr "voir les invitations en attente"
+
+msgid "§eNo pending invites"
+msgstr "§eAucunes invitations en attente"
+
+msgid "withdraw an invite"
+msgstr "retirer une invitation"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4Vous n'avez pas la permission pour inviter des joueurs."
+
+msgid "check your or another''s island info"
+msgstr "vérifier les informations d'une autre île"
+
+msgid "allows user to see others island info"
+msgstr ""
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBlocks sur l''île de {0} (page {1,number} of {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Nombre de blocks"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "ajouter/retirer un joueur pour vous aider sur votre île."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eLes membres auxquels vous faites confiance:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eLes chefs auxquels vous faites confiance:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr ""
+"§ePour ajouter/retirer des membres de confiances, /island trust <joueur>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4Membre déjà ajouté !"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Joueur inconnu {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eVous avez ajouté §4{0}§e comme joueur de confiance sur l'île."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} a ajouté {1} comme membre de confiance sur l'île"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eVous n'êtes plus un joueur de confiance sur l'île de §4{0}."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0}a retiré le joueur {1} comme membre de confiance sur l'île"
+
+msgid "delete your island and start a new one."
+msgstr "supprimer votre île et créer une nouvelle."
+
+msgid "exempt player from restart-cooldown"
+msgstr ""
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4Uniquement le chef de l'île peut remettre à zéro l'île. Quittez l'île pour "
+"créer la votre (/island leave)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eVous devez enlever tout les joueurs de votre île avant de le remettre à "
+"zéro (/island kick <joueur>. Pour voir les membres de votre île faites /"
+"island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§cVous pouvez remettre à zéro votre île dans {0} secondes."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr ""
+"§cVotre île est en génération, vous ne pouvez la remettre à zéro maintenant."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr ""
+"§eRAPPEL: La totalité de votre île et tous vos biens seront remis à zéro !"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "téléporter au spawn du skyblock"
+
+msgid "change the biome of the island"
+msgstr "changer le biome de votre île"
+
+msgid "exempt player from biome-cooldown"
+msgstr ""
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr ""
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr "§cVous n'avez pas la permission de changer le biome de l'île actuelle."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4Vous n'avez pas la permission de changer le biome de l'île !"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eVous devez être sur votre île pour changer le biome !"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr ""
+"§cVous avez mal orthographié le nom du biome. Doit faire parti de cette "
+"liste : {0}"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eVous ne pouvez pas changer le biome avant {0,number,#} minutes."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§cVous n'êtes pas autorisé à changer votre biome vers ce type."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr ""
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aVous avez changé le biome de l''île en {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} a changé le biome de l''île en {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr ""
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr ""
+
+msgid "set your island''s warp location"
+msgstr "modifier la position du point de spawn du warp"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr ""
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§cVous devez être le chef de l'île pour modifier le warp !"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d a changé la position du warp de l'île."
+
+msgid "teleports you to your island (or create one)"
+msgstr "vous téléporte sur votre île (ou en crée une)"
+
+msgid "ban/unban a player from your island."
+msgstr "bannir/débannir un joueur de votre île."
+
+msgid "exempts user from being banned"
+msgstr ""
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§eLes joueurs bannis du warp de votre île :"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr "§ePour bannir/debannir un joueur de votre île, /island ban <pseudo>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4Vous ne pouvez pas bannir de joueur. Retirer les de l'île d'abord !"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4Vous n'avez pas la permission pour exclure/bannir des joueurs."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§eImpossible de ban ce joueur (joueur inconnu) {0}"
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4{0} a essayé de vous bannir de leur île !"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4{0} est excepté du bannissement."
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eVous avez banni §4{0}§e du warp de votre île."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eVous avez été §cBANNI§e de l''île de {0}."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§eVous avez débanni §a{0}§e du warp de votre île."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eVous avez été §aDEBANNI§e de l''île de {0}."
+
+msgid "display log"
+msgstr "afficher les logs"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "modifier le home de l'île"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "activer/désactiver le warp à votre île."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4Votre île est vérrouillé. Vous devez la dévérouilleé pour activer votre "
+"warp."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d a activé le warp de l'île."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr ""
+
+msgid "try to complete a challenge"
+msgstr "essayer de completer un challenge"
+
+msgid "show information about the challenge"
+msgstr "voir les informations à propos du challenge"
+
+msgid "§eRank: "
+msgstr "§eRang : "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4Ce challenge ne peut être refait !"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr ""
+"§eVous perdrez tous les éléments nécessaires lorsque vous remplirez ce "
+"challenge !"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4Tous les élements requis doivent être placés sur votre île, dans {0} blocs "
+"autour de vous."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§ePour compléter le challenge, utilise §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4Nom de challenge invalide ! Utilise /c help pour plus d'informations"
+
+msgid "§eSending you to spawn."
+msgstr "§aTéléportation au spawn."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§eL'île a été §cVÉRROUILLÉ§e."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr "§9Vous n'êtes pas vraiment patient, n'est-ce pas ?"
+
+msgid "§9Be patient, young padawan"
+msgstr "§9Soyez patient, jeune padawan"
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr "§9Jeune padawan, la patience tu DOIS avoir"
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4Impossible de trouver un endroit sécurisé sur votre île !"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§cATTENTION : §eTéléportation en plein air."
+
+msgid "§aTeleporting you to your island."
+msgstr "§aTéléportation à votre île."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aVous serez téléporté dans {0} secondes."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Impossible d'utiliser le warp de cette île !"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aTéléporté à l''île de {0}."
+
+msgid "§7Teleport cancelled"
+msgstr "§7Téléportation annulée"

--- a/uSkyBlock-Core/src/main/po/it.po
+++ b/uSkyBlock-Core/src/main/po/it.po
@@ -12,6 +12,30 @@ msgstr ""
 "X-Generator: Poedit 2.0.9\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+msgid "d"
+msgstr "d"
+
+msgid "h"
+msgstr "h"
+
+msgid "m"
+msgstr "m"
+
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§eNon hai accesso (§4{0}§e)"
@@ -19,6 +43,15 @@ msgstr "§eNon hai accesso (§4{0}§e)"
 #, java-format
 msgid "§eInvalid command: {0}"
 msgstr "§eComando invalido: {0}"
+
+msgid "Command"
+msgstr "Comando"
+
+msgid "Permission"
+msgstr "Permesso"
+
+msgid "Description"
+msgstr "Descrizione"
 
 #, java-format
 msgid "§7Usage: {0}"
@@ -43,1711 +76,13 @@ msgstr "Scritta la documentazione su {0}"
 msgid "§4Error writing documentation: {0}"
 msgstr "§4Errore scrivendo la documentazione: {0}"
 
-msgid "Command"
-msgstr "Comando"
-
-msgid "Permission"
-msgstr "Permesso"
-
-msgid "Description"
-msgstr "Descrizione"
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-msgid "d"
-msgstr "d"
-
-msgid "h"
-msgstr "h"
-
-msgid "m"
-msgstr "m"
-
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
+msgid "§cWither Despawned!§e It wandered too far from your island."
 msgstr ""
+"§9* §7Il Wither è §4despawnato!§7 E'' andato troppo lontano dalla tua isola."
 
 #, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§4* §7Ancora i seguenti blocchi: §4{0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr "§4Puoi completare questo altre {0} volte."
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§7I requisiti saranno resettati tra §4{0} §7giorni."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§7I requisiti saranno resettati tra §4{0} §7ore."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§7I requisiti saranno resettati tra §4{0} §7minuti."
-
-msgid "§4This challenge is currently unavailable."
-msgstr "§a* §7Questa sfida è attualmente non disponibile."
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr "§a* §7Potrai completare questo ancora tra {0} giorni."
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr "§a* §7Potrai completare questo ancora tra {0} ore."
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr "§a* §7Potrai completare questo ancora tra {0} minuti."
-
-msgid "§eThis challenge requires:"
-msgstr "§eQuesta sfida richiede:"
-
-msgid "§7and more..."
-msgstr "§7e altro..."
-
-msgid "§eItems will be traded for reward."
-msgstr "§eGli oggetti saranno scambiati per una ricompensa."
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr "§eDeve essere entro {0} metri."
-
-msgid "§6Item Reward: §a"
-msgstr "§6Ricompensa Oggetti: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Ricompensa Monetaria: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Ricompensa XP: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dTotale volte completata: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr "§7Richiede {0}"
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4* §7Nessuna sfida chiamata §4{0} §7è stata trovata"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4* §7Devi essere sulla tua isola per farlo!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§a* §7La sfida {0} §4non §7è ancora disponibile!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4* §7La sfida §a{0} §7non si può ripetere!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr "§a* §7Non puoi completare di nuovo la sfida {0} ancora!"
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§a* §7Tentando di completare la sfida §a{0}"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr ""
-"§4* §7Devi essere entro §c{0} §7blocchi di tutti gli oggetti richiesti."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr ""
-"§4* §7La tua isola deve essere al livello §4{0} §7per completare questa "
-"sfida!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4* §7Tipo di sfida sconosciuto: §4{0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§4* §7Ancora le seguenti entità:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§a* §7Ti mancano i seguenti oggetti:§4{0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§a* §7Hai completato la sfida §a{0}§7!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§a* §6{0}§7 ha completato la sfida §a{1}§7!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§eRicompensa Oggetti: §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eRicompensa XP: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eRicompensa monetaria: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§9* §7Il tuo inventario è §4pieno§7. Oggetti droppati a terra."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§eClicca per completare questa sfida."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4Non puoi ripetere questa sfida."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Rango: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fCompleta la maggior parte delle sfide in"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fquesto rango per sbloccare il prossimo."
-
-msgid "§eClick here to show previous page"
-msgstr "§eClicca qui per la pagina precedente"
-
-msgid "§eClick here to show next page"
-msgstr "§eClicca qui per la prossima pagina"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lSfida Bloccata"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "§7Completa altre {0} sfide {1}"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Completa §a{0}"
-
-msgid "to unlock this rank"
-msgstr "per sbloccare questo rango"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "§7Ma sei SOLLLLLLL SOOOOOLO!"
-
-msgid "But you are Yelling in the wind!"
-msgstr "§7Ma stai Parlando al vento!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "§7Ma i tuoi amici di fantasia sono andati!"
-
-msgid "But you are Talking to your self!"
-msgstr "§7Ma stai Parlando a te stesso!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§4* §7Scusa! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr "Invia un messaggio direttamente al tuo gruppo, o impostalo on/off."
-
-msgid "party"
-msgstr "party"
-
-msgid "island"
-msgstr "isola"
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§cChat impostata a {0} §aON"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§cRipeti §9{0}§c per impostarlo su off"
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§aChat impostata su §cOFF§a per {0}"
-
-msgid "§cCommand only available to players"
-msgstr "§cComando disponibile solo per i giocatori"
-
-msgid "talk to players on your island"
-msgstr "parla ai giocatori nella tua isola"
-
-msgid "talk to your island party"
-msgstr "parla ai membri del tuo party"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§9* §7Il giocatore §6{0} §7non ha un''isola!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§4* §7Giocatore §6{0} §7specificato non valido."
-
-msgid "Manage challenges for a player"
-msgstr "Gestisce le sfide per un giocatore"
-
-msgid "resets the challenge for the player"
-msgstr "resetta la sfide per il giocatore"
-
-msgid "§4Challenge has never been completed"
-msgstr "§a* §7La sfida non è mai stata completata"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§a* §7sfida: §a{0} è stata resettata per §6{1}"
-
-msgid "resets all challenges for the player"
-msgstr "resetta tutte le sfide per il giocatore"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§a* §6{0} §7ha avuto tutte le sfide resettate."
-
-msgid "complete all challenges in the rank"
-msgstr "completa tutte le sfide nel rango"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4* §7Nessun giocatore chiamato §6{0} §7trovato!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4La sfida {0} è già stata completata"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§a& §7La sfida §a{0} §7è stata completata per §6{1}"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4* §7Nessuna sfida chiamata §a{0} §7trovata!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4* §7Nessun rango chiamato §a{0} §7trovato!"
-
-msgid "manage islands"
-msgstr "gestisce le isole"
-
-msgid "protects the island"
-msgstr "protegge l''isola"
-
-msgid "delete the island (removes the blocks)"
-msgstr "elimina l''isola (rimuove i blocchi)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9* §7Cancellata un''isola abbandonata nella tua posizione."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4* §7L''isola in questa posizione ha dei membri!\n"
-"§4* §7Usa §a/usb island delete <nome>§7 per cancellarla."
-
-msgid "removes the player from the island"
-msgstr "rimuove il giocatore dall''isola"
-
-msgid "adds the player to the island"
-msgstr "aggiunge il giocatore all''isola"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§6{0} §7è entrato nel tuo party."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4* §7Nessun giocatore chiamato §6{0} §7trovato!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-"§4* §7Nessuna isola valida fornita, vai su un''isola, o fornisci il nome di "
-"un''isola"
-
-msgid "print out info about the island"
-msgstr "mostra le informazioni sull''isola"
-
-msgid "sets the biome of the island"
-msgstr "imposta il bioma dell''isola"
-
-msgid "§4That player has no island."
-msgstr "§4* §7Quel giocatore non ha un''isola."
-
-msgid "§4No valid island at your location"
-msgstr "§4* §7Nessuna isola valida alla tua posizione"
-
-msgid "purges the island"
-msgstr "ripulisce l''isola"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4* Errore! §7Nessuna isola valida trovata per la pulizia."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§4* PULIZIA: §7Ripulita l''isola a {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "cambia lo stato delle isole di ignorato"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr ""
-"§4* §7Imposta l''isola di §4 {0}s §7come ignorata nella top-tene la "
-"ripulisce."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§4* §7Tolto lo stato di ignorato all''isola di §4{0} §7,sarà ora mostrata "
-"nella top-ten e ripulita."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4* §7Nome giocatore fornito non valido."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "§4* §7Rimuovendo §6{0} §7dall''isola"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§9* §7Cambiato il bioma dell''isola di §6{0} §7a {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§9* §7Cambiato il bioma dell''isola di §6{0} §7a OCEANO."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr ""
-"§9* §7Potresti dover andare allo spawn, o riloggare, §7per vedere i "
-"cambiamenti."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§9* §6{0} §7ha avuto il suo bioma cambiato a {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§9* §6{0} §7hanno avuto il loro bioma cambiato ad OCEANO."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§4* §7Rimuovendo l''isola di §6{0} §7."
-
-msgid "Error: That player does not have an island!"
-msgstr "Errore: Quel giocatore non ha un''isola!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§4* §7L''isola di §6{0} §7a {1} è stata protetta"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4* §7L''isola di §6{0} §7a {1} è già protetta"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "apre la GUI per la config"
-
-msgid "searches config for a specific key"
-msgstr "cerca nella config una chiave specifica"
-
-#, java-format
-msgid "§c{0}§9"
-msgstr "§c{0}§9"
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr "§9{0}§8: §e{1}"
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr "Trovati i seguenti risultati {0}:"
-
-msgid "§a<section>"
-msgstr "§a<sezione>"
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr "§3{0,number,#.##}"
-
-#, java-format
-msgid "§2{0}"
-msgstr "§2{0}"
-
-msgid "§eInvalid configuration name"
-msgstr "§4* §7Nome configurazione non valido"
-
-msgid "Controls player-cooldowns"
-msgstr "Controlla le ricariche dei giocatori"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "cancella la ricarica su un comando (* = tutti)"
-
-msgid "§eThe player is not currently online"
-msgstr "§4* §7Il giocatore non è online"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Cancellata la ricarica su {0} per {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Nessuna ricarica attiva su {0} per {1} rilevata!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Comando fornito invalido, solo riavvio e bioma supportati!"
-
-msgid "restarts the cooldown on the command"
-msgstr "riavvia la ricarica sul comando"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§4* §7Reimpostata la ricarica su {0} per {1}§7 a {2} secondi"
-
-msgid "lists all the active cooldowns"
-msgstr "elenca tutte le ricariche attive"
-
-msgid "§eCmd Cooldown"
-msgstr "§9* §7Ricarica Cmd"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§4* §7Nessuna ricarica attiva per §6{0}§7 trovata."
-
-msgid "control debugging"
-msgstr "controlla il debugging"
-
-msgid "set debug-level"
-msgstr "imposta il livello-debug"
-
-msgid "toggle debug-logging"
-msgstr "attiva/disattiva il debug-logging"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4* §7Il logging non era attivo, quindi non puoi disabilitarlo!"
-
-msgid "flush current content of the logger to file."
-msgstr "scrive il contenuto corrente del logger su file."
-
-msgid "§eLog-file has been flushed."
-msgstr "§4* §7Il file-log è stato scritto."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4* §7Il logging non è abilitato, usa §a/usb debug §7enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr ""
-"§4* §7Argomento non valido, prova §eINFO§7, §6FINE§7, §cFINER§7, §4FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§4* §7Logging disabilitato!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "tenta di correggere l''area di pianura."
-
-msgid "§4No valid island found"
-msgstr "§4* §7Nessuna isola valida trovata"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4* §7Nessuna pianura rilevata nell''isola di §6{0}§7!"
-
-msgid "flushes all caches to files"
-msgstr "scrive tutte le cache sui file"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-"§9* §7Scritti §a{0} isole§e, §b{1} giocatori e §6{2} completamenti-sfida."
-
-msgid "manually update the top 10 list"
-msgstr "aggiorna manualmente la top 10"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§9* §7Generando la lista Top Ten"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§4* §7Finita la generazione della lista Top Ten"
-
-msgid "advanced command for getting island-data"
-msgstr "comando avanzato per ottenere i dati-isola"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§4* §7Il valore corrente per {0} è ''{1}''"
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§4* §7Impossibile ottenere lo stato per {0}"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§4* §7Campi validi sono {0}"
-
-msgid "teleport to another players island"
-msgstr "teletrasporta nell''isola di altri giocatori"
-
-msgid "§4Only supported for players"
-msgstr "§4* §7Supportato solo per i giocatori"
-
-msgid "§4That player does not have an island!"
-msgstr "§4* §7Quel giocatore non ha un''isola!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr "§9* §7Teletrasporto all''isola di §6{0}§7."
-
-msgid "imports players and islands from other formats"
-msgstr "importa i giocatori e le isole da altri formati"
-
-msgid "controls async jobs"
-msgstr "controlla i processi asincroni"
-
-msgid "§9Job Statistics"
-msgstr "§9* §7Statistiche Lavori"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/job"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "tick"
-
-msgid "act"
-msgstr "act"
-
-msgid "time"
-msgstr "tempo"
-
-msgid "name"
-msgstr "nome"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "cambia la lingua del plugin, e lo ricarica"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§4* §7Lingua cambiata con successo a §4{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§4* §7Fallito nel cambiare la lingua a §4{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9* §7Lingue Supportate:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§4* §7Impossibile individuare tutte le lingue."
-
-msgid "transfer leadership to another player"
-msgstr "trasferisce la leadership a un altro giocatore"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4* §6Il giocatore {0} §7non ha un''isola da trasferire!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§4* §7Il giocatore §6{0} §7ha già un''isola. §7Usa §a/usb island remove "
-"<nome>§7 prima per rimuoverlo."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§4* §7La leadership è stata trasferita da §4{0} §7a §a{1}"
-
-msgid "advanced info about NBT stuff"
-msgstr "§9* §7info avanzate sull''NBT"
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "§9* §7mostra i Tag NBT per l''oggetto corrente in mano"
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§e* §7Info per §9{0}"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - nome: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - tag nbt: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§4* §7Nessun oggetto in mano!"
-
-msgid "§eCan only be executed as a player"
-msgstr "§4* §7Può essere eseguito solo come giocatore"
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "§9* §7imposta la Tag NBT sull''oggetto corrente in mano"
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "§e* §7Impostato §9{0}§e a §c{1}"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "§9* §7aggiunge la Tag NBT nell''oggetto corrente in mano"
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§e* §7Aggiunto §9{0}§e a §c{1}"
-
-msgid "manage orphans"
-msgstr "gestisce gli orfani"
-
-msgid "count orphans"
-msgstr "conta gli orfani"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§4* §7{0} i luoghi vecchi dell''isola verranno usati prima dei nuovi."
-
-msgid "clear orphans"
-msgstr "pulisce gli orfani"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§4* §7Cancellando tutti i vecchi (vuoti) luoghi dell''isola."
-
-msgid "list orphans"
-msgstr "elenca gli orfani"
-
-msgid "§eNo orphans currently registered."
-msgstr "§4* §7Non ci sono attualmente orfani registrati."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr "§eOrfani ({0}/{1}): {2}"
-
-msgid "shows perk-information"
-msgstr "mostra le informazioni sui vantaggi"
-
-msgid "shows a specific players perks"
-msgstr "mostra vantaggi specifici per i giocatori"
-
-#, java-format
-msgid "additional perks {0}"
-msgstr "vantaggi aggiuntivi {0}"
-
-msgid "protects all islands (time consuming)"
-msgstr "protegge tutte le isole (richiede tempo)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§4* §7Cercando di abortire il processo proteggi-tutto."
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-"§4* Scusa!§7 Un proteggi-tutto è già in esecuzione. Lascialo completare, o "
-"usa §9/usb protectall §4stop"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§4* §7Avviando un processo proteggi-tutto. Può richiedere tempo."
-
-msgid "purges all abandoned islands"
-msgstr "ripulisce tutte le isole abbandonate"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4* §7Devi fornire l''età in giorni per ripulire!"
-
-msgid "§4The level must be a valid number"
-msgstr "§4Il livello deve essere un numero valido"
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-"§eRicerca in corso di tutte le isole che sono state abbandonate da più di "
-"{0} giorni sotto il livello {1}"
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr "§4PULIZIA:§e Fai §9usb purge confirm§e entro {0} per accettare."
-
-msgid "§4Trying to abort purge"
-msgstr "§4* §7Provando ad interrompere la pulizia"
-
-msgid "§4Purge aborted!"
-msgstr "§4Pulizia interrotta!"
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-"§4Una pulizia è già in esecuzione.§e O §9confermala§e o §9interrompila§e."
-
-msgid "§4Starting purge..."
-msgstr "§4* §7Avviando la pulizia..."
-
-msgid "region manipulations"
-msgstr "manipolazioni delle regioni"
-
-msgid "shows the borders of the current island"
-msgstr "mostra i confini dell''isola corrente"
-
-msgid "§eNo island found at your current location"
-msgstr "§4* §7Nessuna isola trovata alla tua posizione"
-
-msgid "shows the borders of the current chunk"
-msgstr "mostra i confini del chunk corrente"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "mostra i confini dei chunk interni"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "mostra i confini dei chunk non allineati"
-
-msgid "shows the borders of the outer-chunks"
-msgstr "mostra i confini dei chunk esterni"
-
-msgid "hides the regions again"
-msgstr "nasconde ancora le regioni"
-
-msgid "§eStopped displaying regions"
-msgstr "§4* §7Arrestata la visualizzazione delle regioni"
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§4* §7Nessuna regione mostrata per questo giocatore"
-
-msgid "set the ticks between animations"
-msgstr "imposta i tick tra le animazioni"
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§4* §7Animation-tick changed to {0}."
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§4* §7Animation-tick must be a valid integer."
-
-msgid "refreshes the existing animations"
-msgstr "aggiorna le animazioni esistenti"
-
-msgid "set a player''s island to your location"
-msgstr "imposta un''isola del giocatore alla tua posizione"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr "§aImpostata l''isola di {0} a quella attuale."
-
-msgid "§4Island not found: unable to set the island!"
-msgstr "§4Isola non trovata: impossibile impostare l'isola!"
-
-msgid "reload configuration from file."
-msgstr "ricarica la configurazione dal file."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§4* §7Configurazione ricaricata dal file."
-
-msgid "advanced command for setting island-data"
-msgstr "comando avanzato per impostare i dati dell''isola"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§4* §7{0} è stato impostato a ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§4* §7Impossibile impostare il campo {0} a ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr ""
-"§4* §7Impossibile impostare il campo {0} a ''{1}'', si aspettava un numerico"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§4* §7Campo non valido {0}"
-
-msgid "toggles maintenance mode"
-msgstr "§9* §7attiva/disattiva la modalità manutenzione"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-"§4* MANUTENZIONE: §aAttivata§7, tutte le funzioni di uSkyBlock sono "
-"attualmente disabilitate."
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-"§4* MANUTENZIONE: §4Disattivata§7, tutte le funzioni di uSkyBlock sono di "
-"nuovo operative."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr "§4* §7La modalità manutenzione può essere cambiata solo dalla console!"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§4* ABORTITO:§7 Proteggi-Tutto è stato abortito!"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr "§e* §7Completato proteggi-tutto in {0}, {1} nuove regioni create!"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§4* §7- SCANSIONE: {0,number,##}% ({1}/{2} fallito: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4* PULIZIA:§7 Scansione interrotta."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-"§4PULIZIA:§9 Scansione completata, trovati {0} candidati, sotto il livello "
-"{1}, pronti per la pulizia."
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-"- PULIZIA: {0,number,##}% ({1}/{2}), trascorso {3}, stimato per "
-"completamento ~{4}"
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4* PULIZIA:§7 Finito di ripulire le isole abbandonate."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4* PULIZIA:§7 Abortita la pulizia delle isole abbandonate."
-
-msgid "displays version information"
-msgstr "visualizza informazioni sulla versione"
-
-msgid "various WorldGuard utilities"
-msgstr "varie utilità di WorldGuard"
-
-msgid "refreshes the chunks around the player"
-msgstr "aggiorna i chunk attorno al giocatore"
-
-msgid "§eResending chunks to the client"
-msgstr "§4* §7Reinviando i chunk al client"
-
-msgid "load the region chunks"
-msgstr "carica i chunk di una regione"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§4* §7Caricamento dei chunk a {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§4* §7Scaricamento dei chunk a {0}"
-
-msgid "update the WG regions"
-msgstr "§4* §7aggiorna le regioni di WG"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§4* §7Regioni world-guard dell''isola aggiornate per {0}"
-
-msgid "§eNo island found at your location!"
-msgstr "§4* §7Nessuna isola trovata alla tua posizione!"
-
-msgid "refreshes the chunk around the player"
-msgstr "ricarica il chunk attorno al giocatore"
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "mostra le informazioni-giocatore"
-
-msgid "try to complete a challenge"
-msgstr "tenta di completare una sfida"
-
-msgid "§cCommand only available for players."
-msgstr "§4* §7Comando eseguibile solo dai giocatori."
-
-msgid "show information about the challenge"
-msgstr "mostra le informazioni sulla sfida"
-
-msgid "§eRank: "
-msgstr "§eRango: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4Questa Sfida non è ripetibile!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr ""
-"§4* §7Perderai tutti gli oggetti richiesti quando completerai questa sfida!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4* §7Tutti gli oggetti richiesti devono essere piazzati sulla tua isola, "
-"entro §c{0} §7blocchi da te."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§a* §7Per completare questa sfida, usa §a/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4* §7Nome sfida invalido! Usa §a/c §7help per maggiori informazioni"
-
-msgid "complete and list challenges"
-msgstr "completa ed elenca le sfide"
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§4* §7Le sfide sono state disabilitate. Contatta un admin."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4* §7Puoi inviare sfide solo nel mondo skyblock!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4* §7Puoi fare sfide solo quando hai un''isola!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4* §7La tua isola è piena, o hai troppi inviti in attesa. Non puoi invitare "
-"nessun altro."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4* §7Quel giocatore è già leader di un''altra isola."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§9* §{0}§7 ha provato ad invitarti, ma sei già in un party."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr "§9* §7Invito inviato a {0}"
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "§9* §6{0} §7ti ha invitato ad entrare nella sua isola!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr ""
-"§9* §f/island [accept/reject]§7 per §aaccettare o §4rifiutare §7l''invito."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4* AVVERTIMENTO§7: Se accetterai l''invito perderai la tua isola!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "§6{0}§a ha invitato §6{1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "§9* §6{0} §7ha §4rifiutato §7l''invito."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr "§4* §7Non puoi usare questo comando ora. Prima lascia il tuo party."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§9* §7Sei entrato in un''isola! Usa §a/island party §7per vedere gli altri "
-"membri."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§7L''invito per §6{0} §7è scaduto o è stato cancellato."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§9* §7L''invito per l''isola di §6{0} è scaduto o stato cancellato."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§9* §7Hai §aaccettato §7l''invito per entrare in un''isola."
-
-msgid "§4You haven't been invited."
-msgstr "§9* §7Non sei stato invitato."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§9* §7Hai §4rifiutato §7l''invito per entrare in un''isola."
-
-msgid "accept/reject an invitation."
-msgstr "accetta/rifiuta un invito."
-
-msgid "teleports you to your island (or create one)"
-msgstr "§9* §7ti teletrasporta alla tua isola (o ne crea una)"
-
-msgid "ban/unban a player from your island."
-msgstr "banna/sbanna un giocatore dalla tua isola."
-
-msgid "exempts user from being banned"
-msgstr "esenta un utente dall''essere bannato"
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr ""
-"§4* §7I seguenti giocatori sono §4bannati §7dal fare il warp alla tua isola:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr ""
-"§9* §7Per §4bannare§7/§asbannare §7dalla tua isola, usa §a/island ban "
-"<giocatore>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4* §7Non puoi bannare i membri. §4Rimuovili §7prima!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4* §7Non hai il permesso per cacciare/bannare giocatori."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§e* §7Impossibile bannare il giocatore sconosciuto {0}"
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4* §7{0} ha provato a §4bannarti §7dalla loro isola!"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4* §7{0} è esente dall''essere bannato."
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§4* §7Hai bannato §4{0}§7 dal fare il warp alla tua isola."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§4* §7Sei stato §4BANNATO§7 dall''isola di §6{0}§7."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§9* §7Hai §asbannato §6{0} §7dal fare il warp alla tua isola."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§9* §7Sei stato §aSBANNATO§7 dall''isola di §6{0}§7."
-
-msgid "change the biome of the island"
-msgstr "cambia il bioma dell''isola"
-
-msgid "exempt player from biome-cooldown"
-msgstr "esenta il giocatore dalla ricarica-bioma"
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr "Lascia il giocatore cambiare il bioma della sua isola a {0}"
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr ""
-"§4* §7Non hai il permesso di cambiare il bioma della tua isola corrente."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4* §7Non hai il permesso di cambiare il bioma di questa isola!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§4* §7Devi essere sulla tua isola per cambiare il bioma!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr "§4* §7Hai scritto male il nome del bioma. Deve essere uno di {0}"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§9* §7Potrai cambiare il tuo bioma ancora tra §c{0,number,#} §7minuti."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§4* §7Non hai il permesso di cambiare il tuo bioma in quel tipo."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-"§2* §7I pixie sono impegnati a cambiare il bioma vicino a te a §9{0}§7, sii "
-"paziente."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-"§a* §7I pixie sono occupati cambiando il bioma della tua isola a §9{0}§7, "
-"sii paziente."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr "§4* §7Bioma {0} fornito invalido!"
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§9* §7Hai cambiato il bioma della tua isola a §a{0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "§9* §6{0} §7ha cambiato il bioma dell''isola a §a{1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr "§2* §7Hai cambiato §9{0} §7blocchi intorno a te nel bioma §2{1}§7"
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr "{0} ha creato un''area con bioma {1}"
-
-msgid "create an island"
-msgstr "crea un''isola"
-
-msgid "exempt player from create-cooldown"
-msgstr "esenta un giocatore dalla ricarica di creazione"
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4* Isola trovata!§7 Hai già un''isola. Se vuoi un''isola nuova, digita§a /"
-"is restart§7 per ottenerne una"
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4* Isola trovata!§7 Sei già membro di un''isola. Per cominciare la tua, "
-"prima§a /is leave"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§9* §7Potrai creare una nuova isola tra §c{0,number,#} §7secondi."
-
-msgid "teleport to the island home"
-msgstr "teletrasporta alla casa dell''isola"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§4 §7La tua isola è in fase di generazione, non puoi teletrasportarti a casa "
-"in questo momento."
-
-msgid "check your or another''s island info"
-msgstr "controlla le info dell''isola tua o di altri"
-
-msgid "allows user to see others island info"
-msgstr "consente all''utente di visualizzare le informazioni di altre isole"
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr ""
-"§4* §7Il livello delle isole è disabilito, contatta una amministratore."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr "§4Frena i cavalli! §eDevi essere paziente..."
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§4* §7Devi essere sulla tua isola per usare questo comando."
-
-msgid "§4You do not have an island!"
-msgstr "§4* §7Non hai un''isola!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4* §7Non hai accesso a quel comando!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4* §7Quel giocatore è invalido o non ha un''isola!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBlocchi nell''isola di {0} (pagina {1,number} di {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Blocco Conto Punteggi"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr "{0,number,00.00}  {1,number,#} {2}"
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§9* §7Il livello dell''isola è §a{0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "invita un giocatore nella tua isola"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§9* §7Usa§a /island invite <nomegiocatore>§7 per invitare un giocatore nella "
-"tua isola."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4* §7Solo il proprietario dell''isola può invitare!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§9* §7Puoi invitare altri §c{0} §7giocatori."
-
-msgid "§4You can't invite any more players."
-msgstr "§4* Non puoi §7invitare altri giocatori."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4* §7Non hai il permesso di invitare altri in questa isola!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4* §7Quel giocatore è offline o non esiste."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4* §7Non puoi invitare te stesso!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4* §7Quel giocatore è il leader della tua isola!"
-
-msgid "remove a member from your island."
-msgstr "rimuove un membro dalla tua isola."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4* Non §7hai il permesso di cacciare altri da questa isola!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4* §7Non puoi rimuovere il leader dall''Isola!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4* §7Fermati di cacciare te stesso!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4* §6{0} §7ti ha rimosso dalla loro isola!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4* §6{0} §7è stato rimosso dall''isola."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4* §7{0} ha provato a §4cacciarti §7dalla loro isola!"
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4* §6{0} §7è esonerato dall''essere cacciato."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4* §7{0} ti ha §4cacciato §7dalla loro isola!"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4* §6{0} §7è stato §4cacciato §7dall''isola."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr ""
-"§4* §7Quel giocatore non fa parte del tuo gruppo isola, e non è sulla tua "
-"isola!"
-
-msgid "leave your party"
-msgstr "abbandona il tuo party"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4* §7Non puoi abbandonare la tua isola se sei l''unica persona. Prova "
-"usando §a/island restart §7se ne vuoi una nuova!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr ""
-"§9* §7Tu possiedi questa isola, usa §a/island remove <player> §7invece."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§9* §7Hai lasciato l''isola e sei ritornato allo spawn."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§9* §6{0} §7ha lasciato la tua isola!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4* §7Devi essere nel mondo skyblock per abbandonare il tuo party!"
-
-msgid "check your or anothers island level"
-msgstr "controlla il livello dell''isola tuo o degli altri"
-
-msgid "allows user to query for others levels"
-msgstr "consente all''utente di chiedere altri livelli"
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§9* §7Informazioni sull''Isola di §6{0}§7:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9* §7Il Rango è §9{0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr "§4Impossibile individuare il rango di {0}"
-
-msgid "lock your island to non-party members."
-msgstr "blocca la tua isola ai non membri del party."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4* §7Non hai il permesso di bloccare la tua isola!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4* §7Non hai accesso a questo comando!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4* §7Non hai il permesso di sbloccare la tua isola!"
-
-msgid "display log"
-msgstr "mostra log"
-
-msgid "transfer leadership to another member"
-msgstr "trasferisci la leadership a un altro membro"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4* §7Puoi trasferire la proprietà solo ai membri del party!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "§6{0}§7 è già capo della tua isola!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4* §7Solo il leader può trasferire la leadership!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "§c{0} §7ha provato a rilevare l''isola!"
-
-msgid "show the islands limits"
-msgstr "mostra i limiti delle isole"
-
-msgid "show party information"
-msgstr "mostra le informazioni del party"
-
-msgid "shows information about your party"
-msgstr "mostra le informazioni sul tuo party"
-
-msgid "show pending invites"
-msgstr "mostra gli inviti in attesa"
-
-msgid "§eNo pending invites"
-msgstr "§9* §7Non ci sono inviti in sospeso"
-
-msgid "withdraw an invite"
-msgstr "ritira un invito"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4* §7Non hai i permessi per ritirare gli inviti dei giocatori."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4* §7Questo comando può essere eseguito solo da un giocatore"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4* Nessuna Isola. §7Usa §a/is create§7 per ottenerne una"
-
-msgid "changes a members island-permissions"
-msgstr "cambia i permessi-isola dei membri"
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr "§9* §7Permessi per §6{0}§7:"
-
-msgid "§aON"
-msgstr "§aON"
-
-msgid "§cOFF"
-msgstr "§cOFF"
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr "§7 - §6{0}§7 : {1}"
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr "§4* §7Permesso {0} non valido. Deve essere uno tra {1}"
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr "§9* §7Commutato il permesso §9{0}§7 per §9{1}§7 a {2}"
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr "§4* §7Impossibile commutare il permesso §9{0}§7 per §9{1}"
-
-msgid "delete your island and start a new one."
-msgstr "cancella la tua isola e avviane una nuova."
-
-msgid "exempt player from restart-cooldown"
-msgstr "esenta il giocatore dalla ricarica-riavvio"
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4* §7Solo il proprietario può riavviare questa isola. Lascia questa isola "
-"per §7avviarne una tua (§a/island leave§7)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§4* §7Devi rimuovere tutti i giocatori dalla tua isola prima di poterla "
-"riavviare (§a/island kick <giocatore>§7). Consulta l''elenco di giocatori "
-"parte della tua isola usando §a/island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§4* §7Puoi riavviare la tua isola tra §c{0} §7secondi."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr ""
-"§4* §7La tua isola è in fase di generazione, non puoi riavviarla adesso."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§4NOTA: §7La tua intera isola e tutti gli effetti saranno §4RESETTATI!"
-
-msgid "set the island-home"
-msgstr "imposta la casa dell''isola"
-
-msgid "set your island''s warp location"
-msgstr "imposta la posizione del warp della tua isola"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cNon hai il permesso di impostare il punto di warp della tua isola!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§4* §7Hai bisogno di essere sulla tua isola per impostare il warp!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§6{0}§7 ha cambiato la posizione del warp dell''isola."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "ti teletrasporta allo spawn dello skyblock"
-
-msgid "enable/disable warping to your island."
-msgstr "abilita/disabilita il warping alla tua isola."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4* §7La tua isola è §4bloccata§7. Devi §asbloccarla §7prima di abilitare il "
-"tuo warp."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§6{0}§a ha attivato §7il warp dell''isola."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§6{0}§4 ha disattivato §7il warp dell''isola."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr ""
-"§cNon hai il permesso di abilitare/disabilitare il warp della tua isola!"
-
-msgid "display the top10 of islands"
-msgstr "visualizza la top10 delle isole"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr "abilita all''utente tutti i modi di generare la top-ten (senza cache)"
-
-msgid "trust/untrust a player to help on your island."
-msgstr "dai/togli la fiducia a un giocatore per aiutare sulla tua isola."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§9* §7I seguenti giocatori sono §adi fiducia §7sulla tua isola:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§9* §7I seguenti leader ti danno §afiducia§7:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr ""
-"§9* §7Per §adare§7/§4togliere §7fiducia dalla tua isola, usa §a/island trust "
-"<giocatore>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4* §7I membri sono già §adi fiducia§7!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4* §7Giocatore sconosciuto §6{0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§4* §7Sei ora §adi fiducia nell''isola di §6{0} §7."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§6{0} §adata la fiducia §7a §6{1} §7sull''isola"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§4* §7Non sei più §4di fiducia §7nell''isola di §6{0}§7."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§6{0} §crevocata la §7fiducia in §6{1} §7sull''isola"
-
-msgid "warp to another player''s island"
-msgstr "fai il warp nell''isola di un altro giocatore"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr ""
-"§9* §7Il tuo warp è §aattivo§7, i giocatori possono andare nella tua isola."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§9* §7Il tuo warp è §4inattivo§7, i giocatori non possono andare nella tua "
-"isola."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr ""
-"§9* §7Imposta il warp alla tua posizione corrente usando §a/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§9* §7Imposta il tuo warp on/off usando §a/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4* §7Non hai il permesso di creare un warp sulla tua isola!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§9* §7Fai il warp su un''altra isola usando §a/island warp <giocatore>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4* §7Non hai il permesso per fare il warp sulle altre isole!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§4* §7La tua isola è in fase di generazione, non puoi fare il warp su isole "
-"di altri giocatori adesso."
-
-msgid "§4That player does not exist!"
-msgstr "§4* §7Quel giocatore non esiste!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4* §7Quel giocatore non ha un warp attivo."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§4* §7L''isola di quei giocatori è in fase di generazione, non puoi andarci "
-"adesso."
-
-#, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§4* AVVERTIMENTO: §6{0}§7 sta facendo il warp alla tua isola!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4* §7Quel giocatore ti ha proibito di fare il warp alla loro isola."
-
-msgid "general island command"
-msgstr "comando generale dell''isola"
-
-msgid "allows user to bypass cooldowns"
-msgstr "consente all''utente di bypassare le ricariche"
-
-msgid "allows user to bypass visitor-protections"
-msgstr "consente all''utente di bypassare le protezioni-visitatore"
-
-msgid "allows user to bypass teleport-delay"
-msgstr "consente all''utente di bypassare il ritardo-teletrasporto"
-
-msgid "allows user to use [usb] signs"
-msgstr "consente all''utente di usare i cartelli [usb]"
-
-msgid "allows user to place [usb] signs"
-msgstr "consente all''utente di piazzare cartelli [usb]"
+msgid "{0}''s Wither"
+msgstr "Wither di {0}"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr "§eNon puoi usare portali di altre isole!"
@@ -1763,36 +98,6 @@ msgstr "§4* §7Cavalcare è consentito solo nella tua isola!"
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr "§4* §7Non puoi rompere veicoli mentre sei un visitatore!"
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr ""
-"§9* §7Il Wither è §4despawnato!§7 E'' andato troppo lontano dalla tua isola."
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "Wither di {0}"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§9* §7I visitatori non possono droppare oggetti!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Proprietario: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr ""
-"Non puoi raccogliere gli oggetti degli altri giocatori quando sei un "
-"visitatore!"
-
-msgid "Config:"
-msgstr "Config:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§4* Nessun Accesso! §7Stai cercando di teletrasportarti sul tetto del "
-"§4NETHER§7, non è consentito."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr "§4* §7Puoi convertire ossidiana solo una volta ogni 10 secondi"
@@ -1841,19 +146,90 @@ msgstr "§9* §7Puoi solo usare uova sulla tua isola."
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§4* §7Hai raggiunto il tuo limite di spawn per la tua isola."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§9* §7I visitatori non possono droppare oggetti!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Proprietario: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr ""
+"Non puoi raccogliere gli oggetti degli altri giocatori quando sei un "
+"visitatore!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§4* §lBannato§r§4:§7 Sei bannato da questa isola."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§4* Bloccata:§7 Quell''isola è §4bloccata! §7Accesso non consentito."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§4* §7In attesa del nostro turno §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "Qualcosa è andato storto salvando l''isola e/o i dati party!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr ""
+"§9* §7Conversione dei dati a UUID, questo può prendere un po'' di tempo!"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§4* MANUTENZIONE:§7 uSkyBlock è attualmente in manutenzione"
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9* §7Creazione di un''isola...§c{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"§buSkyBlock§e dipende da §9{0}§e >= §av{1}§e ma solo §cv{2}§e trovato!\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e dipende da §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§4* §7Non hai accesso a quella schematica di isola!"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4* §7Il giocatore è già assegnato a questa isola!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr ""
+"§4* §7Devi essere più vicino alla tua isola per impostare la casa skyblock!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§9* §7La tua casa skyblock è stata impostata alla tua posizione."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4* §7La tua posizione attuale non è sicura."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+"§a* §7I pixie sono occupati cambiando il bioma della tua isola a §9{0}§7, "
+"sii paziente."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr ""
+"§4* §7La tua isola è in fase di generazione, non è possibile creare ora."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr ""
+"§4* §7Impossibile creare la tua Isola. Contatta un moderatore del server."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+"§ePreparazione della tua isola in corso, sii paziente, può volerci un po''."
+
+msgid "§cCommand is currently disabled!"
+msgstr "§4* §7Il comando è attualmente disabilitato!"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§4* §7Ancora i seguenti blocchi: §4{0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1866,9 +242,6 @@ msgid ""
 msgstr ""
 "§4* §7Fare §a{0}§7 è §4RISCHIOSO§7. Ripeti il comando entro §4{1}§7 secondi "
 "per accettare!"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr ""
@@ -1904,218 +277,34 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4* §7Devi essere il leader del party per sbloccare la tua isola!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§9* §7DB Giocatori: Filtrando {0} giocatori da uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§4* §7In attesa del nostro turno §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9* §7Creazione di un''isola...§c{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lSfida Bloccata"
+
+msgid "READY"
+msgstr "§a* §7PRONTO"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§9* §7DB Giocatori: Filtrati {0} nomi"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-"§9* §7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, fallito:{3} ~ "
-"{5,number,##}%), {6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§9* §7MojangAPI: Cercando di recuperare {0} giocatori da Mojang"
-
-msgid "SUCCESS"
-msgstr "§e* §7SUCCESSO"
-
-msgid "FAILED"
-msgstr "§4* §7FALLITO"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§9* §7 - MojangAPI:§aCOMPLETATO: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§9* §7 - MojangAPI:§cERRORE: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-"§4e* §7Progresso: {0,number,##}% ({1}/{2} - successo:{3}, fallito:{4}, "
-"saltato:{5}) ~ {6}"
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4* §7Nessun importatore chiamato §6{0}§7 trovato"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§e* §7Convertiti {0}/{1} file in {2}"
-
-msgid "The island has been created."
-msgstr "L''isola è stata creata."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§6{0} §4ha bloccato §7l''isola."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr ""
-"§4* §7Dal momento che la tua isola è §4bloccata§7, il tuo warp in arrivo §7è "
-"stato §4disattivato§7."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§6{0}§a ha sbloccato §7l''isola."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§4Sky §9Messaggio §4: §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "{0}§7 è stato rimosso dal gruppo dell''isola."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9* §7Creando un''isola alla tua posizione"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9* §7Creando un''isola §9{0}§7 di te"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§a* §7La sfida {0} §4non §7è ancora disponibile!"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
-"§4* §7L''isola che possiede questo pezzo di nether sta per essere eliminata! "
-"Inviandoti allo spawn."
+"§4* ATTENZIONE:§7 Impossibile trasferire tutti gli oggetti richiesti al tuo "
+"inventario!"
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§4* §7L''isola in cui sei viene cancellata! Inviandoti allo spawn."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eWALL OF FAME (pagina {0} di {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr ""
-"§4* §7La Top ten è vuota! Solo le isole sopra il livello §a{0} §7sono "
-"considerate."
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§9* §7Il tuo rango è: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "SCONOSCIUTO"
-
-msgid "ANIMAL"
-msgstr "ANIMALE"
-
-msgid "MONSTER"
-msgstr "MOSTRO"
-
-msgid "VILLAGER"
-msgstr "VILLICO"
-
-msgid "GOLEM"
-msgstr "GOLEM"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (max. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "§4* §7Impossibile individuare la schematica §c{0}§7, contatta un admin"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aCongratulazioni! §eLa tua isola è apparsa."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§4* Nota:§7 La costruzione potrebbe essere ancora in corso."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "§9* §7Usa §a/is h§7 o la §a/is§7 menu GUI per andare là."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr ""
-"§4* Watchdog!§7 Impossibile trovare una cassa entro §4{0}§7, abbandono."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7Pagina {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr "§c{0,number,#}"
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr "§a+{0,number,#}"
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr "§a{0,number,#}"
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr "&aSinistra:&7 Incrementa con {0}"
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr "&cClic-Destro:&7 Imposta a {0}"
-
-msgid "Return"
-msgstr "Ritorna"
-
-msgid "§9Integer Editor"
-msgstr "§4* §7Editor Interi"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§4* §7Configurazione salvata e ricaricata."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§4* Errore! §9Impossibile salvare il file di configurazione!"
-
-msgid "§3First Page"
-msgstr "§3Prima Pagina"
-
-msgid "§3Last Page"
-msgstr "§3Ultima Pagina"
-
-msgid "§cSave & Reload config"
-msgstr "§4* Salva & Ricarica la config"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Salva le impostazioni nel\n"
-"§7file & ricarica ancora.\n"
-"§4Nota: §7Usare con cura!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (sola lettura)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr "§4* §7Non abbastanza oggetti nella cassa per completare la sfida!"
 
 msgid "true"
 msgstr "true"
@@ -2571,6 +760,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "§7Pagina corrente"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7Pagina {0}"
+
 msgid "§7First Page"
 msgstr "§7Prima Pagina"
 
@@ -2885,8 +1078,8 @@ msgstr "§cClicca per abbandonare"
 msgid "Island Restart Menu"
 msgstr "Menu Riavvio Isola"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§4* §7Non hai accesso a quella schematica di isola!"
+msgid "Config:"
+msgstr "Config:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2902,119 +1095,122 @@ msgstr "§cClicca entro §9{0}§c per riavviare!"
 msgid "§aClick to restart!"
 msgstr "§aClicca per riavviare!"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr "§c{0,number,#}"
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr "§a+{0,number,#}"
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr "§a{0,number,#}"
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr "&aSinistra:&7 Incrementa con {0}"
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr "&cClic-Destro:&7 Imposta a {0}"
+
+msgid "Return"
+msgstr "Ritorna"
+
+msgid "§9Integer Editor"
+msgstr "§4* §7Editor Interi"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9Editor Testuale"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§4* §7Configurazione salvata e ricaricata."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§4* Errore! §9Impossibile salvare il file di configurazione!"
+
+msgid "§3First Page"
+msgstr "§3Prima Pagina"
+
+msgid "§3Last Page"
+msgstr "§3Ultima Pagina"
+
+msgid "§cSave & Reload config"
+msgstr "§4* Salva & Ricarica la config"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Salva le impostazioni nel\n"
+"§7file & ricarica ancora.\n"
+"§4Nota: §7Usare con cura!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (sola lettura)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+"§4e* §7Progresso: {0,number,##}% ({1}/{2} - successo:{3}, fallito:{4}, "
+"saltato:{5}) ~ {6}"
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4* §7Nessun importatore chiamato §6{0}§7 trovato"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§e* §7Convertiti {0}/{1} file in {2}"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§9* §7DB Giocatori: Filtrando {0} giocatori da uuid2name.yml"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§9* §7DB Giocatori: Filtrati {0} nomi"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§9* §7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, fallito:{3} ~ "
+"{5,number,##}%), {6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§9* §7MojangAPI: Cercando di recuperare {0} giocatori da Mojang"
+
+msgid "SUCCESS"
+msgstr "§e* §7SUCCESSO"
+
+msgid "FAILED"
+msgstr "§4* §7FALLITO"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§9* §7 - MojangAPI:§aCOMPLETATO: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§9* §7 - MojangAPI:§cERRORE: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "§4* §7Troppe richieste alle API Mojang ({0} entro {1}), dormendo {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr "§9Frena i cavalli! Devi essere paziente..."
-
-msgid "§9Not really patient, are you?"
-msgstr "§9Non molto paziente, vero?"
-
-msgid "§9Be patient, young padawan"
-msgstr "§9Sii paziente, giovane padawan"
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr "§9Pazienza DEVI avere, giovane padawan"
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr "§9I due guerrieri più potenti sono la pazienza e il tempo."
-
-msgid "§eSending you to spawn."
-msgstr "§9* §7Inviandoti allo spawn."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§9* §7L''isola è stata §4BLOCCATA§7."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§9* §7Sarai teletrasportato tra §4{0} §7secondi."
-
-msgid "§7Teleport cancelled"
-msgstr "§4* §7Teletrasporto cancellato"
-
-msgid "READY"
-msgstr "§a* §7PRONTO"
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-"§4* ATTENZIONE:§7 Impossibile trasferire tutti gli oggetti richiesti al tuo "
-"inventario!"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr "§4* §7Non abbastanza oggetti nella cassa per completare la sfida!"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Qualcosa è andato storto salvando l''isola e/o i dati party!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr ""
-"§9* §7Conversione dei dati a UUID, questo può prendere un po'' di tempo!"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§4* MANUTENZIONE:§7 uSkyBlock è attualmente in manutenzione"
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"§buSkyBlock§e dipende da §9{0}§e >= §av{1}§e ma solo §cv{2}§e trovato!\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e dipende da §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4* §7Il giocatore è già assegnato a questa isola!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4* §7Impossibile trovare una posizione casa sicura sulla tua isola!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§4* ATTENZIONE: §7Teletrasporto a mezz''aria."
-
-msgid "§aTeleporting you to your island."
-msgstr "§aTeletrasporto alla tua isola."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Impossibile fare il warp nell''isola di quel giocatore!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§9* §7Teletrasporto all''isola di §6{0} §7."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr ""
-"§4* §7Devi essere più vicino alla tua isola per impostare la casa skyblock!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§9* §7La tua casa skyblock è stata impostata alla tua posizione."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4* §7La tua posizione attuale non è sicura."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr ""
-"§4* §7La tua isola è in fase di generazione, non è possibile creare ora."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr ""
-"§4* §7Impossibile creare la tua Isola. Contatta un moderatore del server."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-"§ePreparazione della tua isola in corso, sii paziente, può volerci un po''."
-
-msgid "§cCommand is currently disabled!"
-msgstr "§4* §7Il comando è attualmente disabilitato!"
 
 msgid "North"
 msgstr "Nord"
@@ -3039,3 +1235,1803 @@ msgstr "Ovest"
 
 msgid "North-West"
 msgstr "Nord-Ovest"
+
+msgid "The island has been created."
+msgstr "L''isola è stata creata."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§6{0} §4ha bloccato §7l''isola."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr ""
+"§4* §7Dal momento che la tua isola è §4bloccata§7, il tuo warp in arrivo §7è "
+"stato §4disattivato§7."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§6{0}§4 ha disattivato §7il warp dell''isola."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§6{0}§a ha sbloccato §7l''isola."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§4Sky §9Messaggio §4: §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "{0}§7 è stato rimosso dal gruppo dell''isola."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9* §7Creando un''isola alla tua posizione"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9* §7Creando un''isola §9{0}§7 di te"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aCongratulazioni! §eLa tua isola è apparsa."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§4* Nota:§7 La costruzione potrebbe essere ancora in corso."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "§9* §7Usa §a/is h§7 o la §a/is§7 menu GUI per andare là."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "§4* §7Impossibile individuare la schematica §c{0}§7, contatta un admin"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr ""
+"§4* Watchdog!§7 Impossibile trovare una cassa entro §4{0}§7, abbandono."
+
+msgid "UNKNOWN"
+msgstr "SCONOSCIUTO"
+
+msgid "ANIMAL"
+msgstr "ANIMALE"
+
+msgid "MONSTER"
+msgstr "MOSTRO"
+
+msgid "VILLAGER"
+msgstr "VILLICO"
+
+msgid "GOLEM"
+msgstr "GOLEM"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (max. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§4* §7L''isola che possiede questo pezzo di nether sta per essere eliminata! "
+"Inviandoti allo spawn."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§4* §7L''isola in cui sei viene cancellata! Inviandoti allo spawn."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eWALL OF FAME (pagina {0} di {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr ""
+"§4* §7La Top ten è vuota! Solo le isole sopra il livello §a{0} §7sono "
+"considerate."
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr ""
+"§4* §7Il livello delle isole è disabilito, contatta una amministratore."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§9* §7Il tuo rango è: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "§7Completa altre {0} sfide {1}"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Completa §a{0}"
+
+msgid "to unlock this rank"
+msgstr "per sbloccare questo rango"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr "§4Puoi completare questo altre {0} volte."
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§7I requisiti saranno resettati tra §4{0} §7giorni."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§7I requisiti saranno resettati tra §4{0} §7ore."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§7I requisiti saranno resettati tra §4{0} §7minuti."
+
+msgid "§4This challenge is currently unavailable."
+msgstr "§a* §7Questa sfida è attualmente non disponibile."
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr "§a* §7Potrai completare questo ancora tra {0} giorni."
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr "§a* §7Potrai completare questo ancora tra {0} ore."
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr "§a* §7Potrai completare questo ancora tra {0} minuti."
+
+msgid "§eThis challenge requires:"
+msgstr "§eQuesta sfida richiede:"
+
+msgid "§7and more..."
+msgstr "§7e altro..."
+
+msgid "§eItems will be traded for reward."
+msgstr "§eGli oggetti saranno scambiati per una ricompensa."
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr "§eDeve essere entro {0} metri."
+
+msgid "§6Item Reward: §a"
+msgstr "§6Ricompensa Oggetti: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Ricompensa Monetaria: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Ricompensa XP: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dTotale volte completata: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr "§7Richiede {0}"
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4* §7Nessuna sfida chiamata §4{0} §7è stata trovata"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4* §7Devi essere sulla tua isola per farlo!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4* §7La sfida §a{0} §7non si può ripetere!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr "§a* §7Non puoi completare di nuovo la sfida {0} ancora!"
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§a* §7Tentando di completare la sfida §a{0}"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr ""
+"§4* §7Devi essere entro §c{0} §7blocchi di tutti gli oggetti richiesti."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr ""
+"§4* §7La tua isola deve essere al livello §4{0} §7per completare questa "
+"sfida!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4* §7Tipo di sfida sconosciuto: §4{0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§4* §7Ancora le seguenti entità:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§a* §7Ti mancano i seguenti oggetti:§4{0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§a* §7Hai completato la sfida §a{0}§7!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§a* §6{0}§7 ha completato la sfida §a{1}§7!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§eRicompensa Oggetti: §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eRicompensa XP: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eRicompensa monetaria: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§9* §7Il tuo inventario è §4pieno§7. Oggetti droppati a terra."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§eClicca per completare questa sfida."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4Non puoi ripetere questa sfida."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Rango: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fCompleta la maggior parte delle sfide in"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fquesto rango per sbloccare il prossimo."
+
+msgid "§eClick here to show previous page"
+msgstr "§eClicca qui per la pagina precedente"
+
+msgid "§eClick here to show next page"
+msgstr "§eClicca qui per la prossima pagina"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "§7Ma sei SOLLLLLLL SOOOOOLO!"
+
+msgid "But you are Yelling in the wind!"
+msgstr "§7Ma stai Parlando al vento!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "§7Ma i tuoi amici di fantasia sono andati!"
+
+msgid "But you are Talking to your self!"
+msgstr "§7Ma stai Parlando a te stesso!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§4* §7Scusa! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr "Invia un messaggio direttamente al tuo gruppo, o impostalo on/off."
+
+msgid "party"
+msgstr "party"
+
+msgid "island"
+msgstr "isola"
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§cChat impostata a {0} §aON"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§cRipeti §9{0}§c per impostarlo su off"
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§aChat impostata su §cOFF§a per {0}"
+
+msgid "§cCommand only available to players"
+msgstr "§cComando disponibile solo per i giocatori"
+
+msgid "talk to your island party"
+msgstr "parla ai membri del tuo party"
+
+msgid "talk to players on your island"
+msgstr "parla ai giocatori nella tua isola"
+
+msgid "manually update the top 10 list"
+msgstr "aggiorna manualmente la top 10"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§9* §7Generando la lista Top Ten"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§4* §7Finita la generazione della lista Top Ten"
+
+msgid "purges all abandoned islands"
+msgstr "ripulisce tutte le isole abbandonate"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4* §7Devi fornire l''età in giorni per ripulire!"
+
+msgid "§4The level must be a valid number"
+msgstr "§4Il livello deve essere un numero valido"
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+"§eRicerca in corso di tutte le isole che sono state abbandonate da più di "
+"{0} giorni sotto il livello {1}"
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr "§4PULIZIA:§e Fai §9usb purge confirm§e entro {0} per accettare."
+
+msgid "§4Trying to abort purge"
+msgstr "§4* §7Provando ad interrompere la pulizia"
+
+msgid "§4Purge aborted!"
+msgstr "§4Pulizia interrotta!"
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+"§4Una pulizia è già in esecuzione.§e O §9confermala§e o §9interrompila§e."
+
+msgid "§4Starting purge..."
+msgstr "§4* §7Avviando la pulizia..."
+
+msgid "Controls player-cooldowns"
+msgstr "Controlla le ricariche dei giocatori"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "cancella la ricarica su un comando (* = tutti)"
+
+msgid "§eThe player is not currently online"
+msgstr "§4* §7Il giocatore non è online"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Cancellata la ricarica su {0} per {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Nessuna ricarica attiva su {0} per {1} rilevata!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Comando fornito invalido, solo riavvio e bioma supportati!"
+
+msgid "restarts the cooldown on the command"
+msgstr "riavvia la ricarica sul comando"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§4* §7Reimpostata la ricarica su {0} per {1}§7 a {2} secondi"
+
+msgid "lists all the active cooldowns"
+msgstr "elenca tutte le ricariche attive"
+
+msgid "§eCmd Cooldown"
+msgstr "§9* §7Ricarica Cmd"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§4* §7Nessuna ricarica attiva per §6{0}§7 trovata."
+
+msgid "toggles maintenance mode"
+msgstr "§9* §7attiva/disattiva la modalità manutenzione"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+"§4* MANUTENZIONE: §aAttivata§7, tutte le funzioni di uSkyBlock sono "
+"attualmente disabilitate."
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+"§4* MANUTENZIONE: §4Disattivata§7, tutte le funzioni di uSkyBlock sono di "
+"nuovo operative."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr "§4* §7La modalità manutenzione può essere cambiata solo dalla console!"
+
+msgid "controls async jobs"
+msgstr "controlla i processi asincroni"
+
+msgid "§9Job Statistics"
+msgstr "§9* §7Statistiche Lavori"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/job"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "tick"
+
+msgid "act"
+msgstr "act"
+
+msgid "time"
+msgstr "tempo"
+
+msgid "name"
+msgstr "nome"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§9* §7Il giocatore §6{0} §7non ha un''isola!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§4* §7Giocatore §6{0} §7specificato non valido."
+
+msgid "flushes all caches to files"
+msgstr "scrive tutte le cache sui file"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+"§9* §7Scritti §a{0} isole§e, §b{1} giocatori e §6{2} completamenti-sfida."
+
+msgid "tries to fix the the area of flatland."
+msgstr "tenta di correggere l''area di pianura."
+
+msgid "§4No valid island found"
+msgstr "§4* §7Nessuna isola valida trovata"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4* §7Nessuna pianura rilevata nell''isola di §6{0}§7!"
+
+msgid "manage orphans"
+msgstr "gestisce gli orfani"
+
+msgid "count orphans"
+msgstr "conta gli orfani"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§4* §7{0} i luoghi vecchi dell''isola verranno usati prima dei nuovi."
+
+msgid "clear orphans"
+msgstr "pulisce gli orfani"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§4* §7Cancellando tutti i vecchi (vuoti) luoghi dell''isola."
+
+msgid "list orphans"
+msgstr "elenca gli orfani"
+
+msgid "§eNo orphans currently registered."
+msgstr "§4* §7Non ci sono attualmente orfani registrati."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr "§eOrfani ({0}/{1}): {2}"
+
+msgid "transfer leadership to another player"
+msgstr "trasferisce la leadership a un altro giocatore"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4* §6Il giocatore {0} §7non ha un''isola da trasferire!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§4* §7Il giocatore §6{0} §7ha già un''isola. §7Usa §a/usb island remove "
+"<nome>§7 prima per rimuoverlo."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§4* §7La leadership è stata trasferita da §4{0} §7a §a{1}"
+
+msgid "open GUI for config"
+msgstr "apre la GUI per la config"
+
+msgid "searches config for a specific key"
+msgstr "cerca nella config una chiave specifica"
+
+#, java-format
+msgid "§c{0}§9"
+msgstr "§c{0}§9"
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr "§9{0}§8: §e{1}"
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr "Trovati i seguenti risultati {0}:"
+
+msgid "§a<section>"
+msgstr "§a<sezione>"
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr "§3{0,number,#.##}"
+
+#, java-format
+msgid "§2{0}"
+msgstr "§2{0}"
+
+msgid "§eInvalid configuration name"
+msgstr "§4* §7Nome configurazione non valido"
+
+msgid "teleport to another players island"
+msgstr "teletrasporta nell''isola di altri giocatori"
+
+msgid "§4Only supported for players"
+msgstr "§4* §7Supportato solo per i giocatori"
+
+msgid "§4That player does not have an island!"
+msgstr "§4* §7Quel giocatore non ha un''isola!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr "§9* §7Teletrasporto all''isola di §6{0}§7."
+
+msgid "various WorldGuard utilities"
+msgstr "varie utilità di WorldGuard"
+
+msgid "refreshes the chunks around the player"
+msgstr "aggiorna i chunk attorno al giocatore"
+
+msgid "§eResending chunks to the client"
+msgstr "§4* §7Reinviando i chunk al client"
+
+msgid "load the region chunks"
+msgstr "carica i chunk di una regione"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§4* §7Caricamento dei chunk a {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§4* §7Scaricamento dei chunk a {0}"
+
+msgid "update the WG regions"
+msgstr "§4* §7aggiorna le regioni di WG"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§4* §7Regioni world-guard dell''isola aggiornate per {0}"
+
+msgid "§eNo island found at your location!"
+msgstr "§4* §7Nessuna isola trovata alla tua posizione!"
+
+msgid "refreshes the chunk around the player"
+msgstr "ricarica il chunk attorno al giocatore"
+
+msgid "region manipulations"
+msgstr "manipolazioni delle regioni"
+
+msgid "shows the borders of the current island"
+msgstr "mostra i confini dell''isola corrente"
+
+msgid "§eNo island found at your current location"
+msgstr "§4* §7Nessuna isola trovata alla tua posizione"
+
+msgid "§eCan only be executed as a player"
+msgstr "§4* §7Può essere eseguito solo come giocatore"
+
+msgid "shows the borders of the current chunk"
+msgstr "mostra i confini del chunk corrente"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "mostra i confini dei chunk interni"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "mostra i confini dei chunk non allineati"
+
+msgid "shows the borders of the outer-chunks"
+msgstr "mostra i confini dei chunk esterni"
+
+msgid "hides the regions again"
+msgstr "nasconde ancora le regioni"
+
+msgid "§eStopped displaying regions"
+msgstr "§4* §7Arrestata la visualizzazione delle regioni"
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§4* §7Nessuna regione mostrata per questo giocatore"
+
+msgid "set the ticks between animations"
+msgstr "imposta i tick tra le animazioni"
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§4* §7Animation-tick changed to {0}."
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§4* §7Animation-tick must be a valid integer."
+
+msgid "refreshes the existing animations"
+msgstr "aggiorna le animazioni esistenti"
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+"- PULIZIA: {0,number,##}% ({1}/{2}), trascorso {3}, stimato per "
+"completamento ~{4}"
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4* PULIZIA:§7 Finito di ripulire le isole abbandonate."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4* PULIZIA:§7 Abortita la pulizia delle isole abbandonate."
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§4* §7- SCANSIONE: {0,number,##}% ({1}/{2} fallito: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4* PULIZIA:§7 Scansione interrotta."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+"§4PULIZIA:§9 Scansione completata, trovati {0} candidati, sotto il livello "
+"{1}, pronti per la pulizia."
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§4* ABORTITO:§7 Proteggi-Tutto è stato abortito!"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr "§e* §7Completato proteggi-tutto in {0}, {1} nuove regioni create!"
+
+msgid "control debugging"
+msgstr "controlla il debugging"
+
+msgid "set debug-level"
+msgstr "imposta il livello-debug"
+
+msgid "toggle debug-logging"
+msgstr "attiva/disattiva il debug-logging"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4* §7Il logging non era attivo, quindi non puoi disabilitarlo!"
+
+msgid "flush current content of the logger to file."
+msgstr "scrive il contenuto corrente del logger su file."
+
+msgid "§eLog-file has been flushed."
+msgstr "§4* §7Il file-log è stato scritto."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4* §7Il logging non è abilitato, usa §a/usb debug §7enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr ""
+"§4* §7Argomento non valido, prova §eINFO§7, §6FINE§7, §cFINER§7, §4FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§4* §7Logging disabilitato!"
+
+msgid "advanced command for setting island-data"
+msgstr "comando avanzato per impostare i dati dell''isola"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§4* §7{0} è stato impostato a ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§4* §7Impossibile impostare il campo {0} a ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr ""
+"§4* §7Impossibile impostare il campo {0} a ''{1}'', si aspettava un numerico"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§4* §7Campo non valido {0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§4* §7Il valore corrente per {0} è ''{1}''"
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§4* §7Impossibile ottenere lo stato per {0}"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§4* §7Campi validi sono {0}"
+
+msgid "set a player''s island to your location"
+msgstr "imposta un''isola del giocatore alla tua posizione"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr "§aImpostata l''isola di {0} a quella attuale."
+
+msgid "§4Island not found: unable to set the island!"
+msgstr "§4Isola non trovata: impossibile impostare l'isola!"
+
+msgid "advanced info about NBT stuff"
+msgstr "§9* §7info avanzate sull''NBT"
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "§9* §7mostra i Tag NBT per l''oggetto corrente in mano"
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§e* §7Info per §9{0}"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - nome: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - tag nbt: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§4* §7Nessun oggetto in mano!"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "§9* §7imposta la Tag NBT sull''oggetto corrente in mano"
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "§e* §7Impostato §9{0}§e a §c{1}"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "§9* §7aggiunge la Tag NBT nell''oggetto corrente in mano"
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§e* §7Aggiunto §9{0}§e a §c{1}"
+
+msgid "Manage challenges for a player"
+msgstr "Gestisce le sfide per un giocatore"
+
+msgid "resets the challenge for the player"
+msgstr "resetta la sfide per il giocatore"
+
+msgid "§4Challenge has never been completed"
+msgstr "§a* §7La sfida non è mai stata completata"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§a* §7sfida: §a{0} è stata resettata per §6{1}"
+
+msgid "resets all challenges for the player"
+msgstr "resetta tutte le sfide per il giocatore"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§a* §6{0} §7ha avuto tutte le sfide resettate."
+
+msgid "complete all challenges in the rank"
+msgstr "completa tutte le sfide nel rango"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4* §7Nessun giocatore chiamato §6{0} §7trovato!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4La sfida {0} è già stata completata"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§a& §7La sfida §a{0} §7è stata completata per §6{1}"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4* §7Nessuna sfida chiamata §a{0} §7trovata!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4* §7Nessun rango chiamato §a{0} §7trovato!"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "protegge tutte le isole (richiede tempo)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§4* §7Cercando di abortire il processo proteggi-tutto."
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4* Scusa!§7 Un proteggi-tutto è già in esecuzione. Lascialo completare, o "
+"usa §9/usb protectall §4stop"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§4* §7Avviando un processo proteggi-tutto. Può richiedere tempo."
+
+msgid "reload configuration from file."
+msgstr "ricarica la configurazione dal file."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§4* §7Configurazione ricaricata dal file."
+
+msgid "manage islands"
+msgstr "gestisce le isole"
+
+msgid "protects the island"
+msgstr "protegge l''isola"
+
+msgid "delete the island (removes the blocks)"
+msgstr "elimina l''isola (rimuove i blocchi)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9* §7Cancellata un''isola abbandonata nella tua posizione."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4* §7L''isola in questa posizione ha dei membri!\n"
+"§4* §7Usa §a/usb island delete <nome>§7 per cancellarla."
+
+msgid "removes the player from the island"
+msgstr "rimuove il giocatore dall''isola"
+
+msgid "adds the player to the island"
+msgstr "aggiunge il giocatore all''isola"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§6{0} §7è entrato nel tuo party."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4* §7Nessun giocatore chiamato §6{0} §7trovato!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+"§4* §7Nessuna isola valida fornita, vai su un''isola, o fornisci il nome di "
+"un''isola"
+
+msgid "print out info about the island"
+msgstr "mostra le informazioni sull''isola"
+
+msgid "sets the biome of the island"
+msgstr "imposta il bioma dell''isola"
+
+msgid "§4That player has no island."
+msgstr "§4* §7Quel giocatore non ha un''isola."
+
+msgid "§4No valid island at your location"
+msgstr "§4* §7Nessuna isola valida alla tua posizione"
+
+msgid "purges the island"
+msgstr "ripulisce l''isola"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4* Errore! §7Nessuna isola valida trovata per la pulizia."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§4* PULIZIA: §7Ripulita l''isola a {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "cambia lo stato delle isole di ignorato"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr ""
+"§4* §7Imposta l''isola di §4 {0}s §7come ignorata nella top-tene la "
+"ripulisce."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§4* §7Tolto lo stato di ignorato all''isola di §4{0} §7,sarà ora mostrata "
+"nella top-ten e ripulita."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4* §7Nome giocatore fornito non valido."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "§4* §7Rimuovendo §6{0} §7dall''isola"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§9* §7Cambiato il bioma dell''isola di §6{0} §7a {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§9* §7Cambiato il bioma dell''isola di §6{0} §7a OCEANO."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr ""
+"§9* §7Potresti dover andare allo spawn, o riloggare, §7per vedere i "
+"cambiamenti."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§9* §6{0} §7ha avuto il suo bioma cambiato a {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§9* §6{0} §7hanno avuto il loro bioma cambiato ad OCEANO."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§4* §7Rimuovendo l''isola di §6{0} §7."
+
+msgid "Error: That player does not have an island!"
+msgstr "Errore: Quel giocatore non ha un''isola!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§4* §7L''isola di §6{0} §7a {1} è stata protetta"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4* §7L''isola di §6{0} §7a {1} è già protetta"
+
+msgid "displays version information"
+msgstr "visualizza informazioni sulla versione"
+
+msgid "imports players and islands from other formats"
+msgstr "importa i giocatori e le isole da altri formati"
+
+msgid "shows perk-information"
+msgstr "mostra le informazioni sui vantaggi"
+
+msgid "shows a specific players perks"
+msgstr "mostra vantaggi specifici per i giocatori"
+
+#, java-format
+msgid "additional perks {0}"
+msgstr "vantaggi aggiuntivi {0}"
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "cambia la lingua del plugin, e lo ricarica"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§4* §7Lingua cambiata con successo a §4{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§4* §7Fallito nel cambiare la lingua a §4{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9* §7Lingue Supportate:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§4* §7Impossibile individuare tutte le lingue."
+
+msgid "advanced command for getting island-data"
+msgstr "comando avanzato per ottenere i dati-isola"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "mostra le informazioni-giocatore"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4* §7La tua isola è piena, o hai troppi inviti in attesa. Non puoi invitare "
+"nessun altro."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4* §7Quel giocatore è già leader di un''altra isola."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§9* §{0}§7 ha provato ad invitarti, ma sei già in un party."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr "§9* §7Invito inviato a {0}"
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "§9* §6{0} §7ti ha invitato ad entrare nella sua isola!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr ""
+"§9* §f/island [accept/reject]§7 per §aaccettare o §4rifiutare §7l''invito."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4* AVVERTIMENTO§7: Se accetterai l''invito perderai la tua isola!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "§6{0}§a ha invitato §6{1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "§9* §6{0} §7ha §4rifiutato §7l''invito."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr "§4* §7Non puoi usare questo comando ora. Prima lascia il tuo party."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§9* §7Sei entrato in un''isola! Usa §a/island party §7per vedere gli altri "
+"membri."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§7L''invito per §6{0} §7è scaduto o è stato cancellato."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§9* §7L''invito per l''isola di §6{0} è scaduto o stato cancellato."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§9* §7Hai §aaccettato §7l''invito per entrare in un''isola."
+
+msgid "§4You haven't been invited."
+msgstr "§9* §7Non sei stato invitato."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§9* §7Hai §4rifiutato §7l''invito per entrare in un''isola."
+
+msgid "general island command"
+msgstr "comando generale dell''isola"
+
+msgid "allows user to bypass cooldowns"
+msgstr "consente all''utente di bypassare le ricariche"
+
+msgid "allows user to bypass visitor-protections"
+msgstr "consente all''utente di bypassare le protezioni-visitatore"
+
+msgid "allows user to bypass teleport-delay"
+msgstr "consente all''utente di bypassare il ritardo-teletrasporto"
+
+msgid "allows user to use [usb] signs"
+msgstr "consente all''utente di usare i cartelli [usb]"
+
+msgid "allows user to place [usb] signs"
+msgstr "consente all''utente di piazzare cartelli [usb]"
+
+msgid "complete and list challenges"
+msgstr "completa ed elenca le sfide"
+
+msgid "§cCommand only available for players."
+msgstr "§4* §7Comando eseguibile solo dai giocatori."
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§4* §7Le sfide sono state disabilitate. Contatta un admin."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4* §7Puoi inviare sfide solo nel mondo skyblock!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4* §7Puoi fare sfide solo quando hai un''isola!"
+
+msgid "warp to another player''s island"
+msgstr "fai il warp nell''isola di un altro giocatore"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr ""
+"§9* §7Il tuo warp è §aattivo§7, i giocatori possono andare nella tua isola."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§9* §7Il tuo warp è §4inattivo§7, i giocatori non possono andare nella tua "
+"isola."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr ""
+"§9* §7Imposta il warp alla tua posizione corrente usando §a/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§9* §7Imposta il tuo warp on/off usando §a/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4* §7Non hai il permesso di creare un warp sulla tua isola!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§9* §7Fai il warp su un''altra isola usando §a/island warp <giocatore>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4* §7Non hai il permesso per fare il warp sulle altre isole!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§4* §7La tua isola è in fase di generazione, non puoi fare il warp su isole "
+"di altri giocatori adesso."
+
+msgid "§4That player does not exist!"
+msgstr "§4* §7Quel giocatore non esiste!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4* §7Quel giocatore non ha un warp attivo."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§4* §7L''isola di quei giocatori è in fase di generazione, non puoi andarci "
+"adesso."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§4* AVVERTIMENTO: §6{0}§7 sta facendo il warp alla tua isola!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4* §7Quel giocatore ti ha proibito di fare il warp alla loro isola."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4* Nessuna Isola. §7Usa §a/is create§7 per ottenerne una"
+
+msgid "accept/reject an invitation."
+msgstr "accetta/rifiuta un invito."
+
+msgid "leave your party"
+msgstr "abbandona il tuo party"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4* §7Non puoi abbandonare la tua isola se sei l''unica persona. Prova "
+"usando §a/island restart §7se ne vuoi una nuova!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr ""
+"§9* §7Tu possiedi questa isola, usa §a/island remove <player> §7invece."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§9* §7Hai lasciato l''isola e sei ritornato allo spawn."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§9* §6{0} §7ha lasciato la tua isola!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4* §7Devi essere nel mondo skyblock per abbandonare il tuo party!"
+
+msgid "check your or anothers island level"
+msgstr "controlla il livello dell''isola tuo o degli altri"
+
+msgid "allows user to query for others levels"
+msgstr "consente all''utente di chiedere altri livelli"
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§4* §7Devi essere sulla tua isola per usare questo comando."
+
+msgid "§4You do not have an island!"
+msgstr "§4* §7Non hai un''isola!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4* §7Non hai accesso a quel comando!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4* §7Quel giocatore è invalido o non ha un''isola!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§9* §7Informazioni sull''Isola di §6{0}§7:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§9* §7Il livello dell''isola è §a{0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9* §7Il Rango è §9{0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr "§4Impossibile individuare il rango di {0}"
+
+msgid "create an island"
+msgstr "crea un''isola"
+
+msgid "exempt player from create-cooldown"
+msgstr "esenta un giocatore dalla ricarica di creazione"
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4* Isola trovata!§7 Hai già un''isola. Se vuoi un''isola nuova, digita§a /"
+"is restart§7 per ottenerne una"
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4* Isola trovata!§7 Sei già membro di un''isola. Per cominciare la tua, "
+"prima§a /is leave"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§9* §7Potrai creare una nuova isola tra §c{0,number,#} §7secondi."
+
+msgid "invite a player to your island"
+msgstr "invita un giocatore nella tua isola"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§9* §7Usa§a /island invite <nomegiocatore>§7 per invitare un giocatore nella "
+"tua isola."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4* §7Solo il proprietario dell''isola può invitare!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§9* §7Puoi invitare altri §c{0} §7giocatori."
+
+msgid "§4You can't invite any more players."
+msgstr "§4* Non puoi §7invitare altri giocatori."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4* §7Non hai il permesso di invitare altri in questa isola!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4* §7Quel giocatore è offline o non esiste."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4* §7Non puoi invitare te stesso!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4* §7Quel giocatore è il leader della tua isola!"
+
+msgid "lock your island to non-party members."
+msgstr "blocca la tua isola ai non membri del party."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4* §7Non hai il permesso di bloccare la tua isola!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4* §7Non hai accesso a questo comando!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4* §7Non hai il permesso di sbloccare la tua isola!"
+
+msgid "display the top10 of islands"
+msgstr "visualizza la top10 delle isole"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr "abilita all''utente tutti i modi di generare la top-ten (senza cache)"
+
+msgid "remove a member from your island."
+msgstr "rimuove un membro dalla tua isola."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4* Non §7hai il permesso di cacciare altri da questa isola!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4* §7Non puoi rimuovere il leader dall''Isola!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4* §7Fermati di cacciare te stesso!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4* §6{0} §7ti ha rimosso dalla loro isola!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4* §6{0} §7è stato rimosso dall''isola."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4* §7{0} ha provato a §4cacciarti §7dalla loro isola!"
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4* §6{0} §7è esonerato dall''essere cacciato."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4* §7{0} ti ha §4cacciato §7dalla loro isola!"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4* §6{0} §7è stato §4cacciato §7dall''isola."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr ""
+"§4* §7Quel giocatore non fa parte del tuo gruppo isola, e non è sulla tua "
+"isola!"
+
+msgid "teleport to the island home"
+msgstr "teletrasporta alla casa dell''isola"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§4 §7La tua isola è in fase di generazione, non puoi teletrasportarti a casa "
+"in questo momento."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4* §7Questo comando può essere eseguito solo da un giocatore"
+
+msgid "transfer leadership to another member"
+msgstr "trasferisci la leadership a un altro membro"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4* §7Puoi trasferire la proprietà solo ai membri del party!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "§6{0}§7 è già capo della tua isola!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4* §7Solo il leader può trasferire la leadership!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "§c{0} §7ha provato a rilevare l''isola!"
+
+msgid "show party information"
+msgstr "mostra le informazioni del party"
+
+msgid "shows information about your party"
+msgstr "mostra le informazioni sul tuo party"
+
+msgid "show pending invites"
+msgstr "mostra gli inviti in attesa"
+
+msgid "§eNo pending invites"
+msgstr "§9* §7Non ci sono inviti in sospeso"
+
+msgid "withdraw an invite"
+msgstr "ritira un invito"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4* §7Non hai i permessi per ritirare gli inviti dei giocatori."
+
+msgid "check your or another''s island info"
+msgstr "controlla le info dell''isola tua o di altri"
+
+msgid "allows user to see others island info"
+msgstr "consente all''utente di visualizzare le informazioni di altre isole"
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr "§4Frena i cavalli! §eDevi essere paziente..."
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBlocchi nell''isola di {0} (pagina {1,number} di {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Blocco Conto Punteggi"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr "{0,number,00.00}  {1,number,#} {2}"
+
+msgid "trust/untrust a player to help on your island."
+msgstr "dai/togli la fiducia a un giocatore per aiutare sulla tua isola."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§9* §7I seguenti giocatori sono §adi fiducia §7sulla tua isola:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§9* §7I seguenti leader ti danno §afiducia§7:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr ""
+"§9* §7Per §adare§7/§4togliere §7fiducia dalla tua isola, usa §a/island trust "
+"<giocatore>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4* §7I membri sono già §adi fiducia§7!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4* §7Giocatore sconosciuto §6{0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§4* §7Sei ora §adi fiducia nell''isola di §6{0} §7."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§6{0} §adata la fiducia §7a §6{1} §7sull''isola"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§4* §7Non sei più §4di fiducia §7nell''isola di §6{0}§7."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§6{0} §crevocata la §7fiducia in §6{1} §7sull''isola"
+
+msgid "delete your island and start a new one."
+msgstr "cancella la tua isola e avviane una nuova."
+
+msgid "exempt player from restart-cooldown"
+msgstr "esenta il giocatore dalla ricarica-riavvio"
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4* §7Solo il proprietario può riavviare questa isola. Lascia questa isola "
+"per §7avviarne una tua (§a/island leave§7)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§4* §7Devi rimuovere tutti i giocatori dalla tua isola prima di poterla "
+"riavviare (§a/island kick <giocatore>§7). Consulta l''elenco di giocatori "
+"parte della tua isola usando §a/island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§4* §7Puoi riavviare la tua isola tra §c{0} §7secondi."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr ""
+"§4* §7La tua isola è in fase di generazione, non puoi riavviarla adesso."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§4NOTA: §7La tua intera isola e tutti gli effetti saranno §4RESETTATI!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "ti teletrasporta allo spawn dello skyblock"
+
+msgid "change the biome of the island"
+msgstr "cambia il bioma dell''isola"
+
+msgid "exempt player from biome-cooldown"
+msgstr "esenta il giocatore dalla ricarica-bioma"
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr "Lascia il giocatore cambiare il bioma della sua isola a {0}"
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr ""
+"§4* §7Non hai il permesso di cambiare il bioma della tua isola corrente."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4* §7Non hai il permesso di cambiare il bioma di questa isola!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§4* §7Devi essere sulla tua isola per cambiare il bioma!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr "§4* §7Hai scritto male il nome del bioma. Deve essere uno di {0}"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§9* §7Potrai cambiare il tuo bioma ancora tra §c{0,number,#} §7minuti."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§4* §7Non hai il permesso di cambiare il tuo bioma in quel tipo."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+"§2* §7I pixie sono impegnati a cambiare il bioma vicino a te a §9{0}§7, sii "
+"paziente."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr "§4* §7Bioma {0} fornito invalido!"
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§9* §7Hai cambiato il bioma della tua isola a §a{0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "§9* §6{0} §7ha cambiato il bioma dell''isola a §a{1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr "§2* §7Hai cambiato §9{0} §7blocchi intorno a te nel bioma §2{1}§7"
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr "{0} ha creato un''area con bioma {1}"
+
+msgid "set your island''s warp location"
+msgstr "imposta la posizione del warp della tua isola"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cNon hai il permesso di impostare il punto di warp della tua isola!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§4* §7Hai bisogno di essere sulla tua isola per impostare il warp!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§6{0}§7 ha cambiato la posizione del warp dell''isola."
+
+msgid "teleports you to your island (or create one)"
+msgstr "§9* §7ti teletrasporta alla tua isola (o ne crea una)"
+
+msgid "ban/unban a player from your island."
+msgstr "banna/sbanna un giocatore dalla tua isola."
+
+msgid "exempts user from being banned"
+msgstr "esenta un utente dall''essere bannato"
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr ""
+"§4* §7I seguenti giocatori sono §4bannati §7dal fare il warp alla tua isola:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr ""
+"§9* §7Per §4bannare§7/§asbannare §7dalla tua isola, usa §a/island ban "
+"<giocatore>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4* §7Non puoi bannare i membri. §4Rimuovili §7prima!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4* §7Non hai il permesso per cacciare/bannare giocatori."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§e* §7Impossibile bannare il giocatore sconosciuto {0}"
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4* §7{0} ha provato a §4bannarti §7dalla loro isola!"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4* §7{0} è esente dall''essere bannato."
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§4* §7Hai bannato §4{0}§7 dal fare il warp alla tua isola."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§4* §7Sei stato §4BANNATO§7 dall''isola di §6{0}§7."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§9* §7Hai §asbannato §6{0} §7dal fare il warp alla tua isola."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§9* §7Sei stato §aSBANNATO§7 dall''isola di §6{0}§7."
+
+msgid "display log"
+msgstr "mostra log"
+
+msgid "changes a members island-permissions"
+msgstr "cambia i permessi-isola dei membri"
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr "§9* §7Permessi per §6{0}§7:"
+
+msgid "§aON"
+msgstr "§aON"
+
+msgid "§cOFF"
+msgstr "§cOFF"
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr "§7 - §6{0}§7 : {1}"
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr "§4* §7Permesso {0} non valido. Deve essere uno tra {1}"
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr "§9* §7Commutato il permesso §9{0}§7 per §9{1}§7 a {2}"
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr "§4* §7Impossibile commutare il permesso §9{0}§7 per §9{1}"
+
+msgid "set the island-home"
+msgstr "imposta la casa dell''isola"
+
+msgid "show the islands limits"
+msgstr "mostra i limiti delle isole"
+
+msgid "enable/disable warping to your island."
+msgstr "abilita/disabilita il warping alla tua isola."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4* §7La tua isola è §4bloccata§7. Devi §asbloccarla §7prima di abilitare il "
+"tuo warp."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§6{0}§a ha attivato §7il warp dell''isola."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr ""
+"§cNon hai il permesso di abilitare/disabilitare il warp della tua isola!"
+
+msgid "try to complete a challenge"
+msgstr "tenta di completare una sfida"
+
+msgid "show information about the challenge"
+msgstr "mostra le informazioni sulla sfida"
+
+msgid "§eRank: "
+msgstr "§eRango: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4Questa Sfida non è ripetibile!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr ""
+"§4* §7Perderai tutti gli oggetti richiesti quando completerai questa sfida!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4* §7Tutti gli oggetti richiesti devono essere piazzati sulla tua isola, "
+"entro §c{0} §7blocchi da te."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§a* §7Per completare questa sfida, usa §a/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4* §7Nome sfida invalido! Usa §a/c §7help per maggiori informazioni"
+
+msgid "§eSending you to spawn."
+msgstr "§9* §7Inviandoti allo spawn."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§9* §7L''isola è stata §4BLOCCATA§7."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr "§9Frena i cavalli! Devi essere paziente..."
+
+msgid "§9Not really patient, are you?"
+msgstr "§9Non molto paziente, vero?"
+
+msgid "§9Be patient, young padawan"
+msgstr "§9Sii paziente, giovane padawan"
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr "§9Pazienza DEVI avere, giovane padawan"
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr "§9I due guerrieri più potenti sono la pazienza e il tempo."
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4* §7Impossibile trovare una posizione casa sicura sulla tua isola!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§4* ATTENZIONE: §7Teletrasporto a mezz''aria."
+
+msgid "§aTeleporting you to your island."
+msgstr "§aTeletrasporto alla tua isola."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§9* §7Sarai teletrasportato tra §4{0} §7secondi."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Impossibile fare il warp nell''isola di quel giocatore!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§9* §7Teletrasporto all''isola di §6{0} §7."
+
+msgid "§7Teleport cancelled"
+msgstr "§4* §7Teletrasporto cancellato"

--- a/uSkyBlock-Core/src/main/po/keys.pot
+++ b/uSkyBlock-Core/src/main/po/keys.pot
@@ -16,12 +16,45 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+msgid "d"
+msgstr ""
+
+msgid "h"
+msgstr ""
+
+msgid "m"
+msgstr ""
+
+msgid "s"
+msgstr ""
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr ""
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}"
+msgstr ""
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr ""
 
 #, java-format
 msgid "§eInvalid command: {0}"
+msgstr ""
+
+msgid "Command"
+msgstr ""
+
+msgid "Permission"
+msgstr ""
+
+msgid "Description"
 msgstr ""
 
 #, java-format
@@ -47,1628 +80,11 @@ msgstr ""
 msgid "§4Error writing documentation: {0}"
 msgstr ""
 
-msgid "Command"
+msgid "§cWither Despawned!§e It wandered too far from your island."
 msgstr ""
 
-msgid "Permission"
-msgstr ""
-
-msgid "Description"
-msgstr ""
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}"
-msgstr ""
-
-msgid "d"
-msgstr ""
-
-msgid "h"
-msgstr ""
-
-msgid "m"
-msgstr ""
-
-msgid "s"
-msgstr ""
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr ""
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr ""
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr ""
-
-msgid "§7and more..."
-msgstr ""
-
-msgid "§eItems will be traded for reward."
-msgstr ""
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr ""
-
-msgid "§6Item Reward: §a"
-msgstr ""
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr ""
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr ""
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr ""
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr ""
-
-msgid "§4You must be on your island to do that!"
-msgstr ""
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr ""
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr ""
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr ""
-
-#, java-format
-msgid "§4{0}"
-msgstr ""
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr ""
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr ""
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr ""
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr ""
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr ""
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr ""
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr ""
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr ""
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr ""
-
-msgid "§e§lClick to complete this challenge."
-msgstr ""
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr ""
-
-#, java-format
-msgid "Rank: {0}"
-msgstr ""
-
-msgid "§fComplete most challenges in"
-msgstr ""
-
-msgid "§fthis rank to unlock the next rank."
-msgstr ""
-
-msgid "§eClick here to show previous page"
-msgstr ""
-
-msgid "§eClick here to show next page"
-msgstr ""
-
-msgid "§4§lLocked Challenge"
-msgstr ""
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr ""
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr ""
-
-msgid "to unlock this rank"
-msgstr ""
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr ""
-
-msgid "But you are Yelling in the wind!"
-msgstr ""
-
-msgid "But your fantasy friends are gone!"
-msgstr ""
-
-msgid "But you are Talking to your self!"
-msgstr ""
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr ""
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr ""
-
-msgid "party"
-msgstr ""
-
-msgid "island"
-msgstr ""
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr ""
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr ""
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr ""
-
-msgid "§cCommand only available to players"
-msgstr ""
-
-msgid "talk to players on your island"
-msgstr ""
-
-msgid "talk to your island party"
-msgstr ""
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr ""
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr ""
-
-msgid "Manage challenges for a player"
-msgstr ""
-
-msgid "resets the challenge for the player"
-msgstr ""
-
-msgid "§4Challenge has never been completed"
-msgstr ""
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr ""
-
-msgid "resets all challenges for the player"
-msgstr ""
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr ""
-
-msgid "complete all challenges in the rank"
-msgstr ""
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr ""
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr ""
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr ""
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr ""
-
-msgid "manage islands"
-msgstr ""
-
-msgid "protects the island"
-msgstr ""
-
-msgid "delete the island (removes the blocks)"
-msgstr ""
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr ""
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-
-msgid "removes the player from the island"
-msgstr ""
-
-msgid "adds the player to the island"
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr ""
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr ""
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-
-msgid "print out info about the island"
-msgstr ""
-
-msgid "sets the biome of the island"
-msgstr ""
-
-msgid "§4That player has no island."
-msgstr ""
-
-msgid "§4No valid island at your location"
-msgstr ""
-
-msgid "purges the island"
-msgstr ""
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr ""
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr ""
-
-msgid "toggles the islands ignore status"
-msgstr ""
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr ""
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-
-msgid "§4No valid player-name supplied."
-msgstr ""
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr ""
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr ""
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr ""
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr ""
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr ""
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr ""
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr ""
-
-msgid "Error: That player does not have an island!"
-msgstr ""
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr ""
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr ""
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr ""
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr ""
-
-msgid "Controls player-cooldowns"
-msgstr ""
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr ""
-
-msgid "§eThe player is not currently online"
-msgstr ""
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr ""
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr ""
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr ""
-
-msgid "restarts the cooldown on the command"
-msgstr ""
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr ""
-
-msgid "lists all the active cooldowns"
-msgstr ""
-
-msgid "§eCmd Cooldown"
-msgstr ""
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr ""
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr ""
-
-msgid "control debugging"
-msgstr ""
-
-msgid "set debug-level"
-msgstr ""
-
-msgid "toggle debug-logging"
-msgstr ""
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr ""
-
-msgid "flush current content of the logger to file."
-msgstr ""
-
-msgid "§eLog-file has been flushed."
-msgstr ""
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr ""
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr ""
-
-msgid "§eLogging disabled!"
-msgstr ""
-
-msgid "tries to fix the the area of flatland."
-msgstr ""
-
-msgid "§4No valid island found"
-msgstr ""
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr ""
-
-msgid "flushes all caches to files"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-
-msgid "manually update the top 10 list"
-msgstr ""
-
-msgid "§eGenerating the Top Ten list"
-msgstr ""
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr ""
-
-msgid "advanced command for getting island-data"
-msgstr ""
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr ""
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr ""
-
-msgid "teleport to another players island"
-msgstr ""
-
-msgid "§4Only supported for players"
-msgstr ""
-
-msgid "§4That player does not have an island!"
-msgstr ""
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr ""
-
-msgid "imports players and islands from other formats"
-msgstr ""
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr ""
-
-msgid "§7----------------"
-msgstr ""
-
-msgid "#"
-msgstr ""
-
-msgid "ms/job"
-msgstr ""
-
-msgid "ms/tick"
-msgstr ""
-
-msgid "ticks"
-msgstr ""
-
-msgid "act"
-msgstr ""
-
-msgid "time"
-msgstr ""
-
-msgid "name"
-msgstr ""
-
-msgid "changes the language of the plugin, and reloads"
-msgstr ""
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr ""
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr ""
-
-msgid "§9Supported Languages:\n"
-msgstr ""
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr ""
-
-msgid "§cUnable to locate any languages."
-msgstr ""
-
-msgid "transfer leadership to another player"
-msgstr ""
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr ""
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr ""
-
-msgid "advanced info about NBT stuff"
-msgstr ""
-
-msgid "shows the NBTTag for the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr ""
-
-msgid "§cNo item in hand!"
-msgstr ""
-
-msgid "§eCan only be executed as a player"
-msgstr ""
-
-msgid "sets the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "adds the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "manage orphans"
-msgstr ""
-
-msgid "count orphans"
-msgstr ""
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr ""
-
-msgid "clear orphans"
-msgstr ""
-
-msgid "§eClearing all old (empty) island locations."
-msgstr ""
-
-msgid "list orphans"
-msgstr ""
-
-msgid "§eNo orphans currently registered."
-msgstr ""
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr ""
-
-msgid "protects all islands (time consuming)"
-msgstr ""
-
-msgid "§cTrying to abort protect-all task."
-msgstr ""
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr ""
-
-msgid "purges all abandoned islands"
-msgstr ""
-
-msgid "§4You must provide the age in days to purge!"
-msgstr ""
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr ""
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr ""
-
-msgid "region manipulations"
-msgstr ""
-
-msgid "shows the borders of the current island"
-msgstr ""
-
-msgid "§eNo island found at your current location"
-msgstr ""
-
-msgid "shows the borders of the current chunk"
-msgstr ""
-
-msgid "shows the borders of the inner-chunks"
-msgstr ""
-
-msgid "shows the non-chunk-aligned borders"
-msgstr ""
-
-msgid "shows the borders of the outer-chunks"
-msgstr ""
-
-msgid "hides the regions again"
-msgstr ""
-
-msgid "§eStopped displaying regions"
-msgstr ""
-
-msgid "§eNo currently shown regions for this player"
-msgstr ""
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr ""
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr ""
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr ""
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr ""
-
-msgid "§eConfiguration reloaded from file."
-msgstr ""
-
-msgid "advanced command for setting island-data"
-msgstr ""
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr ""
-
-msgid "toggles maintenance mode"
-msgstr ""
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr ""
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr ""
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr ""
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr ""
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr ""
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr ""
-
-msgid "displays version information"
-msgstr ""
-
-msgid "various WorldGuard utilities"
-msgstr ""
-
-msgid "refreshes the chunks around the player"
-msgstr ""
-
-msgid "§eResending chunks to the client"
-msgstr ""
-
-msgid "load the region chunks"
-msgstr ""
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr ""
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr ""
-
-msgid "update the WG regions"
-msgstr ""
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr ""
-
-msgid "§eNo island found at your location!"
-msgstr ""
-
-msgid "refreshes the chunk around the player"
-msgstr ""
-
-msgid "Ultimate SkyBlock Admin"
-msgstr ""
-
-msgid "show player-information"
-msgstr ""
-
-msgid "try to complete a challenge"
-msgstr ""
-
-msgid "§cCommand only available for players."
-msgstr ""
-
-msgid "show information about the challenge"
-msgstr ""
-
-msgid "§eRank: "
-msgstr ""
-
-msgid "§4This Challenge is not repeatable!"
-msgstr ""
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr ""
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr ""
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr ""
-
-msgid "complete and list challenges"
-msgstr ""
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr ""
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr ""
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr ""
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-
-msgid "§4That player is already leader on another island."
-msgstr ""
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr ""
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr ""
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr ""
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr ""
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr ""
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr ""
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr ""
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr ""
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr ""
-
-msgid "§4You haven't been invited."
-msgstr ""
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr ""
-
-msgid "accept/reject an invitation."
-msgstr ""
-
-msgid "teleports you to your island (or create one)"
-msgstr ""
-
-msgid "ban/unban a player from your island."
-msgstr ""
-
-msgid "exempts user from being banned"
-msgstr ""
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr ""
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr ""
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr ""
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr ""
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr ""
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr ""
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr ""
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr ""
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr ""
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr ""
-
-msgid "change the biome of the island"
-msgstr ""
-
-msgid "exempt player from biome-cooldown"
-msgstr ""
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr ""
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr ""
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr ""
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr ""
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr ""
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr ""
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr ""
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr ""
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr ""
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr ""
-
-msgid "create an island"
-msgstr ""
-
-msgid "exempt player from create-cooldown"
-msgstr ""
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr ""
-
-msgid "teleport to the island home"
-msgstr ""
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-
-msgid "check your or another''s island info"
-msgstr ""
-
-msgid "allows user to see others island info"
-msgstr ""
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr ""
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr ""
-
-msgid "§4You do not have an island!"
-msgstr ""
-
-msgid "§4You do not have access to that command!"
-msgstr ""
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr ""
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr ""
-
-msgid "Score Count Block"
-msgstr ""
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr ""
-
-msgid "invite a player to your island"
-msgstr ""
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-
-msgid "§4Only the island''s owner can invite!"
-msgstr ""
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr ""
-
-msgid "§4You can't invite any more players."
-msgstr ""
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr ""
-
-msgid "§4That player is offline or doesn't exist."
-msgstr ""
-
-msgid "§4You can't invite yourself!"
-msgstr ""
-
-msgid "§4That player is the leader of your island!"
-msgstr ""
-
-msgid "remove a member from your island."
-msgstr ""
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr ""
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr ""
-
-msgid "§4Stop kickin' yourself!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr ""
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr ""
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr ""
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr ""
-
-msgid "leave your party"
-msgstr ""
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr ""
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr ""
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr ""
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr ""
-
-msgid "check your or anothers island level"
-msgstr ""
-
-msgid "allows user to query for others levels"
-msgstr ""
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr ""
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr ""
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr ""
-
-msgid "§4You do not have permission to lock your island!"
-msgstr ""
-
-msgid "§4You don't have access to this command!"
-msgstr ""
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr ""
-
-msgid "display log"
-msgstr ""
-
-msgid "transfer leadership to another member"
-msgstr ""
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr ""
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr ""
-
-msgid "§4Only leader can transfer leadership!"
-msgstr ""
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr ""
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr ""
-
-msgid "shows information about your party"
-msgstr ""
-
-msgid "show pending invites"
-msgstr ""
-
-msgid "§eNo pending invites"
-msgstr ""
-
-msgid "withdraw an invite"
-msgstr ""
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr ""
-
-msgid "§4This command can only be executed by a player"
-msgstr ""
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr ""
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr ""
-
-msgid "exempt player from restart-cooldown"
-msgstr ""
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr ""
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr ""
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr ""
-
-msgid "set the island-home"
-msgstr ""
-
-msgid "set your island''s warp location"
-msgstr ""
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr ""
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr ""
-
-msgid "teleports you to the skyblock spawn"
-msgstr ""
-
-msgid "enable/disable warping to your island."
-msgstr ""
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr ""
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr ""
-
-msgid "display the top10 of islands"
-msgstr ""
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr ""
-
-msgid "trust/untrust a player to help on your island."
-msgstr ""
-
-msgid "§eThe following players are trusted on your island:"
-msgstr ""
-
-msgid "§eThe following leaders trusts you:"
-msgstr ""
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr ""
-
-msgid "§4Members are already trusted!"
-msgstr ""
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr ""
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr ""
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr ""
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr ""
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr ""
-
-msgid "warp to another player''s island"
-msgstr ""
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr ""
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr ""
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr ""
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr ""
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr ""
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr ""
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-
-msgid "§4That player does not exist!"
-msgstr ""
-
-msgid "§4That player does not have an active warp."
-msgstr ""
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr ""
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr ""
-
-msgid "general island command"
-msgstr ""
-
-msgid "allows user to bypass cooldowns"
-msgstr ""
-
-msgid "allows user to bypass visitor-protections"
-msgstr ""
-
-msgid "allows user to bypass teleport-delay"
-msgstr ""
-
-msgid "allows user to use [usb] signs"
-msgstr ""
-
-msgid "allows user to place [usb] signs"
+msgid "{0}''s Wither"
 msgstr ""
 
 msgid "§eYou can not use another island''s portals!"
@@ -1684,31 +100,6 @@ msgid "§eRiding is only allowed on your own island!"
 msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
-msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr ""
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr ""
-
-msgid "§eVisitors can't drop items!"
-msgstr ""
-
-#, java-format
-msgid "Owner: {0}"
-msgstr ""
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr ""
-
-msgid "Config:"
-msgstr ""
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
 msgstr ""
 
 msgid "§4You can only convert obsidian once every 10 seconds"
@@ -1753,18 +144,79 @@ msgstr ""
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr ""
 
+msgid "§eVisitors can't drop items!"
+msgstr ""
+
+#, java-format
+msgid "Owner: {0}"
+msgstr ""
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr ""
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr ""
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr ""
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr ""
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr ""
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
 msgstr ""
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr ""
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr ""
+
+msgid "§4Player is already assigned to this island!"
+msgstr ""
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr ""
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr ""
+
+msgid "§4Your current location is not a safe home-location."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr ""
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr ""
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+
+msgid "§cCommand is currently disabled!"
+msgstr ""
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
 msgstr ""
 
 #, java-format
@@ -1775,9 +227,6 @@ msgstr ""
 msgid ""
 "§eDoing §9{0}§e is §cRISKY§e. Repeat the command within §a{1}§e seconds to "
 "accept!"
-msgstr ""
-
-msgid "N/A"
 msgstr ""
 
 msgid "§4** You are entering a protected - but abandoned - island area."
@@ -1809,206 +258,31 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr ""
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
 msgstr ""
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr ""
+
+msgid "N/A"
+msgstr ""
+
+msgid "§4§lLocked Challenge"
+msgstr ""
+
+msgid "READY"
 msgstr ""
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr ""
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr ""
-
-msgid "SUCCESS"
-msgstr ""
-
-msgid "FAILED"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr ""
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr ""
-
-msgid "The island has been created."
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr ""
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr ""
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr ""
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr ""
-
-msgid "§9Creating an island at your location"
-msgstr ""
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
+msgid "§4The {0} challenge is not available yet!"
 msgstr ""
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr ""
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr ""
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr ""
-
-msgid "Click to warp to the island!"
-msgstr ""
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr ""
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr ""
-
-msgid "UNKNOWN"
-msgstr ""
-
-msgid "ANIMAL"
-msgstr ""
-
-msgid "MONSTER"
-msgstr ""
-
-msgid "VILLAGER"
-msgstr ""
-
-msgid "GOLEM"
-msgstr ""
-
-#, java-format
-msgid "§c{0}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr ""
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr ""
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr ""
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr ""
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr ""
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr ""
-
-#, java-format
-msgid "§7Page {0}"
-msgstr ""
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr ""
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr ""
-
-msgid "Return"
-msgstr ""
-
-msgid "§9Integer Editor"
-msgstr ""
-
-msgid "§eConfiguration saved and reloaded."
-msgstr ""
-
-msgid "§cError! §9Unable to save config file!"
-msgstr ""
-
-msgid "§3First Page"
-msgstr ""
-
-msgid "§3Last Page"
-msgstr ""
-
-msgid "§cSave & Reload config"
-msgstr ""
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-
-msgid "§7 (readonly)"
+msgid "§cNot enough items in chest to complete challenge!"
 msgstr ""
 
 msgid "true"
@@ -2370,6 +644,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr ""
 
+#, java-format
+msgid "§7Page {0}"
+msgstr ""
+
 msgid "§7First Page"
 msgstr ""
 
@@ -2610,7 +888,7 @@ msgstr ""
 msgid "Island Restart Menu"
 msgstr ""
 
-msgid "§eYou do not have access to that island-schematic!"
+msgid "Config:"
 msgstr ""
 
 #, java-format
@@ -2627,110 +905,114 @@ msgstr ""
 msgid "§aClick to restart!"
 msgstr ""
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr ""
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr ""
+
+msgid "Return"
+msgstr ""
+
+msgid "§9Integer Editor"
+msgstr ""
+
 msgid "Caps On"
 msgstr ""
 
 msgid "§9Text Editor"
 msgstr ""
 
+msgid "§eConfiguration saved and reloaded."
+msgstr ""
+
+msgid "§cError! §9Unable to save config file!"
+msgstr ""
+
+msgid "§3First Page"
+msgstr ""
+
+msgid "§3Last Page"
+msgstr ""
+
+msgid "§cSave & Reload config"
+msgstr ""
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+
+msgid "§7 (readonly)"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr ""
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr ""
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr ""
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr ""
+
+msgid "SUCCESS"
+msgstr ""
+
+msgid "FAILED"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr ""
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
-msgstr ""
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr ""
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr ""
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr ""
-
-msgid "§7Teleport cancelled"
-msgstr ""
-
-msgid "READY"
-msgstr ""
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr ""
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr ""
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr ""
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr ""
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr ""
-
-msgid "§4Player is already assigned to this island!"
-msgstr ""
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr ""
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr ""
-
-msgid "§aTeleporting you to your island."
-msgstr ""
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr ""
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr ""
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr ""
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr ""
-
-msgid "§4Your current location is not a safe home-location."
-msgstr ""
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr ""
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr ""
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-
-msgid "§cCommand is currently disabled!"
 msgstr ""
 
 msgid "North"
@@ -2755,4 +1037,1717 @@ msgid "West"
 msgstr ""
 
 msgid "North-West"
+msgstr ""
+
+msgid "The island has been created."
+msgstr ""
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr ""
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr ""
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr ""
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr ""
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr ""
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr ""
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr ""
+
+msgid "§9Creating an island at your location"
+msgstr ""
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr ""
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr ""
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr ""
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr ""
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr ""
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr ""
+
+msgid "UNKNOWN"
+msgstr ""
+
+msgid "ANIMAL"
+msgstr ""
+
+msgid "MONSTER"
+msgstr ""
+
+msgid "VILLAGER"
+msgstr ""
+
+msgid "GOLEM"
+msgstr ""
+
+#, java-format
+msgid "§c{0}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr ""
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr ""
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr ""
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr ""
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr ""
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr ""
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr ""
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr ""
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr ""
+
+msgid "to unlock this rank"
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr ""
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr ""
+
+msgid "§7and more..."
+msgstr ""
+
+msgid "§eItems will be traded for reward."
+msgstr ""
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr ""
+
+msgid "§6Item Reward: §a"
+msgstr ""
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr ""
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr ""
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr ""
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr ""
+
+msgid "§4You must be on your island to do that!"
+msgstr ""
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr ""
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr ""
+
+#, java-format
+msgid "§4{0}"
+msgstr ""
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr ""
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr ""
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr ""
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr ""
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr ""
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr ""
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr ""
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr ""
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr ""
+
+msgid "§e§lClick to complete this challenge."
+msgstr ""
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr ""
+
+#, java-format
+msgid "Rank: {0}"
+msgstr ""
+
+msgid "§fComplete most challenges in"
+msgstr ""
+
+msgid "§fthis rank to unlock the next rank."
+msgstr ""
+
+msgid "§eClick here to show previous page"
+msgstr ""
+
+msgid "§eClick here to show next page"
+msgstr ""
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr ""
+
+msgid "But you are Yelling in the wind!"
+msgstr ""
+
+msgid "But your fantasy friends are gone!"
+msgstr ""
+
+msgid "But you are Talking to your self!"
+msgstr ""
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr ""
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr ""
+
+msgid "party"
+msgstr ""
+
+msgid "island"
+msgstr ""
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr ""
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr ""
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr ""
+
+msgid "§cCommand only available to players"
+msgstr ""
+
+msgid "talk to your island party"
+msgstr ""
+
+msgid "talk to players on your island"
+msgstr ""
+
+msgid "manually update the top 10 list"
+msgstr ""
+
+msgid "§eGenerating the Top Ten list"
+msgstr ""
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr ""
+
+msgid "purges all abandoned islands"
+msgstr ""
+
+msgid "§4You must provide the age in days to purge!"
+msgstr ""
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr ""
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr ""
+
+msgid "Controls player-cooldowns"
+msgstr ""
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr ""
+
+msgid "§eThe player is not currently online"
+msgstr ""
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr ""
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr ""
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr ""
+
+msgid "restarts the cooldown on the command"
+msgstr ""
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr ""
+
+msgid "lists all the active cooldowns"
+msgstr ""
+
+msgid "§eCmd Cooldown"
+msgstr ""
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr ""
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr ""
+
+msgid "toggles maintenance mode"
+msgstr ""
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr ""
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr ""
+
+msgid "§7----------------"
+msgstr ""
+
+msgid "#"
+msgstr ""
+
+msgid "ms/job"
+msgstr ""
+
+msgid "ms/tick"
+msgstr ""
+
+msgid "ticks"
+msgstr ""
+
+msgid "act"
+msgstr ""
+
+msgid "time"
+msgstr ""
+
+msgid "name"
+msgstr ""
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr ""
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr ""
+
+msgid "flushes all caches to files"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+
+msgid "tries to fix the the area of flatland."
+msgstr ""
+
+msgid "§4No valid island found"
+msgstr ""
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr ""
+
+msgid "manage orphans"
+msgstr ""
+
+msgid "count orphans"
+msgstr ""
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr ""
+
+msgid "clear orphans"
+msgstr ""
+
+msgid "§eClearing all old (empty) island locations."
+msgstr ""
+
+msgid "list orphans"
+msgstr ""
+
+msgid "§eNo orphans currently registered."
+msgstr ""
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr ""
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr ""
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr ""
+
+msgid "open GUI for config"
+msgstr ""
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr ""
+
+msgid "teleport to another players island"
+msgstr ""
+
+msgid "§4Only supported for players"
+msgstr ""
+
+msgid "§4That player does not have an island!"
+msgstr ""
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr ""
+
+msgid "various WorldGuard utilities"
+msgstr ""
+
+msgid "refreshes the chunks around the player"
+msgstr ""
+
+msgid "§eResending chunks to the client"
+msgstr ""
+
+msgid "load the region chunks"
+msgstr ""
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr ""
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr ""
+
+msgid "update the WG regions"
+msgstr ""
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr ""
+
+msgid "§eNo island found at your location!"
+msgstr ""
+
+msgid "refreshes the chunk around the player"
+msgstr ""
+
+msgid "region manipulations"
+msgstr ""
+
+msgid "shows the borders of the current island"
+msgstr ""
+
+msgid "§eNo island found at your current location"
+msgstr ""
+
+msgid "§eCan only be executed as a player"
+msgstr ""
+
+msgid "shows the borders of the current chunk"
+msgstr ""
+
+msgid "shows the borders of the inner-chunks"
+msgstr ""
+
+msgid "shows the non-chunk-aligned borders"
+msgstr ""
+
+msgid "shows the borders of the outer-chunks"
+msgstr ""
+
+msgid "hides the regions again"
+msgstr ""
+
+msgid "§eStopped displaying regions"
+msgstr ""
+
+msgid "§eNo currently shown regions for this player"
+msgstr ""
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr ""
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr ""
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr ""
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr ""
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr ""
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr ""
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr ""
+
+msgid "control debugging"
+msgstr ""
+
+msgid "set debug-level"
+msgstr ""
+
+msgid "toggle debug-logging"
+msgstr ""
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr ""
+
+msgid "flush current content of the logger to file."
+msgstr ""
+
+msgid "§eLog-file has been flushed."
+msgstr ""
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr ""
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr ""
+
+msgid "§eLogging disabled!"
+msgstr ""
+
+msgid "advanced command for setting island-data"
+msgstr ""
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr ""
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr ""
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr ""
+
+msgid "set a player''s island to your location"
+msgstr ""
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr ""
+
+msgid "shows the NBTTag for the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr ""
+
+msgid "§cNo item in hand!"
+msgstr ""
+
+msgid "sets the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "adds the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "Manage challenges for a player"
+msgstr ""
+
+msgid "resets the challenge for the player"
+msgstr ""
+
+msgid "§4Challenge has never been completed"
+msgstr ""
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr ""
+
+msgid "resets all challenges for the player"
+msgstr ""
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr ""
+
+msgid "complete all challenges in the rank"
+msgstr ""
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr ""
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr ""
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr ""
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr ""
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr ""
+
+msgid "§cTrying to abort protect-all task."
+msgstr ""
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr ""
+
+msgid "reload configuration from file."
+msgstr ""
+
+msgid "§eConfiguration reloaded from file."
+msgstr ""
+
+msgid "manage islands"
+msgstr ""
+
+msgid "protects the island"
+msgstr ""
+
+msgid "delete the island (removes the blocks)"
+msgstr ""
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr ""
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+
+msgid "removes the player from the island"
+msgstr ""
+
+msgid "adds the player to the island"
+msgstr ""
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr ""
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr ""
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+
+msgid "print out info about the island"
+msgstr ""
+
+msgid "sets the biome of the island"
+msgstr ""
+
+msgid "§4That player has no island."
+msgstr ""
+
+msgid "§4No valid island at your location"
+msgstr ""
+
+msgid "purges the island"
+msgstr ""
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr ""
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr ""
+
+msgid "toggles the islands ignore status"
+msgstr ""
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr ""
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+
+msgid "§4No valid player-name supplied."
+msgstr ""
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr ""
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr ""
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr ""
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr ""
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr ""
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr ""
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr ""
+
+msgid "Error: That player does not have an island!"
+msgstr ""
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr ""
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr ""
+
+msgid "displays version information"
+msgstr ""
+
+msgid "imports players and islands from other formats"
+msgstr ""
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr ""
+
+msgid "changes the language of the plugin, and reloads"
+msgstr ""
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr ""
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr ""
+
+msgid "§9Supported Languages:\n"
+msgstr ""
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr ""
+
+msgid "§cUnable to locate any languages."
+msgstr ""
+
+msgid "advanced command for getting island-data"
+msgstr ""
+
+msgid "Ultimate SkyBlock Admin"
+msgstr ""
+
+msgid "show player-information"
+msgstr ""
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+
+msgid "§4That player is already leader on another island."
+msgstr ""
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr ""
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr ""
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr ""
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr ""
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr ""
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr ""
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr ""
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr ""
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr ""
+
+msgid "§4You haven't been invited."
+msgstr ""
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr ""
+
+msgid "general island command"
+msgstr ""
+
+msgid "allows user to bypass cooldowns"
+msgstr ""
+
+msgid "allows user to bypass visitor-protections"
+msgstr ""
+
+msgid "allows user to bypass teleport-delay"
+msgstr ""
+
+msgid "allows user to use [usb] signs"
+msgstr ""
+
+msgid "allows user to place [usb] signs"
+msgstr ""
+
+msgid "complete and list challenges"
+msgstr ""
+
+msgid "§cCommand only available for players."
+msgstr ""
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr ""
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr ""
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr ""
+
+msgid "warp to another player''s island"
+msgstr ""
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr ""
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr ""
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr ""
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr ""
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr ""
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr ""
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+
+msgid "§4That player does not exist!"
+msgstr ""
+
+msgid "§4That player does not have an active warp."
+msgstr ""
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr ""
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr ""
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr ""
+
+msgid "accept/reject an invitation."
+msgstr ""
+
+msgid "leave your party"
+msgstr ""
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr ""
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr ""
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr ""
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr ""
+
+msgid "check your or anothers island level"
+msgstr ""
+
+msgid "allows user to query for others levels"
+msgstr ""
+
+msgid "§eYou must be on your island to use this command."
+msgstr ""
+
+msgid "§4You do not have an island!"
+msgstr ""
+
+msgid "§4You do not have access to that command!"
+msgstr ""
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr ""
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr ""
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr ""
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr ""
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr ""
+
+msgid "exempt player from create-cooldown"
+msgstr ""
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr ""
+
+msgid "invite a player to your island"
+msgstr ""
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+
+msgid "§4Only the island''s owner can invite!"
+msgstr ""
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr ""
+
+msgid "§4You can't invite any more players."
+msgstr ""
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr ""
+
+msgid "§4That player is offline or doesn't exist."
+msgstr ""
+
+msgid "§4You can't invite yourself!"
+msgstr ""
+
+msgid "§4That player is the leader of your island!"
+msgstr ""
+
+msgid "lock your island to non-party members."
+msgstr ""
+
+msgid "§4You do not have permission to lock your island!"
+msgstr ""
+
+msgid "§4You don't have access to this command!"
+msgstr ""
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr ""
+
+msgid "display the top10 of islands"
+msgstr ""
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr ""
+
+msgid "remove a member from your island."
+msgstr ""
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr ""
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr ""
+
+msgid "§4Stop kickin' yourself!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr ""
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr ""
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr ""
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr ""
+
+msgid "teleport to the island home"
+msgstr ""
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+
+msgid "§4This command can only be executed by a player"
+msgstr ""
+
+msgid "transfer leadership to another member"
+msgstr ""
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr ""
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr ""
+
+msgid "§4Only leader can transfer leadership!"
+msgstr ""
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr ""
+
+msgid "show party information"
+msgstr ""
+
+msgid "shows information about your party"
+msgstr ""
+
+msgid "show pending invites"
+msgstr ""
+
+msgid "§eNo pending invites"
+msgstr ""
+
+msgid "withdraw an invite"
+msgstr ""
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr ""
+
+msgid "check your or another''s island info"
+msgstr ""
+
+msgid "allows user to see others island info"
+msgstr ""
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr ""
+
+msgid "Score Count Block"
+msgstr ""
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr ""
+
+msgid "§eThe following players are trusted on your island:"
+msgstr ""
+
+msgid "§eThe following leaders trusts you:"
+msgstr ""
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr ""
+
+msgid "§4Members are already trusted!"
+msgstr ""
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr ""
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr ""
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr ""
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr ""
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr ""
+
+msgid "delete your island and start a new one."
+msgstr ""
+
+msgid "exempt player from restart-cooldown"
+msgstr ""
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr ""
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr ""
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr ""
+
+msgid "teleports you to the skyblock spawn"
+msgstr ""
+
+msgid "change the biome of the island"
+msgstr ""
+
+msgid "exempt player from biome-cooldown"
+msgstr ""
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr ""
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr ""
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr ""
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr ""
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr ""
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr ""
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr ""
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr ""
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr ""
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr ""
+
+msgid "set your island''s warp location"
+msgstr ""
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr ""
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr ""
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr ""
+
+msgid "teleports you to your island (or create one)"
+msgstr ""
+
+msgid "ban/unban a player from your island."
+msgstr ""
+
+msgid "exempts user from being banned"
+msgstr ""
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr ""
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr ""
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr ""
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr ""
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr ""
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr ""
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr ""
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr ""
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr ""
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr ""
+
+msgid "display log"
+msgstr ""
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr ""
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr ""
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr ""
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr ""
+
+msgid "try to complete a challenge"
+msgstr ""
+
+msgid "show information about the challenge"
+msgstr ""
+
+msgid "§eRank: "
+msgstr ""
+
+msgid "§4This Challenge is not repeatable!"
+msgstr ""
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr ""
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr ""
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr ""
+
+msgid "§eSending you to spawn."
+msgstr ""
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr ""
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr ""
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr ""
+
+msgid "§aTeleporting you to your island."
+msgstr ""
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr ""
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr ""
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr ""
+
+msgid "§7Teleport cancelled"
 msgstr ""

--- a/uSkyBlock-Core/src/main/po/ko.po
+++ b/uSkyBlock-Core/src/main/po/ko.po
@@ -11,6 +11,30 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
 
+msgid "d"
+msgstr "일"
+
+msgid "h"
+msgstr "시"
+
+msgid "m"
+msgstr "월"
+
+msgid "s"
+msgstr "초"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§e당신은 (§4 {0} §e)에 접근 권한이 없습니다."
@@ -18,6 +42,15 @@ msgstr "§e당신은 (§4 {0} §e)에 접근 권한이 없습니다."
 #, java-format
 msgid "§eInvalid command: {0}"
 msgstr "§e올바르지 않은 명령: {0}"
+
+msgid "Command"
+msgstr "명령어"
+
+msgid "Permission"
+msgstr "퍼미션"
+
+msgid "Description"
+msgstr "설명"
 
 #, java-format
 msgid "§7Usage: {0}"
@@ -42,1682 +75,12 @@ msgstr "{0}에 문서를 작성합니다."
 msgid "§4Error writing documentation: {0}"
 msgstr "§4다음 문서 저장중 오류가 발생했습니다: {0}"
 
-msgid "Command"
-msgstr "명령어"
+msgid "§cWither Despawned!§e It wandered too far from your island."
+msgstr "§c!마녀 소환이 취소되었습니다!§e 당신의 섬에서 너무 멀리 있습니다."
 
-msgid "Permission"
-msgstr "퍼미션"
-
-msgid "Description"
-msgstr "설명"
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-msgid "d"
-msgstr "일"
-
-msgid "h"
-msgstr "시"
-
-msgid "m"
-msgstr "월"
-
-msgid "s"
-msgstr "초"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§e여전히 다음의 블록들이 부족합니다: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4필요 조건이 {0} 일 후에 리셋됩니다."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4필요 조건이 {0} 시간 후에 리셋됩니다."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4필요 조건이 {0} 분 후에 리셋됩니다."
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr "§e도전과제의 필요항목:"
-
-msgid "§7and more..."
-msgstr "§7그리고 더..."
-
-msgid "§eItems will be traded for reward."
-msgstr "§e보상을 위하여 아이템이 거래될 예정입니다."
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr "§e최소 {0} 미터가 되어야 합니다."
-
-msgid "§6Item Reward: §a"
-msgstr "§6아이템 보상: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6돈 보상: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6경험치 보상: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§d완료된 전체 횟수: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr "§7필요 {0}"
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4{0}란 이름의 도전과제를 찾지 못했습니다"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4그 일을 하려면 당신의 섬에 있어야 합니다!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§4도전과제 {0}는 아직 사용이 불가능합니다!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4{0} 반복할 수 없는 도전과제입니다!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§e도전과제를 완료하려면, §a{0}를 사용하세요"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr "§4당신은 모든 요구된 아이템의 {0} 블록 안에 서있어야 합니다."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4도전과제를 완료하려면 당신의 섬의 레벨이 {0} 여야 합니다!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4알려지지않은 타입의 도전과제입니다: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§e여전히 다음의 엔티티가 부족합니다:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§e당신은 다음의 아이템이 부족합니다: {0}개의"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§a당신은 {0} 도전과제를 완료했습니다!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9{0}§f가 §9{1}§f 도전과제를 완료했습니다!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§e아아템 보상: §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§e경험치 보상: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§e돈 보상: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§e당신의 인벤토리가 §4가득 찼습니다§e. 아이템이 섬에 떨어졌습니다."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§l도전과제를 완료하려면 클릭하세요."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§l이 도전과제는 반복할 수 없습니다."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "랭크: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§f대부분의 도전과제를 완료하였습니다"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§f이 랭크는 다음 랭크를 해제하기 위한 랭크 입니다."
-
-msgid "§eClick here to show previous page"
-msgstr "§e전 페이지를 보려면 여기를 클릭하세요"
-
-msgid "§eClick here to show next page"
-msgstr "§e다음 페이지를 보려면 여기를 클릭하세요"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§l잠긴 도전과제"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "{0}개의  {1}§7 challenges"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7를 완료하여 {0} 랭크를"
-
-msgid "to unlock this rank"
-msgstr "잠금해제 하세요"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "하지만 당신은 와아아아아안전 호오오온자!"
-
-msgid "But you are Yelling in the wind!"
-msgstr "하지만 당신은 바람 속에서 외칩니다!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "하지만 당신의 상상속 친구들은 가버렸죠!"
-
-msgid "But you are Talking to your self!"
-msgstr "하지만 당신은 자신한테 말을 걸고 있어요!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§c죄송합니다! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr "타 그룹에 메세지를 보내기, 혹은 on/off 로 조절"
-
-msgid "party"
-msgstr "파티"
-
-msgid "island"
-msgstr "섬"
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§c다음 키 {0} §a를 눌러 채팅 켜기"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§c다음키 §9{0}§c 를 반복하여 기능 끄기"
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§c다음 키 {0} §a를 눌러 채팅 끄기"
-
-msgid "§cCommand only available to players"
-msgstr "§c플레이어에게만 유효한 명령어 입니다."
-
-msgid "talk to players on your island"
-msgstr "당신의 섬에 있는 플레이어에게 말을 겁니다"
-
-msgid "talk to your island party"
-msgstr "당신의 섬의 파티에게 말을 겁니다"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§e플레이어 {0}는 섬이 없습니다!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§e유효하지 않은 플레이어 {0}가 공급하였습니다."
-
-msgid "Manage challenges for a player"
-msgstr "도전과제를 관리하세요"
-
-msgid "resets the challenge for the player"
-msgstr "해당 플레이어의 도전과제를 리셋합니다"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4도전과제가 전혀 완료되지 않았습니다"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§e도전과제: {0} has been reset for {1}"
-
-msgid "resets all challenges for the player"
-msgstr "모든 도전과제를 리셋합니다"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0}는 모든 도전과제를 리셋했습니다."
-
-msgid "complete all challenges in the rank"
-msgstr "이 랭크의 모든 도전과제를 완료하였습니다"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4{0}란 이름의 플레이어를 찾지 못했습니다!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4도전과제 {0}는 이미 완료되었습니다"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§e도전과제: {0}이 {1}를 완료했습니다"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4{0}란 이름의 도전과제를 찾지 못했습니다!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4{0}란 이름의 랭크를 찾지 못했습니다!"
-
-msgid "manage islands"
-msgstr "섬 관리"
-
-msgid "protects the island"
-msgstr "섬 보호"
-
-msgid "delete the island (removes the blocks)"
-msgstr "섬을 삭제함 (블럭을 제거함)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9현재 위치의 버려진 섬을 삭제했습니다."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4이 지역의 섬엔 멤버들이 있습니다!\n"
-"§e섬을 제거하려면 §9 /usb island delete <name>§e를 쓰세요."
-
-msgid "removes the player from the island"
-msgstr "이 섬에서 플레이어를 제거합니다"
-
-msgid "adds the player to the island"
-msgstr "이 섬에 플레이어를 추가합니다"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d가 당신의 섬 그룹에 참여했습니다."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4{0}란 이름의 플레이어를 찾지 못했습니다!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-"§4Nay valid hideout provided, either stand within one, or provide a hideout "
-"name"
-
-msgid "print out info about the island"
-msgstr "섬에 대한 정보를 보여줍니다"
-
-msgid "sets the biome of the island"
-msgstr "섬의 생태계를 지정합니다"
-
-msgid "§4That player has no island."
-msgstr "§4그 플레이어는 섬이 없습니다."
-
-msgid "§4No valid island at your location"
-msgstr "§4당신의 위치에 유효한 섬이 없습니다"
-
-msgid "purges the island"
-msgstr "섬을 청소합니다"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4오류! §9청소를 위한 섬을 찾지 못했습니다'."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§c정화: §9{0}에 정화된 섬"
-
-msgid "toggles the islands ignore status"
-msgstr "섬 상태 무시 버튼"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§c{0}의 섬이 탑 텐과 청소에서 무시되도록 지정합니다"
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§c{0}의 섬의 ignore-flag가 제거되었습니다, 이제 탑 텐에 보여지고 청소합니다"
-
-msgid "§4No valid player-name supplied."
-msgstr "§4유효한 플레이어 이름이 제공되지 않았습니다."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "{0}을 섬에서 제거하는 중"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§e{0}의 섬의 생태계가 {1}로 바뀌었습니다."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§e{0}의 섬의 생태계가 바다로 바뀌었습니다."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr "§a변화를 확인하려면 스폰, 혹은 재로깅이 필요합니다."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0}은 {1}로 변한 생태계를 가졌습니다."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0}은 바다로 변한 생태계를 가졌습니다."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§e{0}의 섬을 제거하는 중."
-
-msgid "Error: That player does not have an island!"
-msgstr "오류: 그 플레이어는 섬이 없습니다!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§e{1}에 있는 {0}의 섬은 보호받고 있습니다"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4{1}에 있는 {0}의 섬은 이미 보호받고 있습니다"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "키 변경을 위해 GUI를 여세요"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§e설정파일 이름이 올바르지 않습니다"
-
-msgid "Controls player-cooldowns"
-msgstr "플레이어 대기시간을 컨트롤 합니다"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "커맨드로 쿨타임을 초기화 합니다 (* = all)"
-
-msgid "§eThe player is not currently online"
-msgstr "§e플레이어가 현재 온라인상태가 아닙니다"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Cleared cooldown on {0} for {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Nay active cooldown on {0} for {1} detected!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "유효하지 않은 커맨드가 입력되었습니다, 오직 재시작과 생태계만 !"
-
-msgid "restarts the cooldown on the command"
-msgstr "커맨드의 대기시간을 다시 시작합니다"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eReset cooldown on {0} for {1}§e to {2} seconds"
-
-msgid "lists all the active cooldowns"
-msgstr "활성화된 모든 대기시간을 목록으로 보여줍니다"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCmd 대기시간"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§e§9{0}§e의 활성화된 대기시간을 찾을 수 없습니다."
-
-msgid "control debugging"
-msgstr "컨트롤 디버깅'"
-
-msgid "set debug-level"
-msgstr "디버그 레벨을 지정합니다"
-
-msgid "toggle debug-logging"
-msgstr "디버그 로깅 버튼'"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr ""
-"§4로그 기능이 활성화 되지 않았습니다. 해당 기능을 비활성화 할 수 없습니다!"
-
-msgid "flush current content of the logger to file."
-msgstr "현재 월드 상태에 관한 로그파일을 파일에서 제거합니다."
-
-msgid "§eLog-file has been flushed."
-msgstr "§e기록 파일이 작성되었습니다 ."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr ""
-"§4로그 저장이 꺼져있습니다, §d/usb debug enable 다음명령어를 사용하세요"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§e로깅 비활성화!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "평지 지역을 고치는 것을 시도합니다."
-
-msgid "§4No valid island found"
-msgstr "§4유효한 섬이 발견되지 않음"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4{0}의 섬에 평지가 탐지되지 않음!"
-
-msgid "flushes all caches to files"
-msgstr "모든 캐시 파일을 제거 합니다"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-"§eFlushed §a{0} islands§e, §b{1} pirates an'' §6{2} challenge-completions."
-
-msgid "manually update the top 10 list"
-msgstr "Top 10 리스트 수동 업데이트"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eTop 10 리스트 생성중"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eTop 10 리스트 생성 완료"
-
-msgid "advanced command for getting island-data"
-msgstr "섬 정보를 확인하기 위한 고급 명렁ㅇ"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§e현재 {0}의 값은 ''{1}''"
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "{0} §c의 정보를 가져올 수 없습니다"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§e올바른 값은 {0} 입니다."
-
-msgid "teleport to another players island"
-msgstr "다른 플레이어 섬으로 텔레포트합니다."
-
-msgid "§4Only supported for players"
-msgstr "§4오직 플레이어들에게만 지원됩니다."
-
-msgid "§4That player does not have an island!"
-msgstr "§4그 플레이어는 가진 섬이 없습니다!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr "§a{0}''의 섬으로 텔레포트중 입니다."
-
-msgid "imports players and islands from other formats"
-msgstr "다른 형식으로 부터 플레이어와 섬을 수입합니다"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9직업 통계s"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/직업"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "행동"
-
-msgid "time"
-msgstr "시간"
-
-msgid "name"
-msgstr "이름"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "플러그인의 언어를 바꾸고 리로드합니다"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§a성공적으로 언어를 §e{0}로 바꾸었습니다"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cF언어를 §e{0}로 바꾸는데 실패하였습니다"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9지원되는 언어:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§c어떤 언어든 설정할 수 없습니다."
-
-msgid "transfer leadership to another player"
-msgstr "다른 플레이어에게 리더 권한을 전달합니다"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4플레이어{0}는 전달할 섬이 없습니다!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§e플레이어 §d{0}§e는 이미 섬이 있습니다 .§e §d/ 섬 제거를 사용하세요 "
-"<name>§e 그를 먼저 제거하려면."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§b리더 권한이 {0}§b에서 {1}로 전달되었습니다"
-
-msgid "advanced info about NBT stuff"
-msgstr "NBT stuff 고급 정보"
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "현재 들고있는 아이템에 대한 NBTTag 확인"
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§9{0} §e정보"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - 이름: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - nbttag: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§c손에 아이템이 없습니다!"
-
-msgid "§eCan only be executed as a player"
-msgstr "§e오직 플레이어에게만 유효합니다."
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "현재 손에 든 아이템으로 NBTTag를 설정합니다."
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "§9{0}§e §e을 §c{1} §e으로 설정"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "현재 들고 있는 아이템에 NBTTag를 추가합니다."
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§9{0}§e에 §c{1}§e 을 추가."
-
-msgid "manage orphans"
-msgstr "고아들을 관리합니다"
-
-msgid "count orphans"
-msgstr "고아의 수를 셉니다"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§e{0} 오래된 섬 위치는 새것으로 교체되기 전까지 사용됩니다."
-
-msgid "clear orphans"
-msgstr "고아들을 없앱니다"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§e모든 예전의 (빈) 섬의 위치를 없애는중."
-
-msgid "list orphans"
-msgstr "고아들의 목록을 만듭니다"
-
-msgid "§eNo orphans currently registered."
-msgstr "§e현재 어느 고아도 등록하지 않았습니다."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr "추가 perks {0}"
-
-msgid "protects all islands (time consuming)"
-msgstr "모든 섬을 보호합니다 (시간을 소모함)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§c보호된 모든 처리작업을 취소중입니다."
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-"§4죄송합니다!§e 보호작업이 이미 진행중 입니다. 완료하거나, §9usb protectall "
-"§cstop§e 명령어를 사용해 중지하세요"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§e모든 보호 작업이 시작되는 중입니다. 몇분의 시간의 소요됩니다."
-
-msgid "purges all abandoned islands"
-msgstr "모든 버려진 섬들을 청소합니다"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4당신은 청소하기위해 나이를 제공해야 합니다!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr "§4청소작업을 취소중입니다."
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr "§4청소작업을 시작합니다..."
-
-msgid "region manipulations"
-msgstr "지역 조작"
-
-msgid "shows the borders of the current island"
-msgstr "현재 섬의 경계를 표시합니다."
-
-msgid "§eNo island found at your current location"
-msgstr "§e현재 위치에서 섬을 발견하지 못하였습니다."
-
-msgid "shows the borders of the current chunk"
-msgstr "현재 청크의 경계를 표시합니다"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "내부 청크의 경계를 표시합니다."
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "경계의 청크가 아닌 부분을 표시합니다."
-
-msgid "shows the borders of the outer-chunks"
-msgstr "외부 청크 경계를 표시합니다."
-
-msgid "hides the regions again"
-msgstr "현재 지역을 다시 숨깁니다."
-
-msgid "§eStopped displaying regions"
-msgstr "§e지역표시를 중지합니다."
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§e해당 플레이여의 지역이 없습니다."
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§eAnimation-tick 표시화면을 {0}로 변경합니다."
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§eAnimation-tick 의 값은 integer 형식 이여야 합니다."
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "당신의 위치에 플레이어의 섬을 지정합니다"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "파일로 부터 외형을 리로드합니다."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§e파일로부터 리로드된 외형."
-
-msgid "advanced command for setting island-data"
-msgstr "섬 데이터 설정 고급 명령어"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§c{0} 를 ''{1}'로 지정'"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§c필드{0} 를 ''{1}''로 지정할 수 없습니다."
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr "§c필드{0} 를 ''{1}'로 지정할 수 없습니다. a number was expected"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§c올바르지 않은 필드 {0}"
-
-msgid "toggles maintenance mode"
-msgstr "관리모드로 전환"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr "§c관리모드: §a활성화§e 모든 uSkyBlock 기능이 현재 비활성화 되었습니다."
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr "§c관리모드: §a비활성화§e 모든 uSkyBlock 기능이 현재 활성화 되었습니다."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr "§c관리모드 변경은 오직 콘솔창에서만 가능합니다!"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§c취소됨:§e 보호가 모두 취소되었습니다!"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr "§e{0}, {1}에 관한 보호를 모두 마쳤습니다 새로운 지역이 생성되었습니다!"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§7- 스캐닝: {0,number,##}% ({1}/{2} 실패: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4PURGE:§9 스캐닝 취소."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr "- PURGING: {0,number,##}% ({1}/{2}), 경과 {3}, 완료까지 남은시가 ~{4}"
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4PURGE:§9 버려진 섬의 청소를 마쳤습니다."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4PURGE:§9 버려진 섬 청소 취소"
-
-msgid "displays version information"
-msgstr "버전 정보를 보여줍니다"
-
-msgid "various WorldGuard utilities"
-msgstr "여러가지 WorldGuard 기능"
-
-msgid "refreshes the chunks around the player"
-msgstr "플레이어 주변의 창크를 청소합니다"
-
-msgid "§eResending chunks to the client"
-msgstr "§e의뢰인에게 덩어리들을 다시보내는 중입니다"
-
-msgid "load the region chunks"
-msgstr "지역의 Chunks를 로드합니다"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§e{0}에 Chunks을 로딩하는 중입니다"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§e{0}에 Chunks들을 언로딩하는 중입니다"
-
-msgid "update the WG regions"
-msgstr "월드가드 지역을 업데이트합니다"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§e{0}를 위하여 섬의 월드가드 지역이 업데이트 되었습니다."
-
-msgid "§eNo island found at your location!"
-msgstr "§e당신의 위치에서 어떠한 섬도 발견하지 못했습니다!"
-
-msgid "refreshes the chunk around the player"
-msgstr "플레이어 주위의 청크를 갱신 합니다."
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "플레이어 정보를 보여줍니다"
-
-msgid "try to complete a challenge"
-msgstr "도전과제를 완료합니다."
-
-msgid "§cCommand only available for players."
-msgstr "§c해당 명령어는 플레이어에게만 유효합니다."
-
-msgid "show information about the challenge"
-msgstr "도전과제에 관한 정보를 확인합니다."
-
-msgid "§eRank: "
-msgstr "§e랭크: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4반복할 수 없는 도전과제입니다!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr "§4이 도전과제를 완료되었을때 모든 필요한 아이템들을 잃게 됩니다!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4All 필요한 아이템들은 무조건 당신의 섬에서 당신의 {0} 블록 안팎으로 놓여져"
-"야 합니다."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§e도전과제를 완료하려면 §f/c c {0}를 사용하세요"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr ""
-"§4유효하지 않은 도전과제 이름입니다! 더 많은 정보가 필요하면 /c help를 이용하"
-"세요"
-
-msgid "complete and list challenges"
-msgstr "도전과제 완료후 목록 확인"
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§e도전과제가 실행되지 않았습니다. 관리자에게 문의하세요."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4당신은 오직 skyblock 월드의 도전과제만을 할 수 있습니다!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4당신이 섬을 가졌을 때에만 도전과제를 할 수 있습니다!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4당신의 섬은 꽉 찼습니다, 아니면 당신은 보류된 초대가 너무 많습니다. 당신은 "
-"아무도 초대할 수 없습니다"
-
-msgid "§4That player is already leader on another island."
-msgstr "§4그 플레이어는 이미 다른 섬의 리더입니다."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e가 당신을 초대하려 했지만 당신은 이미 파티에 들어가 있습니다."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr "§a{0} 에게 초대장 발송"
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e가 당신을 그들의 섬으로 초대하였습니다!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§f/island [accept/reject]§e 초대를 승낙/거절 하세요."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4경고: 승낙하면 당신은 현재 섬을 잃게 됩니다 !"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d가 {1}를 초대했습니다"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e가 초대를 거절하였습니다."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4당신은 해당 커맨드를 지금 쓸 수 없습니다. 당신의 파티를 먼저 떠나주세요."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§a당신은 섬에 참가하였습니다! 다른 멤버들을 보기 원하면 /island party 를 사용"
-"하세요."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§e{0}§e에게 한 초대가 시간초과 되었거나 취소되었습니다."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§e{0}의 섬으로의 초대가 시간초과 되었거나 취소되었습니다 ."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§e당신은 섬에 참여하는 초대를 승낙했습니다."
-
-msgid "§4You haven't been invited."
-msgstr "§4초대받은 것이 없습니다."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§e당신은 섬에 참여하라는 초대를 거절하였습니다."
-
-msgid "accept/reject an invitation."
-msgstr "초대에 accept/reject 하세요."
-
-msgid "teleports you to your island (or create one)"
-msgstr "당신의 섬으로 이동합니다 (혹은 생성)"
-
-msgid "ban/unban a player from your island."
-msgstr "당신의 섬에서 플레이어를 차단/차단 취소 하세요."
-
-msgid "exempts user from being banned"
-msgstr "해당 유저는 벤에서 면제되었습니다."
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§e다음의 플레이어는 당신의 섬에서 워프하는 것이 금지되었습니다:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr "§e당신의 섬에서 차단/차단 취소 하려면, island ban을 쓰세요 <플레이어>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4당신은 멤버들을 차단할 수 없습니다. 먼저 그들을 제거하세요!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4당신은 플레이어를 차단/퇴장 시킬 권한이 없습니다."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§e플레이어 {0}는 벤할 수 없습니다."
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4{0} 가 당신을 그들의 섬에서 벤하려 시도했습니다!"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4{0} 는 벤에서 면제되었습니다."
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§e 당신은 §4{0}§e가 당신의 섬으로 워프하는 것을 금지했습니다.."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§e 당신은 {0}§e''의 섬에서 §c차단§e 되었습니다 ."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§e당신은 §a{0}§e가 당신의 섬에서 워프하는 것의 금지를 풀었습니다."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§e당신은{0}§e''의 섬에서 §a차단 해제§e 되었습니다 ."
-
-msgid "change the biome of the island"
-msgstr "섬의 생태계를 바꿉니다"
-
-msgid "exempt player from biome-cooldown"
-msgstr "바이옴 쿨다운에서 해당 플레이어를 제외합니다."
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr "해당 플레이어의 섬 바이옴을 {0} 로 변경합니다."
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr "§c당신의 현재 섬의 생태계를 바꿀 권한이 없습니다."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4당신은 이섬의 생태계를 바꿀 권한이 없습니다!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§생태계를 바꾸려면 꼭 자신의 섬에 있어야 합니다!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr ""
-"§c당신은 생태계 이름을 잘못 적었습니다. 반드시 {0} 들중 하나여야 합니다."
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§e당신은 생태계를 {0,number,#}분 후에 다시 바꿀 수 있습니다."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§c당신은 생태계를 그 타입으로 바꿀 권한이 없습니다.."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-"§7pixies가 현재 §9{0}§7로 바이옴을 변경하느라 바쁩니다, 인내심을 가지세요."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-"§7작은요정들이 당신 섬의 생태계를 §9{0}§7로 바꾸고 있어 바쁩니다, 조금만 기다"
-"려주세요."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr "§e올바르지 않은 {0} 바이옴 공급!"
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§a당신은 섬의 생태계를 {0}로 바꿨습니다"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0}가 섬의 생태계를 {1}로 바꾸었습니다"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr "§a{1} 바이옴으로 변경하기 위하여 {0} 블럭을 변경해야 합니다"
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr "{1} 바이옴 안에 {0} 장소가 생성되었습니다."
-
-msgid "create an island"
-msgstr "섬을 만듭니다"
-
-msgid "exempt player from create-cooldown"
-msgstr "생성 쿨다운에서 해당 플레이어를 면제합니다."
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4섬을 찾았습니다!§e 당신은 이미 섬이 있습니다. 만약 새로운 섬을 원하시면, "
-"type§b /is restart§e 로 새로운 섬을 얻으세요"
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4섬을 발견했습니다!§e 당신은 이미 섬의 멤버입니다. 당신만의 섬을 시작하려"
-"면, 먼저§b /is leave 를 사용하세요"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§e당신은 {0,number,#}추 후에 새 섬을 만들 수 있습니다."
-
-msgid "teleport to the island home"
-msgstr "섬의 Home으로 텔레포트 합니다"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§cYer 섬이 생성되는 중입니다, 당신은 지금 바로 집으로 텔레포트 할 수 없습니"
-"다. "
-
-msgid "check your or another''s island info"
-msgstr "당신 또는 다른 사람의 섬 정보를 확인합니다"
-
-msgid "allows user to see others island info"
-msgstr "해당 유저가 다른 섬 정보를 보는것을 허용합니다."
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4섬 레벨이 작동하지 않습니다, 관리자에게 문의하세요."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§e이 커맨드를 쓰려면 자신의 섬에 있어야 합니다."
-
-msgid "§4You do not have an island!"
-msgstr "§4가지고 있는 섬이 없습니다!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4그 커맨드의 권한이 없습니다!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4그 플레이어는 유효하지 않거나 가진 섬이 없습니다!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§e{0}의 섬의 블록들(page {1,number} of {2,number}):"
-
-msgid "Score Count Block"
-msgstr "점수 카운트 블록"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§a섬의 레벨은 {0,number,###.##}입니다"
-
-msgid "invite a player to your island"
-msgstr "플레이어를 당신의 섬으로 초대합니다"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§e만약 플레이어를 당신의 섬으로 초대하려면§f /island invite <playername>§e "
-"를 쓰세요 ."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4오직 이 섬의 주인만이 초대할 수 있습니다!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§a{0}명 더 초대할 수 있습니다 ."
-
-msgid "§4You can't invite any more players."
-msgstr "§4당신은 더이상 플레이어를 초대할 수 없습니다."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4당신은 이 섬에 다른 사람을 초대할 권한이 없습니다!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4그 플레이어는 오프라인 상태이거나 존재하지 않습니다."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4자신을 초대할 수 없습니다!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4그 플레이어가 당신 섬의 리더입니다!"
-
-msgid "remove a member from your island."
-msgstr "당신의 섬에서 멤버를 제거합니다."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4당신은 이 섬으로부터 다른 사람을 강퇴할 권한이 없습니다!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4당신은 이 섬으로부터 리더를 제거할 수 없습니다!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4스스로를 강퇴하는것 좀 그만하세요!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0}가 당신을 그들의 섬으로부터 제거하였습니다!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0}가 섬에서 제거되었습니다."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0} 가 그들의 섬에서 당신을 추방하려 시도했습니다."
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4{0} 는 추방에서 면제되었습니다."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4{0} 가 당신을 그들의 섬에서 추방 했습니다.!"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0}가 섬으로부터 강퇴되었습니다."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr "§4그 플레이어는 당신 그룹과 섬의 일원이 아닙니다!"
-
-msgid "leave your party"
-msgstr "당신의 파티를 떠납니다"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4만약 당신이 혼자라면 당신의 섬을 떠날 수 없습니다!. 만약 당신이 새 섬을 원"
-"하면 /island restart를 사용하여 당신만의 섬을 가지세요!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr ""
-"§e당신은 이 섬을 소유합니다, 대신 /island remove <플레이어>를 사용하세요."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§e당신은 섬을 떠나 플레이어 스폰으로 돌아왔습니다."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0}이 당신의 섬을 떠났습니다!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4당신은 파티를 떠나려면 skyblock 월드에 있어야 합니다!"
-
-msgid "check your or anothers island level"
-msgstr "당신 또는 다른 사람의 섬 레벨을 확인합니다"
-
-msgid "allows user to query for others levels"
-msgstr "해당 유저가 다른섬에 쿼리를 날리는 것을 허용합니다."
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§e{0}의 섬에 대한 정보:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9랭크는 {0}입니다"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "파티 멤버가 아닌 사람에게 당신의 섬을 잠그세요."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4자신의 섬을 잠글 권한이 없습니다!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4당신은 이 커멘드에 접근할 권한이 없습니다!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4자신의 섬을 해금할 권한이 없습니다!"
-
-msgid "display log"
-msgstr "기록를 보여줍니다"
-
-msgid "transfer leadership to another member"
-msgstr "다른 멤버에게 리더 권한을 넘겨줍니다"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4당신은 오직 파티 멤버에게만 소유권을 넘길 수 있습니다!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e는 이미 당신의 섬의 리더입니다!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4오직 리더만이 리더 권한을 넘길 수 있습니다!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0}가 섬을 인수하려 합니다!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "파티의 정보를 보여줍니다"
-
-msgid "shows information about your party"
-msgstr "당신의 파티에 대한 정보를 보여줍니다"
-
-msgid "show pending invites"
-msgstr "보류된 초대 요청을 보여줍니다"
-
-msgid "§eNo pending invites"
-msgstr "§e보류된 초대 없음"
-
-msgid "withdraw an invite"
-msgstr "초대 취소"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4당신은 플레이어를 초대하지 않을 수 없습니다."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4이 커맨드는 오직 플레이어에 의해서만 실행됩니다"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4섬 없음. §e다음명령어 §b/is create§e 를 사용해 생성하세요"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "섬을 삭제하고 새로 시작합니다."
-
-msgid "exempt player from restart-cooldown"
-msgstr "재시작 쿨다운에서 해당 플레이어를 제외합니다."
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4오직 소유자만 이 섬을 재시작할 수 있습니다. 이 섬을 떠나고 새로 시작하려면 "
-"이 섬을 떠나세요(/island leave)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§e새로 시작하려면 다음명령어를 사용하여 모든 플레이어들을 당신의 섬에서 제거"
-"해야 합니다 (/island kick <플레이어>). 다음 명령어를 사용해 당신의 섬의 플레"
-"이어의 리스트를 보세요 /island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§c당신은 {0}초 후에 재시작 할 수 있습니다."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§c당신의 섬이 생성되는 중입니다, 지금은 재시작할 수 없습니다."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eNOTE: 당신의 모든 섬과 소유물들이 리셋 될 것입니다!"
-
-msgid "set the island-home"
-msgstr "island-home을 지정하세요"
-
-msgid "set your island''s warp location"
-msgstr "당신의 섬의 워프 지점을 지정하세요"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§c당신은 섬에 워프 포인트를 지정할 권한이 없습니다!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§c워프를 지정하려면 자신의 섬에 있어야 합니다!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d가 워프 지점을 바꾸었습니다."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "skyblock spawn으로 텔레포트 합니다"
-
-msgid "enable/disable warping to your island."
-msgstr "당신의 섬으로 워프 가능/불가능 ."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr "§4당신의 섬은 잠겼습니다. 워프하려면 Unlock해야합니다."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d 활성화된 섬 워프."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d 비활성화된 섬 워프."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr "§c당신 섬에 워프를 온/오프 할 권한이 없습니다!"
-
-msgid "display the top10 of islands"
-msgstr "섬들의 top 10을 보여줍니다"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr "유저가 TOP 10을 생성하는것을 허용합니다."
-
-msgid "trust/untrust a player to help on your island."
-msgstr "당신의 섬에서 도우려는 플레이어를 믿으시겠습니까/믿지 않겠습니까."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§e다음의 플레이어들은 당신의 섬에서 신뢰받았습니다:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§e다음의 리더들은 당신을 신뢰합니다:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr ""
-"§e당신의 섬으로부터 믿거나/말거나 하려면, /island trust <플레이어>를 쓰세요"
-
-msgid "§4Members are already trusted!"
-msgstr "§4멤버들은 이미 신뢰받습니다!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4모르는 플레이어 {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§e§4{0}의§e섬에서 이제 신뢰받습니다."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0}가 {1}를 그 섬에서 믿습니다"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§e당신은 더이상 §4{0}의 섬에서 신뢰받지 못합니다."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0}가 {1}을 신뢰했던 것을 취소합니다"
-
-msgid "warp to another player''s island"
-msgstr "다른 플레이어의 섬으로 워프합니다"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr ""
-"§a당신의 들어오는 워프가 활성화되어있습니다, 플레이어들은 당신의 섬으로 워프"
-"할 수 있습니다."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§4당신의 들어오는 워프가 활성화되어있지 않아 플레이어들이 당신의 섬으로 워프"
-"할 수 없습니다."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr ""
-"§e/island setwarp§f을 이용해서 당신의 현재 위치에 들어오는 워프를 지정하세요"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§f다음 명령어를 사용해 워프 기능을 온오프 하세요 §e/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4당신의 섬에 워프를 만들 권한이 없습니다!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§e/island warp§f <플레이어>를 써서 다른 섬으로 워프하세요"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4다른 섬으로 워프할 권한이 없습니다!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§c당신의 섬이 생성중에 있습니다, 당신은 현재 다른 플레이어의 섬으로 워프할 "
-"수 없습니다. "
-
-msgid "§4That player does not exist!"
-msgstr "§4그 플레이어는 존재하지 않습니다!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4그 플레이어는 활성화된 워프가 없습니다."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§c그 플레이어들의 섬은 생성중에 있습니다, 따라서 당신은 그곳으로 지금 워프할 "
-"수 없습니다."
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§c경고: §9{0}§e이 당신의 섬으로 워프하는 중입니다!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4그 플레이어가 당신이 그들의 섬으로 워프하는 것을 금지했습니다."
-
-msgid "general island command"
-msgstr "일반적인 섬 커맨드"
-
-msgid "allows user to bypass cooldowns"
-msgstr "해당유저가 쿨다운을 Bypass하는 것을 허용합니다."
-
-msgid "allows user to bypass visitor-protections"
-msgstr "해당유저가 visitor-protections을 Bypass하는 것을 허용합니다."
-
-msgid "allows user to bypass teleport-delay"
-msgstr "해당유저가 teleport-delay를 Bypass하는 것을 허용합니다."
-
-msgid "allows user to use [usb] signs"
-msgstr "해당유저가 [usb] signs를 사용하는 것을 허용합니다."
-
-msgid "allows user to place [usb] signs"
-msgstr "해당유저가 [usb] signs를 설치하는 것을 허용합니다."
+msgid "{0}''s Wither"
+msgstr "{0}''의 마녀"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr ""
@@ -1733,33 +96,6 @@ msgstr "§e탑승은 오직 당신의 섬에서만 가능합니다!"
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr "§e당신은 방문자의 탑승물을 때릴 수 없습니다."
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr "§c!마녀 소환이 취소되었습니다!§e 당신의 섬에서 너무 멀리 있습니다."
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "{0}''의 마녀"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§e방문자들은 아이템을 떨굴 수 없습니다!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "소유자: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "당신이 방문자일 때 다른 플레이어의 전리품을 획득할 수 없습니다!"
-
-msgid "Config:"
-msgstr "설정:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§c엑세스 안됨! §e 당신은 §cNETHER§e의 지붕으로 텔레포트하려 했지만, 그것은 불"
-"가능합니다."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr "§4당신은 오직 10초마다 옵시디언을 변환 할 수 있습니다."
@@ -1803,19 +139,84 @@ msgstr "§e당신은 당신 소유의 섬에서 오직 spawn-eggs만 사용할 �
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§c당신은 당신 섬에서의 spawn제한에 다다랐습니다."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§e방문자들은 아이템을 떨굴 수 없습니다!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "소유자: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "당신이 방문자일 때 다른 플레이어의 전리품을 획득할 수 없습니다!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cBanned:§e 당신은 이 섬으로부터 차단 되었습니다."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cLocked:§e 그 지역은 잠겼어! 어누 누구도 못들어가."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§e우리의 턴을 기다리는 중입니다 §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "섬 그리고/혹은 파티 데이터를 저장하는중에 오류가 발생하였습니다!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr "데이터를 UUID로 변환합니다, 이 과정은 시간이 걸릴 수 있습니다!"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§c관리모드:§e uSkyBlock이 현재 관리모드 입니다."
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9섬을 만드는 중입니다...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§e당신은 해당 island-schematic에 접근할 권한이 없습니다!"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4플레이어는 이미 이 섬에 배정되었습니다!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4당신의 skyblock 집에 지정하려면 당신의 섬에 더 가까워야 합니다!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§a당신의 skyblock집이 당신의 현재 지점에 지정되었습니다."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4당신의 현재 지점은 안전한 집 위치가 아닙니다"
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+"§7작은요정들이 당신 섬의 생태계를 §9{0}§7로 바꾸고 있어 바쁩니다, 조금만 기다"
+"려주세요."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr "§c당신의 섬은 생성과정 중에 있습니다, 당신은 지금 만들 수 없습니다."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "당신의 섬을 생성할 수 없었습니다. 서버 관리자에게 문의하세요."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+"§e당신의 섬을 준비하는 중입니다, 조금만 참아주세요, 조금 시간이 걸립니다."
+
+msgid "§cCommand is currently disabled!"
+msgstr "§c이 명령어는 현재 꺼져있습니다!"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§e여전히 다음의 블록들이 부족합니다: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1828,9 +229,6 @@ msgid ""
 msgstr ""
 "§e명령어 §9{0}§e 사용은 §c허벌나게 위험합니다§e. 승낙하려면 §a{1}§e초 내로 커"
 "맨드를 반복하세요"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** 당신은 보호받지만 버려진 섬으로 텔레포트 하는 중입니다."
@@ -1865,213 +263,32 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4파티의 리더여야 당신의 섬을 해제 할 수 있습니다!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§7PlayerDB: uuid2name.yml 에서 {0} 플레이어를 필터링"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§e우리의 턴을 기다리는 중입니다 §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9섬을 만드는 중입니다...§e{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§l잠긴 도전과제"
+
+msgid "READY"
+msgstr "준비완료"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§7PlayerDB: {0} 이름 필터링"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, 실패:{3} ~ {5,number,##}%), {6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§7MojangAPI: {0} 플레이어를 모장에서 검색중입니다"
-
-msgid "SUCCESS"
-msgstr "성공"
-
-msgid "FAILED"
-msgstr "실패"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§7 - MojangAPI:§a완료: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§7 - MojangAPI:§c에러: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-"§e진행중: {0,number,##}% ({1}/{2} - 성공:{3}, 실패:{4}, 스키:{5}) ~ {6}"
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4§e{0}§4란 이름의 수입업자를 찾지 못했습니다 "
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§e다음 {0}/{1} 파일 {2}로 변환"
-
-msgid "The island has been created."
-msgstr "이 섬이 생성되었습니다."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d 섬을 잠궜습니다."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§4당신의 섬이 잠기는 시점에서 당신의 들어오는 워프는 비활성화 됩니다."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d 섬을 잠금해제 했습니다."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§c하늘 §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d이 섬의 그룹에서 제거되었습니다."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9당신의 위치에 섬을 생성 합니다"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "당신의 §7{0}§9 §9섬 만들기"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§4도전과제 {0}는 아직 사용이 불가능합니다!"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
-msgstr ""
-"§c지하의 조각을 가진 섬이 삭제되는 중입니다! 당신을 spawn으로 보내는 중입니"
-"다."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
+msgstr "§c경고:§e 인벤토리에 있는 중요 물품을 이동하지 마세요!"
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr ""
-"§c당신이 밟고 있는 섬이 삭제되고 있습니다! 당신을 스폰으로 보내는 중입니다."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§e명예의 벽 (page {0} of {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr ""
-"§4Top 10 리스트가 비었습니다! 오직 {0} 레벨 이하의 섬들만 고려되었습니다"
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§e당신의 랭크는: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "UNKNOWN"
-
-msgid "ANIMAL"
-msgstr "동물"
-
-msgid "MONSTER"
-msgstr "몬스터"
-
-msgid "VILLAGER"
-msgstr "섬원"
-
-msgid "GOLEM"
-msgstr "골렘"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (max. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "schematic {0}를 적용 할 수 없습니다, 서버 어드민에게 연락하세요"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§a축하드립니다! §e당신의 섬이 등장하였습니다."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cNote:§e 건설이 아마 아직 진행중입니다'."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Use §9/is h§r or the §9/is§r menu to go there."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§c감시견!§9 {0}개 내로 상자를 놓을 수 없음, 돈 내고 풀려나는 중."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7페이지 {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr "§c{0,number,#}"
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr "§a+{0,number,#}"
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr "§a{0,number,#}"
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr "&aㅈ클릭:&7 Increment with {0}"
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr "&c우클릭:&7 Set to {0}"
-
-msgid "Return"
-msgstr "Return"
-
-msgid "§9Integer Editor"
-msgstr "§9Integer 에디터"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§e조작 설정이 저장 및 리로드 되었습니다."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§c오류! §9컨피그 파일 저장 불가!"
-
-msgid "§3First Page"
-msgstr "§3첫번째 페이지"
-
-msgid "§3Last Page"
-msgstr "§3마지막 페이지"
-
-msgid "§cSave & Reload config"
-msgstr "§c저장 & 리로드 조작"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7다음 명령어 \n"
-"로 설정을 저장합니다§7다시 파일 & 리로드.\n"
-"§c노트: §7조심히 쓰세요!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (readonly)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr "§c이 도전과제를 달성하기 위한 아이템이 상자에 충분하지 않습니다!"
 
 msgid "true"
 msgstr "참"
@@ -2501,6 +718,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "현재 페이지"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7페이지 {0}"
+
 msgid "§7First Page"
 msgstr "첫번째 페이지"
 
@@ -2799,8 +1020,8 @@ msgstr "§c클릭하여 떠나기"
 msgid "Island Restart Menu"
 msgstr "섬 재생성 매뉴"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§e당신은 해당 island-schematic에 접근할 권한이 없습니다!"
+msgid "Config:"
+msgstr "설정:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2816,113 +1037,120 @@ msgstr "재시작 하기위하여 §9{0}§c안에 §c클릭 해 주세요!"
 msgid "§aClick to restart!"
 msgstr "§a눌러서 재시작!"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr "§c{0,number,#}"
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr "§a+{0,number,#}"
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr "§a{0,number,#}"
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr "&aㅈ클릭:&7 Increment with {0}"
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr "&c우클릭:&7 Set to {0}"
+
+msgid "Return"
+msgstr "Return"
+
+msgid "§9Integer Editor"
+msgstr "§9Integer 에디터"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9텍스트 에디터"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§e조작 설정이 저장 및 리로드 되었습니다."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§c오류! §9컨피그 파일 저장 불가!"
+
+msgid "§3First Page"
+msgstr "§3첫번째 페이지"
+
+msgid "§3Last Page"
+msgstr "§3마지막 페이지"
+
+msgid "§cSave & Reload config"
+msgstr "§c저장 & 리로드 조작"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7다음 명령어 \n"
+"로 설정을 저장합니다§7다시 파일 & 리로드.\n"
+"§c노트: §7조심히 쓰세요!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (readonly)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+"§e진행중: {0,number,##}% ({1}/{2} - 성공:{3}, 실패:{4}, 스키:{5}) ~ {6}"
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4§e{0}§4란 이름의 수입업자를 찾지 못했습니다 "
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§e다음 {0}/{1} 파일 {2}로 변환"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§7PlayerDB: uuid2name.yml 에서 {0} 플레이어를 필터링"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§7PlayerDB: {0} 이름 필터링"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, 실패:{3} ~ {5,number,##}%), {6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§7MojangAPI: {0} 플레이어를 모장에서 검색중입니다"
+
+msgid "SUCCESS"
+msgstr "성공"
+
+msgid "FAILED"
+msgstr "실패"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§7 - MojangAPI:§a완료: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§7 - MojangAPI:§c에러: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "너무 많은 Mojangs API 호출 입니다 ({0} within {1}), sleeping {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§e스폰으로 이동 중 입니다."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§e해당섬 은 §c잠금§e 되어있습니다."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§a{0}초 후에 당신은 이동될 것 입니다.."
-
-msgid "§7Teleport cancelled"
-msgstr "이동이 취소되었습니다."
-
-msgid "READY"
-msgstr "준비완료"
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr "§c경고:§e 인벤토리에 있는 중요 물품을 이동하지 마세요!"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr "§c이 도전과제를 달성하기 위한 아이템이 상자에 충분하지 않습니다!"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "섬 그리고/혹은 파티 데이터를 저장하는중에 오류가 발생하였습니다!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr "데이터를 UUID로 변환합니다, 이 과정은 시간이 걸릴 수 있습니다!"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§c관리모드:§e uSkyBlock이 현재 관리모드 입니다."
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4플레이어는 이미 이 섬에 배정되었습니다!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4당신의 섬에서 안전한 Home 장소를 찾지 못했습니다!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§c경고: §e하늘 한가운데로 이동중입니다."
-
-msgid "§aTeleporting you to your island."
-msgstr "§a당신을 당신의 섬으로 텔레포트 하는 중입니다."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4해당플레이어의 섬으로 워프 할 수 없습니다!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§a당신은 {0}초 후에 텔레포트 됩니다"
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4당신의 skyblock 집에 지정하려면 당신의 섬에 더 가까워야 합니다!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§a당신의 skyblock집이 당신의 현재 지점에 지정되었습니다."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4당신의 현재 지점은 안전한 집 위치가 아닙니다"
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§c당신의 섬은 생성과정 중에 있습니다, 당신은 지금 만들 수 없습니다."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "당신의 섬을 생성할 수 없었습니다. 서버 관리자에게 문의하세요."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-"§e당신의 섬을 준비하는 중입니다, 조금만 참아주세요, 조금 시간이 걸립니다."
-
-msgid "§cCommand is currently disabled!"
-msgstr "§c이 명령어는 현재 꺼져있습니다!"
 
 msgid "North"
 msgstr "북쪽"
@@ -2947,3 +1175,1771 @@ msgstr "서쪽"
 
 msgid "North-West"
 msgstr "북서쪽"
+
+msgid "The island has been created."
+msgstr "이 섬이 생성되었습니다."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d 섬을 잠궜습니다."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§4당신의 섬이 잠기는 시점에서 당신의 들어오는 워프는 비활성화 됩니다."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d 비활성화된 섬 워프."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d 섬을 잠금해제 했습니다."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§c하늘 §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d이 섬의 그룹에서 제거되었습니다."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9당신의 위치에 섬을 생성 합니다"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "당신의 §7{0}§9 §9섬 만들기"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§a축하드립니다! §e당신의 섬이 등장하였습니다."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cNote:§e 건설이 아마 아직 진행중입니다'."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Use §9/is h§r or the §9/is§r menu to go there."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "schematic {0}를 적용 할 수 없습니다, 서버 어드민에게 연락하세요"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§c감시견!§9 {0}개 내로 상자를 놓을 수 없음, 돈 내고 풀려나는 중."
+
+msgid "UNKNOWN"
+msgstr "UNKNOWN"
+
+msgid "ANIMAL"
+msgstr "동물"
+
+msgid "MONSTER"
+msgstr "몬스터"
+
+msgid "VILLAGER"
+msgstr "섬원"
+
+msgid "GOLEM"
+msgstr "골렘"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (max. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§c지하의 조각을 가진 섬이 삭제되는 중입니다! 당신을 spawn으로 보내는 중입니"
+"다."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr ""
+"§c당신이 밟고 있는 섬이 삭제되고 있습니다! 당신을 스폰으로 보내는 중입니다."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§e명예의 벽 (page {0} of {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr ""
+"§4Top 10 리스트가 비었습니다! 오직 {0} 레벨 이하의 섬들만 고려되었습니다"
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4섬 레벨이 작동하지 않습니다, 관리자에게 문의하세요."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§e당신의 랭크는: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "{0}개의  {1}§7 challenges"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7를 완료하여 {0} 랭크를"
+
+msgid "to unlock this rank"
+msgstr "잠금해제 하세요"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4필요 조건이 {0} 일 후에 리셋됩니다."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4필요 조건이 {0} 시간 후에 리셋됩니다."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4필요 조건이 {0} 분 후에 리셋됩니다."
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr "§e도전과제의 필요항목:"
+
+msgid "§7and more..."
+msgstr "§7그리고 더..."
+
+msgid "§eItems will be traded for reward."
+msgstr "§e보상을 위하여 아이템이 거래될 예정입니다."
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr "§e최소 {0} 미터가 되어야 합니다."
+
+msgid "§6Item Reward: §a"
+msgstr "§6아이템 보상: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6돈 보상: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6경험치 보상: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§d완료된 전체 횟수: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr "§7필요 {0}"
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4{0}란 이름의 도전과제를 찾지 못했습니다"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4그 일을 하려면 당신의 섬에 있어야 합니다!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4{0} 반복할 수 없는 도전과제입니다!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§e도전과제를 완료하려면, §a{0}를 사용하세요"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr "§4당신은 모든 요구된 아이템의 {0} 블록 안에 서있어야 합니다."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4도전과제를 완료하려면 당신의 섬의 레벨이 {0} 여야 합니다!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4알려지지않은 타입의 도전과제입니다: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§e여전히 다음의 엔티티가 부족합니다:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§e당신은 다음의 아이템이 부족합니다: {0}개의"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§a당신은 {0} 도전과제를 완료했습니다!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9{0}§f가 §9{1}§f 도전과제를 완료했습니다!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§e아아템 보상: §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§e경험치 보상: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§e돈 보상: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§e당신의 인벤토리가 §4가득 찼습니다§e. 아이템이 섬에 떨어졌습니다."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§l도전과제를 완료하려면 클릭하세요."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§l이 도전과제는 반복할 수 없습니다."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "랭크: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§f대부분의 도전과제를 완료하였습니다"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§f이 랭크는 다음 랭크를 해제하기 위한 랭크 입니다."
+
+msgid "§eClick here to show previous page"
+msgstr "§e전 페이지를 보려면 여기를 클릭하세요"
+
+msgid "§eClick here to show next page"
+msgstr "§e다음 페이지를 보려면 여기를 클릭하세요"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "하지만 당신은 와아아아아안전 호오오온자!"
+
+msgid "But you are Yelling in the wind!"
+msgstr "하지만 당신은 바람 속에서 외칩니다!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "하지만 당신의 상상속 친구들은 가버렸죠!"
+
+msgid "But you are Talking to your self!"
+msgstr "하지만 당신은 자신한테 말을 걸고 있어요!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§c죄송합니다! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr "타 그룹에 메세지를 보내기, 혹은 on/off 로 조절"
+
+msgid "party"
+msgstr "파티"
+
+msgid "island"
+msgstr "섬"
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§c다음 키 {0} §a를 눌러 채팅 켜기"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§c다음키 §9{0}§c 를 반복하여 기능 끄기"
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§c다음 키 {0} §a를 눌러 채팅 끄기"
+
+msgid "§cCommand only available to players"
+msgstr "§c플레이어에게만 유효한 명령어 입니다."
+
+msgid "talk to your island party"
+msgstr "당신의 섬의 파티에게 말을 겁니다"
+
+msgid "talk to players on your island"
+msgstr "당신의 섬에 있는 플레이어에게 말을 겁니다"
+
+msgid "manually update the top 10 list"
+msgstr "Top 10 리스트 수동 업데이트"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eTop 10 리스트 생성중"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eTop 10 리스트 생성 완료"
+
+msgid "purges all abandoned islands"
+msgstr "모든 버려진 섬들을 청소합니다"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4당신은 청소하기위해 나이를 제공해야 합니다!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr "§4청소작업을 취소중입니다."
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr "§4청소작업을 시작합니다..."
+
+msgid "Controls player-cooldowns"
+msgstr "플레이어 대기시간을 컨트롤 합니다"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "커맨드로 쿨타임을 초기화 합니다 (* = all)"
+
+msgid "§eThe player is not currently online"
+msgstr "§e플레이어가 현재 온라인상태가 아닙니다"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Cleared cooldown on {0} for {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Nay active cooldown on {0} for {1} detected!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "유효하지 않은 커맨드가 입력되었습니다, 오직 재시작과 생태계만 !"
+
+msgid "restarts the cooldown on the command"
+msgstr "커맨드의 대기시간을 다시 시작합니다"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eReset cooldown on {0} for {1}§e to {2} seconds"
+
+msgid "lists all the active cooldowns"
+msgstr "활성화된 모든 대기시간을 목록으로 보여줍니다"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCmd 대기시간"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§e§9{0}§e의 활성화된 대기시간을 찾을 수 없습니다."
+
+msgid "toggles maintenance mode"
+msgstr "관리모드로 전환"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr "§c관리모드: §a활성화§e 모든 uSkyBlock 기능이 현재 비활성화 되었습니다."
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr "§c관리모드: §a비활성화§e 모든 uSkyBlock 기능이 현재 활성화 되었습니다."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr "§c관리모드 변경은 오직 콘솔창에서만 가능합니다!"
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9직업 통계s"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/직업"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "행동"
+
+msgid "time"
+msgstr "시간"
+
+msgid "name"
+msgstr "이름"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§e플레이어 {0}는 섬이 없습니다!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§e유효하지 않은 플레이어 {0}가 공급하였습니다."
+
+msgid "flushes all caches to files"
+msgstr "모든 캐시 파일을 제거 합니다"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+"§eFlushed §a{0} islands§e, §b{1} pirates an'' §6{2} challenge-completions."
+
+msgid "tries to fix the the area of flatland."
+msgstr "평지 지역을 고치는 것을 시도합니다."
+
+msgid "§4No valid island found"
+msgstr "§4유효한 섬이 발견되지 않음"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4{0}의 섬에 평지가 탐지되지 않음!"
+
+msgid "manage orphans"
+msgstr "고아들을 관리합니다"
+
+msgid "count orphans"
+msgstr "고아의 수를 셉니다"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§e{0} 오래된 섬 위치는 새것으로 교체되기 전까지 사용됩니다."
+
+msgid "clear orphans"
+msgstr "고아들을 없앱니다"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§e모든 예전의 (빈) 섬의 위치를 없애는중."
+
+msgid "list orphans"
+msgstr "고아들의 목록을 만듭니다"
+
+msgid "§eNo orphans currently registered."
+msgstr "§e현재 어느 고아도 등록하지 않았습니다."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "다른 플레이어에게 리더 권한을 전달합니다"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4플레이어{0}는 전달할 섬이 없습니다!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§e플레이어 §d{0}§e는 이미 섬이 있습니다 .§e §d/ 섬 제거를 사용하세요 "
+"<name>§e 그를 먼저 제거하려면."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§b리더 권한이 {0}§b에서 {1}로 전달되었습니다"
+
+msgid "open GUI for config"
+msgstr "키 변경을 위해 GUI를 여세요"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§e설정파일 이름이 올바르지 않습니다"
+
+msgid "teleport to another players island"
+msgstr "다른 플레이어 섬으로 텔레포트합니다."
+
+msgid "§4Only supported for players"
+msgstr "§4오직 플레이어들에게만 지원됩니다."
+
+msgid "§4That player does not have an island!"
+msgstr "§4그 플레이어는 가진 섬이 없습니다!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr "§a{0}''의 섬으로 텔레포트중 입니다."
+
+msgid "various WorldGuard utilities"
+msgstr "여러가지 WorldGuard 기능"
+
+msgid "refreshes the chunks around the player"
+msgstr "플레이어 주변의 창크를 청소합니다"
+
+msgid "§eResending chunks to the client"
+msgstr "§e의뢰인에게 덩어리들을 다시보내는 중입니다"
+
+msgid "load the region chunks"
+msgstr "지역의 Chunks를 로드합니다"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§e{0}에 Chunks을 로딩하는 중입니다"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§e{0}에 Chunks들을 언로딩하는 중입니다"
+
+msgid "update the WG regions"
+msgstr "월드가드 지역을 업데이트합니다"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§e{0}를 위하여 섬의 월드가드 지역이 업데이트 되었습니다."
+
+msgid "§eNo island found at your location!"
+msgstr "§e당신의 위치에서 어떠한 섬도 발견하지 못했습니다!"
+
+msgid "refreshes the chunk around the player"
+msgstr "플레이어 주위의 청크를 갱신 합니다."
+
+msgid "region manipulations"
+msgstr "지역 조작"
+
+msgid "shows the borders of the current island"
+msgstr "현재 섬의 경계를 표시합니다."
+
+msgid "§eNo island found at your current location"
+msgstr "§e현재 위치에서 섬을 발견하지 못하였습니다."
+
+msgid "§eCan only be executed as a player"
+msgstr "§e오직 플레이어에게만 유효합니다."
+
+msgid "shows the borders of the current chunk"
+msgstr "현재 청크의 경계를 표시합니다"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "내부 청크의 경계를 표시합니다."
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "경계의 청크가 아닌 부분을 표시합니다."
+
+msgid "shows the borders of the outer-chunks"
+msgstr "외부 청크 경계를 표시합니다."
+
+msgid "hides the regions again"
+msgstr "현재 지역을 다시 숨깁니다."
+
+msgid "§eStopped displaying regions"
+msgstr "§e지역표시를 중지합니다."
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§e해당 플레이여의 지역이 없습니다."
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§eAnimation-tick 표시화면을 {0}로 변경합니다."
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§eAnimation-tick 의 값은 integer 형식 이여야 합니다."
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr "- PURGING: {0,number,##}% ({1}/{2}), 경과 {3}, 완료까지 남은시가 ~{4}"
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4PURGE:§9 버려진 섬의 청소를 마쳤습니다."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4PURGE:§9 버려진 섬 청소 취소"
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§7- 스캐닝: {0,number,##}% ({1}/{2} 실패: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4PURGE:§9 스캐닝 취소."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§c취소됨:§e 보호가 모두 취소되었습니다!"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr "§e{0}, {1}에 관한 보호를 모두 마쳤습니다 새로운 지역이 생성되었습니다!"
+
+msgid "control debugging"
+msgstr "컨트롤 디버깅'"
+
+msgid "set debug-level"
+msgstr "디버그 레벨을 지정합니다"
+
+msgid "toggle debug-logging"
+msgstr "디버그 로깅 버튼'"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr ""
+"§4로그 기능이 활성화 되지 않았습니다. 해당 기능을 비활성화 할 수 없습니다!"
+
+msgid "flush current content of the logger to file."
+msgstr "현재 월드 상태에 관한 로그파일을 파일에서 제거합니다."
+
+msgid "§eLog-file has been flushed."
+msgstr "§e기록 파일이 작성되었습니다 ."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr ""
+"§4로그 저장이 꺼져있습니다, §d/usb debug enable 다음명령어를 사용하세요"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§e로깅 비활성화!"
+
+msgid "advanced command for setting island-data"
+msgstr "섬 데이터 설정 고급 명령어"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§c{0} 를 ''{1}'로 지정'"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§c필드{0} 를 ''{1}''로 지정할 수 없습니다."
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr "§c필드{0} 를 ''{1}'로 지정할 수 없습니다. a number was expected"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§c올바르지 않은 필드 {0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§e현재 {0}의 값은 ''{1}''"
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "{0} §c의 정보를 가져올 수 없습니다"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§e올바른 값은 {0} 입니다."
+
+msgid "set a player''s island to your location"
+msgstr "당신의 위치에 플레이어의 섬을 지정합니다"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr "NBT stuff 고급 정보"
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "현재 들고있는 아이템에 대한 NBTTag 확인"
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§9{0} §e정보"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - 이름: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - nbttag: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§c손에 아이템이 없습니다!"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "현재 손에 든 아이템으로 NBTTag를 설정합니다."
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "§9{0}§e §e을 §c{1} §e으로 설정"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "현재 들고 있는 아이템에 NBTTag를 추가합니다."
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§9{0}§e에 §c{1}§e 을 추가."
+
+msgid "Manage challenges for a player"
+msgstr "도전과제를 관리하세요"
+
+msgid "resets the challenge for the player"
+msgstr "해당 플레이어의 도전과제를 리셋합니다"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4도전과제가 전혀 완료되지 않았습니다"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§e도전과제: {0} has been reset for {1}"
+
+msgid "resets all challenges for the player"
+msgstr "모든 도전과제를 리셋합니다"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0}는 모든 도전과제를 리셋했습니다."
+
+msgid "complete all challenges in the rank"
+msgstr "이 랭크의 모든 도전과제를 완료하였습니다"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4{0}란 이름의 플레이어를 찾지 못했습니다!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4도전과제 {0}는 이미 완료되었습니다"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§e도전과제: {0}이 {1}를 완료했습니다"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4{0}란 이름의 도전과제를 찾지 못했습니다!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4{0}란 이름의 랭크를 찾지 못했습니다!"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "모든 섬을 보호합니다 (시간을 소모함)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§c보호된 모든 처리작업을 취소중입니다."
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4죄송합니다!§e 보호작업이 이미 진행중 입니다. 완료하거나, §9usb protectall "
+"§cstop§e 명령어를 사용해 중지하세요"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§e모든 보호 작업이 시작되는 중입니다. 몇분의 시간의 소요됩니다."
+
+msgid "reload configuration from file."
+msgstr "파일로 부터 외형을 리로드합니다."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§e파일로부터 리로드된 외형."
+
+msgid "manage islands"
+msgstr "섬 관리"
+
+msgid "protects the island"
+msgstr "섬 보호"
+
+msgid "delete the island (removes the blocks)"
+msgstr "섬을 삭제함 (블럭을 제거함)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9현재 위치의 버려진 섬을 삭제했습니다."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4이 지역의 섬엔 멤버들이 있습니다!\n"
+"§e섬을 제거하려면 §9 /usb island delete <name>§e를 쓰세요."
+
+msgid "removes the player from the island"
+msgstr "이 섬에서 플레이어를 제거합니다"
+
+msgid "adds the player to the island"
+msgstr "이 섬에 플레이어를 추가합니다"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d가 당신의 섬 그룹에 참여했습니다."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4{0}란 이름의 플레이어를 찾지 못했습니다!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+"§4Nay valid hideout provided, either stand within one, or provide a hideout "
+"name"
+
+msgid "print out info about the island"
+msgstr "섬에 대한 정보를 보여줍니다"
+
+msgid "sets the biome of the island"
+msgstr "섬의 생태계를 지정합니다"
+
+msgid "§4That player has no island."
+msgstr "§4그 플레이어는 섬이 없습니다."
+
+msgid "§4No valid island at your location"
+msgstr "§4당신의 위치에 유효한 섬이 없습니다"
+
+msgid "purges the island"
+msgstr "섬을 청소합니다"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4오류! §9청소를 위한 섬을 찾지 못했습니다'."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§c정화: §9{0}에 정화된 섬"
+
+msgid "toggles the islands ignore status"
+msgstr "섬 상태 무시 버튼"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§c{0}의 섬이 탑 텐과 청소에서 무시되도록 지정합니다"
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§c{0}의 섬의 ignore-flag가 제거되었습니다, 이제 탑 텐에 보여지고 청소합니다"
+
+msgid "§4No valid player-name supplied."
+msgstr "§4유효한 플레이어 이름이 제공되지 않았습니다."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "{0}을 섬에서 제거하는 중"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§e{0}의 섬의 생태계가 {1}로 바뀌었습니다."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§e{0}의 섬의 생태계가 바다로 바뀌었습니다."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr "§a변화를 확인하려면 스폰, 혹은 재로깅이 필요합니다."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0}은 {1}로 변한 생태계를 가졌습니다."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0}은 바다로 변한 생태계를 가졌습니다."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§e{0}의 섬을 제거하는 중."
+
+msgid "Error: That player does not have an island!"
+msgstr "오류: 그 플레이어는 섬이 없습니다!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§e{1}에 있는 {0}의 섬은 보호받고 있습니다"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4{1}에 있는 {0}의 섬은 이미 보호받고 있습니다"
+
+msgid "displays version information"
+msgstr "버전 정보를 보여줍니다"
+
+msgid "imports players and islands from other formats"
+msgstr "다른 형식으로 부터 플레이어와 섬을 수입합니다"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr "추가 perks {0}"
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "플러그인의 언어를 바꾸고 리로드합니다"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§a성공적으로 언어를 §e{0}로 바꾸었습니다"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cF언어를 §e{0}로 바꾸는데 실패하였습니다"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9지원되는 언어:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§c어떤 언어든 설정할 수 없습니다."
+
+msgid "advanced command for getting island-data"
+msgstr "섬 정보를 확인하기 위한 고급 명렁ㅇ"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "플레이어 정보를 보여줍니다"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4당신의 섬은 꽉 찼습니다, 아니면 당신은 보류된 초대가 너무 많습니다. 당신은 "
+"아무도 초대할 수 없습니다"
+
+msgid "§4That player is already leader on another island."
+msgstr "§4그 플레이어는 이미 다른 섬의 리더입니다."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e가 당신을 초대하려 했지만 당신은 이미 파티에 들어가 있습니다."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr "§a{0} 에게 초대장 발송"
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e가 당신을 그들의 섬으로 초대하였습니다!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§f/island [accept/reject]§e 초대를 승낙/거절 하세요."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4경고: 승낙하면 당신은 현재 섬을 잃게 됩니다 !"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d가 {1}를 초대했습니다"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e가 초대를 거절하였습니다."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4당신은 해당 커맨드를 지금 쓸 수 없습니다. 당신의 파티를 먼저 떠나주세요."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§a당신은 섬에 참가하였습니다! 다른 멤버들을 보기 원하면 /island party 를 사용"
+"하세요."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§e{0}§e에게 한 초대가 시간초과 되었거나 취소되었습니다."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§e{0}의 섬으로의 초대가 시간초과 되었거나 취소되었습니다 ."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§e당신은 섬에 참여하는 초대를 승낙했습니다."
+
+msgid "§4You haven't been invited."
+msgstr "§4초대받은 것이 없습니다."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§e당신은 섬에 참여하라는 초대를 거절하였습니다."
+
+msgid "general island command"
+msgstr "일반적인 섬 커맨드"
+
+msgid "allows user to bypass cooldowns"
+msgstr "해당유저가 쿨다운을 Bypass하는 것을 허용합니다."
+
+msgid "allows user to bypass visitor-protections"
+msgstr "해당유저가 visitor-protections을 Bypass하는 것을 허용합니다."
+
+msgid "allows user to bypass teleport-delay"
+msgstr "해당유저가 teleport-delay를 Bypass하는 것을 허용합니다."
+
+msgid "allows user to use [usb] signs"
+msgstr "해당유저가 [usb] signs를 사용하는 것을 허용합니다."
+
+msgid "allows user to place [usb] signs"
+msgstr "해당유저가 [usb] signs를 설치하는 것을 허용합니다."
+
+msgid "complete and list challenges"
+msgstr "도전과제 완료후 목록 확인"
+
+msgid "§cCommand only available for players."
+msgstr "§c해당 명령어는 플레이어에게만 유효합니다."
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§e도전과제가 실행되지 않았습니다. 관리자에게 문의하세요."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4당신은 오직 skyblock 월드의 도전과제만을 할 수 있습니다!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4당신이 섬을 가졌을 때에만 도전과제를 할 수 있습니다!"
+
+msgid "warp to another player''s island"
+msgstr "다른 플레이어의 섬으로 워프합니다"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr ""
+"§a당신의 들어오는 워프가 활성화되어있습니다, 플레이어들은 당신의 섬으로 워프"
+"할 수 있습니다."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§4당신의 들어오는 워프가 활성화되어있지 않아 플레이어들이 당신의 섬으로 워프"
+"할 수 없습니다."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr ""
+"§e/island setwarp§f을 이용해서 당신의 현재 위치에 들어오는 워프를 지정하세요"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§f다음 명령어를 사용해 워프 기능을 온오프 하세요 §e/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4당신의 섬에 워프를 만들 권한이 없습니다!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§e/island warp§f <플레이어>를 써서 다른 섬으로 워프하세요"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4다른 섬으로 워프할 권한이 없습니다!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§c당신의 섬이 생성중에 있습니다, 당신은 현재 다른 플레이어의 섬으로 워프할 "
+"수 없습니다. "
+
+msgid "§4That player does not exist!"
+msgstr "§4그 플레이어는 존재하지 않습니다!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4그 플레이어는 활성화된 워프가 없습니다."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§c그 플레이어들의 섬은 생성중에 있습니다, 따라서 당신은 그곳으로 지금 워프할 "
+"수 없습니다."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§c경고: §9{0}§e이 당신의 섬으로 워프하는 중입니다!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4그 플레이어가 당신이 그들의 섬으로 워프하는 것을 금지했습니다."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4섬 없음. §e다음명령어 §b/is create§e 를 사용해 생성하세요"
+
+msgid "accept/reject an invitation."
+msgstr "초대에 accept/reject 하세요."
+
+msgid "leave your party"
+msgstr "당신의 파티를 떠납니다"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4만약 당신이 혼자라면 당신의 섬을 떠날 수 없습니다!. 만약 당신이 새 섬을 원"
+"하면 /island restart를 사용하여 당신만의 섬을 가지세요!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr ""
+"§e당신은 이 섬을 소유합니다, 대신 /island remove <플레이어>를 사용하세요."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§e당신은 섬을 떠나 플레이어 스폰으로 돌아왔습니다."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0}이 당신의 섬을 떠났습니다!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4당신은 파티를 떠나려면 skyblock 월드에 있어야 합니다!"
+
+msgid "check your or anothers island level"
+msgstr "당신 또는 다른 사람의 섬 레벨을 확인합니다"
+
+msgid "allows user to query for others levels"
+msgstr "해당 유저가 다른섬에 쿼리를 날리는 것을 허용합니다."
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§e이 커맨드를 쓰려면 자신의 섬에 있어야 합니다."
+
+msgid "§4You do not have an island!"
+msgstr "§4가지고 있는 섬이 없습니다!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4그 커맨드의 권한이 없습니다!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4그 플레이어는 유효하지 않거나 가진 섬이 없습니다!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§e{0}의 섬에 대한 정보:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§a섬의 레벨은 {0,number,###.##}입니다"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9랭크는 {0}입니다"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "섬을 만듭니다"
+
+msgid "exempt player from create-cooldown"
+msgstr "생성 쿨다운에서 해당 플레이어를 면제합니다."
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4섬을 찾았습니다!§e 당신은 이미 섬이 있습니다. 만약 새로운 섬을 원하시면, "
+"type§b /is restart§e 로 새로운 섬을 얻으세요"
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4섬을 발견했습니다!§e 당신은 이미 섬의 멤버입니다. 당신만의 섬을 시작하려"
+"면, 먼저§b /is leave 를 사용하세요"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§e당신은 {0,number,#}추 후에 새 섬을 만들 수 있습니다."
+
+msgid "invite a player to your island"
+msgstr "플레이어를 당신의 섬으로 초대합니다"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§e만약 플레이어를 당신의 섬으로 초대하려면§f /island invite <playername>§e "
+"를 쓰세요 ."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4오직 이 섬의 주인만이 초대할 수 있습니다!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§a{0}명 더 초대할 수 있습니다 ."
+
+msgid "§4You can't invite any more players."
+msgstr "§4당신은 더이상 플레이어를 초대할 수 없습니다."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4당신은 이 섬에 다른 사람을 초대할 권한이 없습니다!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4그 플레이어는 오프라인 상태이거나 존재하지 않습니다."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4자신을 초대할 수 없습니다!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4그 플레이어가 당신 섬의 리더입니다!"
+
+msgid "lock your island to non-party members."
+msgstr "파티 멤버가 아닌 사람에게 당신의 섬을 잠그세요."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4자신의 섬을 잠글 권한이 없습니다!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4당신은 이 커멘드에 접근할 권한이 없습니다!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4자신의 섬을 해금할 권한이 없습니다!"
+
+msgid "display the top10 of islands"
+msgstr "섬들의 top 10을 보여줍니다"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr "유저가 TOP 10을 생성하는것을 허용합니다."
+
+msgid "remove a member from your island."
+msgstr "당신의 섬에서 멤버를 제거합니다."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4당신은 이 섬으로부터 다른 사람을 강퇴할 권한이 없습니다!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4당신은 이 섬으로부터 리더를 제거할 수 없습니다!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4스스로를 강퇴하는것 좀 그만하세요!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0}가 당신을 그들의 섬으로부터 제거하였습니다!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0}가 섬에서 제거되었습니다."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4{0} 가 그들의 섬에서 당신을 추방하려 시도했습니다."
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4{0} 는 추방에서 면제되었습니다."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4{0} 가 당신을 그들의 섬에서 추방 했습니다.!"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0}가 섬으로부터 강퇴되었습니다."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr "§4그 플레이어는 당신 그룹과 섬의 일원이 아닙니다!"
+
+msgid "teleport to the island home"
+msgstr "섬의 Home으로 텔레포트 합니다"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§cYer 섬이 생성되는 중입니다, 당신은 지금 바로 집으로 텔레포트 할 수 없습니"
+"다. "
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4이 커맨드는 오직 플레이어에 의해서만 실행됩니다"
+
+msgid "transfer leadership to another member"
+msgstr "다른 멤버에게 리더 권한을 넘겨줍니다"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4당신은 오직 파티 멤버에게만 소유권을 넘길 수 있습니다!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e는 이미 당신의 섬의 리더입니다!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4오직 리더만이 리더 권한을 넘길 수 있습니다!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0}가 섬을 인수하려 합니다!"
+
+msgid "show party information"
+msgstr "파티의 정보를 보여줍니다"
+
+msgid "shows information about your party"
+msgstr "당신의 파티에 대한 정보를 보여줍니다"
+
+msgid "show pending invites"
+msgstr "보류된 초대 요청을 보여줍니다"
+
+msgid "§eNo pending invites"
+msgstr "§e보류된 초대 없음"
+
+msgid "withdraw an invite"
+msgstr "초대 취소"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4당신은 플레이어를 초대하지 않을 수 없습니다."
+
+msgid "check your or another''s island info"
+msgstr "당신 또는 다른 사람의 섬 정보를 확인합니다"
+
+msgid "allows user to see others island info"
+msgstr "해당 유저가 다른 섬 정보를 보는것을 허용합니다."
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§e{0}의 섬의 블록들(page {1,number} of {2,number}):"
+
+msgid "Score Count Block"
+msgstr "점수 카운트 블록"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "당신의 섬에서 도우려는 플레이어를 믿으시겠습니까/믿지 않겠습니까."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§e다음의 플레이어들은 당신의 섬에서 신뢰받았습니다:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§e다음의 리더들은 당신을 신뢰합니다:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr ""
+"§e당신의 섬으로부터 믿거나/말거나 하려면, /island trust <플레이어>를 쓰세요"
+
+msgid "§4Members are already trusted!"
+msgstr "§4멤버들은 이미 신뢰받습니다!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4모르는 플레이어 {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§e§4{0}의§e섬에서 이제 신뢰받습니다."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0}가 {1}를 그 섬에서 믿습니다"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§e당신은 더이상 §4{0}의 섬에서 신뢰받지 못합니다."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0}가 {1}을 신뢰했던 것을 취소합니다"
+
+msgid "delete your island and start a new one."
+msgstr "섬을 삭제하고 새로 시작합니다."
+
+msgid "exempt player from restart-cooldown"
+msgstr "재시작 쿨다운에서 해당 플레이어를 제외합니다."
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4오직 소유자만 이 섬을 재시작할 수 있습니다. 이 섬을 떠나고 새로 시작하려면 "
+"이 섬을 떠나세요(/island leave)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§e새로 시작하려면 다음명령어를 사용하여 모든 플레이어들을 당신의 섬에서 제거"
+"해야 합니다 (/island kick <플레이어>). 다음 명령어를 사용해 당신의 섬의 플레"
+"이어의 리스트를 보세요 /island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§c당신은 {0}초 후에 재시작 할 수 있습니다."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr "§c당신의 섬이 생성되는 중입니다, 지금은 재시작할 수 없습니다."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§eNOTE: 당신의 모든 섬과 소유물들이 리셋 될 것입니다!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "skyblock spawn으로 텔레포트 합니다"
+
+msgid "change the biome of the island"
+msgstr "섬의 생태계를 바꿉니다"
+
+msgid "exempt player from biome-cooldown"
+msgstr "바이옴 쿨다운에서 해당 플레이어를 제외합니다."
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr "해당 플레이어의 섬 바이옴을 {0} 로 변경합니다."
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr "§c당신의 현재 섬의 생태계를 바꿀 권한이 없습니다."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4당신은 이섬의 생태계를 바꿀 권한이 없습니다!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§생태계를 바꾸려면 꼭 자신의 섬에 있어야 합니다!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr ""
+"§c당신은 생태계 이름을 잘못 적었습니다. 반드시 {0} 들중 하나여야 합니다."
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§e당신은 생태계를 {0,number,#}분 후에 다시 바꿀 수 있습니다."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§c당신은 생태계를 그 타입으로 바꿀 권한이 없습니다.."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+"§7pixies가 현재 §9{0}§7로 바이옴을 변경하느라 바쁩니다, 인내심을 가지세요."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr "§e올바르지 않은 {0} 바이옴 공급!"
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§a당신은 섬의 생태계를 {0}로 바꿨습니다"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0}가 섬의 생태계를 {1}로 바꾸었습니다"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr "§a{1} 바이옴으로 변경하기 위하여 {0} 블럭을 변경해야 합니다"
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr "{1} 바이옴 안에 {0} 장소가 생성되었습니다."
+
+msgid "set your island''s warp location"
+msgstr "당신의 섬의 워프 지점을 지정하세요"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§c당신은 섬에 워프 포인트를 지정할 권한이 없습니다!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§c워프를 지정하려면 자신의 섬에 있어야 합니다!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d가 워프 지점을 바꾸었습니다."
+
+msgid "teleports you to your island (or create one)"
+msgstr "당신의 섬으로 이동합니다 (혹은 생성)"
+
+msgid "ban/unban a player from your island."
+msgstr "당신의 섬에서 플레이어를 차단/차단 취소 하세요."
+
+msgid "exempts user from being banned"
+msgstr "해당 유저는 벤에서 면제되었습니다."
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§e다음의 플레이어는 당신의 섬에서 워프하는 것이 금지되었습니다:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr "§e당신의 섬에서 차단/차단 취소 하려면, island ban을 쓰세요 <플레이어>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4당신은 멤버들을 차단할 수 없습니다. 먼저 그들을 제거하세요!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4당신은 플레이어를 차단/퇴장 시킬 권한이 없습니다."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§e플레이어 {0}는 벤할 수 없습니다."
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4{0} 가 당신을 그들의 섬에서 벤하려 시도했습니다!"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4{0} 는 벤에서 면제되었습니다."
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§e 당신은 §4{0}§e가 당신의 섬으로 워프하는 것을 금지했습니다.."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§e 당신은 {0}§e''의 섬에서 §c차단§e 되었습니다 ."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§e당신은 §a{0}§e가 당신의 섬에서 워프하는 것의 금지를 풀었습니다."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§e당신은{0}§e''의 섬에서 §a차단 해제§e 되었습니다 ."
+
+msgid "display log"
+msgstr "기록를 보여줍니다"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "island-home을 지정하세요"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "당신의 섬으로 워프 가능/불가능 ."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr "§4당신의 섬은 잠겼습니다. 워프하려면 Unlock해야합니다."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d 활성화된 섬 워프."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr "§c당신 섬에 워프를 온/오프 할 권한이 없습니다!"
+
+msgid "try to complete a challenge"
+msgstr "도전과제를 완료합니다."
+
+msgid "show information about the challenge"
+msgstr "도전과제에 관한 정보를 확인합니다."
+
+msgid "§eRank: "
+msgstr "§e랭크: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4반복할 수 없는 도전과제입니다!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr "§4이 도전과제를 완료되었을때 모든 필요한 아이템들을 잃게 됩니다!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4All 필요한 아이템들은 무조건 당신의 섬에서 당신의 {0} 블록 안팎으로 놓여져"
+"야 합니다."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§e도전과제를 완료하려면 §f/c c {0}를 사용하세요"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr ""
+"§4유효하지 않은 도전과제 이름입니다! 더 많은 정보가 필요하면 /c help를 이용하"
+"세요"
+
+msgid "§eSending you to spawn."
+msgstr "§e스폰으로 이동 중 입니다."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§e해당섬 은 §c잠금§e 되어있습니다."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4당신의 섬에서 안전한 Home 장소를 찾지 못했습니다!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§c경고: §e하늘 한가운데로 이동중입니다."
+
+msgid "§aTeleporting you to your island."
+msgstr "§a당신을 당신의 섬으로 텔레포트 하는 중입니다."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§a{0}초 후에 당신은 이동될 것 입니다.."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4해당플레이어의 섬으로 워프 할 수 없습니다!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§a당신은 {0}초 후에 텔레포트 됩니다"
+
+msgid "§7Teleport cancelled"
+msgstr "이동이 취소되었습니다."

--- a/uSkyBlock-Core/src/main/po/nl.po
+++ b/uSkyBlock-Core/src/main/po/nl.po
@@ -17,6 +17,30 @@ msgstr ""
 "X-Loco-Parser: loco_parse_po\n"
 "X-Loco-Target-Locale: nl_NL\n"
 
+msgid "d"
+msgstr "d"
+
+msgid "h"
+msgstr "u"
+
+msgid "m"
+msgstr "m"
+
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§eJe hebt geen toegang tot (§4{0}§e)"
@@ -24,6 +48,15 @@ msgstr "§eJe hebt geen toegang tot (§4{0}§e)"
 #, java-format
 msgid "§eInvalid command: {0}"
 msgstr "§eOngeldige commando: {0}"
+
+msgid "Command"
+msgstr "Commando"
+
+msgid "Permission"
+msgstr "Eigenschappen"
+
+msgid "Description"
+msgstr "Beschrijving"
 
 #, java-format
 msgid "§7Usage: {0}"
@@ -48,1700 +81,12 @@ msgstr "Opgeslagen documentatie naar {0} geschreven"
 msgid "§4Error writing documentation: {0}"
 msgstr "§4Error met opslaan van de documentatie: {0}"
 
-msgid "Command"
-msgstr "Commando"
+msgid "§cWither Despawned!§e It wandered too far from your island."
+msgstr "§cWither verwijderd!§e Hij ging te ver we van je eiland."
 
-msgid "Permission"
-msgstr "Eigenschappen"
-
-msgid "Description"
-msgstr "Beschrijving"
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-msgid "d"
-msgstr "d"
-
-msgid "h"
-msgstr "u"
-
-msgid "m"
-msgstr "m"
-
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eJe komt de volgende blokken tekort: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr "§4Je kan dit nog {0} keer voltooien."
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4De vereisten worden teruggezet in {0} dag(en)."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4De vereisten worden teruggezet in {0} uur."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4De vereisten worden teruggezet in {0} minuten."
-
-msgid "§4This challenge is currently unavailable."
-msgstr "§4Deze uitdaging is momenteel niet beschikbaar"
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr "§4Je kan dit opnieuw voltooien in {0} dagen."
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr "§4Je kan dit opnieuw voltooien in {0} uren."
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr "§4Je kan dit opnieuw voltooien in {0} minuten."
-
-msgid "§eThis challenge requires:"
-msgstr "§eDeze uitdaging vereist:"
-
-msgid "§7and more..."
-msgstr "§7en meer..."
-
-msgid "§eItems will be traded for reward."
-msgstr "§eItems worden verhandeld voor een beloning."
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr "§eMoet binnen {0} meter zijn."
-
-msgid "§6Item Reward: §a"
-msgstr "§6Item beloning: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Geld beloning: §a {0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Exp belonging: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dHet aantal keer dat je de uitdaging hebt voltooid: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr "§7Vereist {0}"
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4De uitdaging met de naam {0} kan niet worden gevonden!"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4Je moet op je eiland zijn om dat te doen!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§4DE {0} uitdaging is nog niet beschikbaar!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4De {0} uitdaging kan niet herhaald worden!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr "§4Je kan de {0} challenge nog niet opnieuw voltooien!"
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§eProberen om §a{0} uitdaging te voltooien"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr "§4Je moet binnen {0} blokken staan van alle benodigde items."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "Je eiland moet level {0} hebben om deze uitdaging te voltooien!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Onbekende soort uitdaging: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§eJe komt de volgende entiteiten tekort:\n"
-" {0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eJe komt de volgende items tekort: {0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aJe hebt de {0} uitdaging volbracht!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9{0}§fheeft de §9{1}§f uitdaging volbracht!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§eItem belonging(en): §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eExp belonging: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§egeld Beloning: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eJe inventaris is §4vol§e. Je items liggen op de grond."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lKlik om deze uitdaging te voltooien."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lJe kan deze uitdaging niet herhalen."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Rang: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fVoltooi de meeste uitdagingen in"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fdeze rang om de volgende rang te openen"
-
-msgid "§eClick here to show previous page"
-msgstr "§eKlik hier om de vorige pagina te zien"
-
-msgid "§eClick here to show next page"
-msgstr "§eKlik hier om de volgende pagina te zien"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lGesloten uitdaging"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "§7Voltooi nog {0} {1} §7uitdagingen"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Voltooi {0}"
-
-msgid "to unlock this rank"
-msgstr "om de volgende rang te openen"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "Maar je bent HELEMAAAAAL ALLEEEEEEN!!"
-
-msgid "But you are Yelling in the wind!"
-msgstr "Maar je bent in de wind aan het Schreeuwen!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "Maar je fantasie vrienden zijn verdwenen!"
-
-msgid "But you are Talking to your self!"
-msgstr "Maar je Praat alleen tegen jezelf!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cSorry! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr "Stuur een bericht direct naar je groep, of schakel het aan/uit."
-
-msgid "party"
-msgstr "party"
-
-msgid "island"
-msgstr "eiland"
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§cChat geschakeld naar {0} §aAAN"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§cHerhaal §9{0}§c om het uit te schakelen."
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§aSchakel chat §cUIT§a voor {0}"
-
-msgid "§cCommand only available to players"
-msgstr "§cCommando alleen voor spelers"
-
-msgid "talk to players on your island"
-msgstr "praat met spelers op je eiland"
-
-msgid "talk to your island party"
-msgstr "praat met je party leden"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§eSpeler {0} heeft geen eiland!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eDe speler {0} bestaat niet."
-
-msgid "Manage challenges for a player"
-msgstr "Beheer de uitdagingen voor een speler"
-
-msgid "resets the challenge for the player"
-msgstr "reset de uitdaging voor een speler"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4De uitdaging is nog nooit voltooid"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§euitdaging: {0} is gereset naar {1}"
-
-msgid "resets all challenges for the player"
-msgstr "reset alle uitdagingen voor een speler"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0} heeft al zijn uitdagingen laten resetten."
-
-msgid "complete all challenges in the rank"
-msgstr "voltooi alle uitdagingen in deze groep"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4De speler met de naam {0} kan niet worden gevonden!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4De {0} uitdaging is al voltooid"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§eDe {0} uitdaging is voltooid voor {1}"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4De uitdaging met de naam {0} kan niet worden gevonden!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4Geen rang genaamd {0} gevonden!"
-
-msgid "manage islands"
-msgstr "beheer de eilanden"
-
-msgid "protects the island"
-msgstr "bescherm het eiland"
-
-msgid "delete the island (removes the blocks)"
-msgstr "verwijder het eiland (dit verwijderd ook de blokken)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Het verlaten eiland op je huidige locatie is verwijderd."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4Het eiland op deze locatie heeft leden!\n"
-"§eGebruik §9/usb island delete <naam>§e om het eiland te verwijderen."
-
-msgid "removes the player from the island"
-msgstr "verwijderd de speler van het eiland"
-
-msgid "adds the player to the island"
-msgstr "voegt de speler toe aan het eiland"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d heeft zich aangesloten bij je eiland groep."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4Er is geen speler gevonden met de naam {0}!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-"§4Er is geen geldig eiland verstrekt, sta op een eiland, of geef een eiland "
-"naam"
-
-msgid "print out info about the island"
-msgstr "geeft informatie over het eiland"
-
-msgid "sets the biome of the island"
-msgstr "zet de biome van het eiland"
-
-msgid "§4That player has no island."
-msgstr "§4Die speler heeft geen eiland."
-
-msgid "§4No valid island at your location"
-msgstr "§4Er is geen geldig eiland op jouw locatie"
-
-msgid "purges the island"
-msgstr "verwijdert het eiland"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Error! §9Er is geen geldig eiland gevonden om te verwijderen."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cVERWIJDER: §9Verwijderd eiland is op {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "het eiland op slot zetten."
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cZet {0}''s eiland op de negeerlijst van verwijderen en de top-tien."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§cVerwijder de negeer-flag van {0}s eiland, het staat weer op de top-tien "
-"lijst en kan verwijderd worden."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Geen geldige speler-naam ingevoerd"
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "{0} is van het eiland verwijderd"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eDe biome van {0}s eiland is veranderd naar {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eDe biome van {0}s eiland is veranderd naar OCEAN."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr ""
-"§aJe moet reloggen of terug naar spawn gaan om de verandering te kunnen zien"
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} heeft zijn/haar biome veranderd naar {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} heeft zijn/haar biome veranderd naar OCEAN."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§e{0}''s eiland wordt verwijderd."
-
-msgid "Error: That player does not have an island!"
-msgstr "Error: Die speler heeft geen eiland!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§e{0}s eiland op {1} is nu beschermd"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4{0}s eiland op {1} is al beschermd"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "open de GUI voor de configuratie"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§eOngeldige configuratie naam"
-
-msgid "Controls player-cooldowns"
-msgstr "Beheert de player-cooldowns"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "reset de cooldown op een command (* = alle)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eDe speler is niet online"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Cooldownperiode gewist op {0} voor {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Geen actieve cooldownperiode gevonden voor {1} op {0}!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Ongeldig command, alleen opnieuw starten en biome is ondersteund!"
-
-msgid "restarts the cooldown on the command"
-msgstr "reset de cooldown met het command"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eReset cooldownperiode op {0} voor {1} §e naar {2} seconden"
-
-msgid "lists all the active cooldowns"
-msgstr "lijst van alle actieve cooldowns"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCmd Cooldownperiode"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eEr zijn geen actieve cooldownperiodes voor §9{0}§e gevonden."
-
-msgid "control debugging"
-msgstr "debugging controle"
-
-msgid "set debug-level"
-msgstr "set debug-niveau"
-
-msgid "toggle debug-logging"
-msgstr "schakel debug-logging"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4Logging was niet actief, uitzetten is dus niet mogelijk!"
-
-msgid "flush current content of the logger to file."
-msgstr "leegt de huidige content van het log naar een bestand"
-
-msgid "§eLog-file has been flushed."
-msgstr "§eHet log-bestand is geleegd."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4Logging staat nog niet aan, gebruiken §d/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Ongeldig argument, probeer INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eLogging staat nu uit!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "probeerd het flatland te repareren in de omgeving."
-
-msgid "§4No valid island found"
-msgstr "§4Er is geen geldig eiland gevonden"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4Er is geen vlakland gevonden onder {0}''s eiland"
-
-msgid "flushes all caches to files"
-msgstr "leegt alle caches naar bestanden"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-"§e§a{0} eilanden§e, §b{1} spelers en §6{2} uitdagingen-volbrenging geleegd."
-
-msgid "manually update the top 10 list"
-msgstr "de top tien lijst handmatig bijwerken"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eHet genereren van de Top Tien lijst"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eHet genereren van de Top Tien lijst is klaar"
-
-msgid "advanced command for getting island-data"
-msgstr "geavanceerde commando voor het krijgen van island-data"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§eActuele waarde van {0} is ''{1}''"
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§cKan geen stand verkrijgen voor {0}"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§eGeldige velden zijn {0}"
-
-msgid "teleport to another players island"
-msgstr "Teleporteert naar een andere speler''s eiland"
-
-msgid "§4Only supported for players"
-msgstr "§4Alleen ondersteund voor spelers"
-
-msgid "§4That player does not have an island!"
-msgstr "§4Die speler heeft geen eiland."
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr "§aTeleporteren naar {0}''s eiland."
-
-msgid "imports players and islands from other formats"
-msgstr "importeert spelers en eilanden van een ander formaat"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Baan Statistieken"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/baan"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "act"
-
-msgid "time"
-msgstr "tijd"
-
-msgid "name"
-msgstr "naam"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "verandert de taal van de plugin en herlaad"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aDe taal is met succes veranderd naar §e{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cHet is mislukt om de taal naar §e{0} te veranderen."
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Ondersteunde Talen:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 bij {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cKan geen talen vinden"
-
-msgid "transfer leadership to another player"
-msgstr "leiderschap overdragen naar een andere speler"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4De speler {0} heeft geen eiland om over te dragen"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§eDe speler §d{0}§e heeft al een eiland.§eGebruik §d/usb island remove "
-"<naam>§e eerst om hem/haar te verwijderen."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bEiland eigenaar overgedragen van {0}§b naar {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr "geavanceerde informatie over NBT materiaal"
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "toont de NBTTag voor het huidige vastgehouden item"
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§eInfo voor §9{0}"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - naam: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - nbttag: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§cJe hand is leeg!"
-
-msgid "§eCan only be executed as a player"
-msgstr "§eKan alleen als speler worden uitgevoerd"
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "zet de NBTTag voor het item in je hand"
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "§eZet §9{0}§e naar §c{1}"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "voegt de NBTTag toe op je huidig vastgehouden item"
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§eVoegt §9{0}§e aan §c{1}"
-
-msgid "manage orphans"
-msgstr "beheer orphans"
-
-msgid "count orphans"
-msgstr "aantal orphans"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr ""
-"§e{0} oude eiland locatie zullen worden hergebruikt voordat een nieuw "
-"locatie word gekozen."
-
-msgid "clear orphans"
-msgstr "verwijder orphans"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eOpschonen van alle oude (lege) eiland locaties."
-
-msgid "list orphans"
-msgstr "orphan lijst"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eEr zijn geen orphans geregistreerd."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr "extra perks {0}"
-
-msgid "protects all islands (time consuming)"
-msgstr "beschermd alle eilanden (dit kan veel tijd inbeslag nemen)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§cProberen om protect-all taak af te breken."
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-"§4Sorry!§e Een protect-all is al bezig. Laat dit z'n gang gaan, of gebruik "
-"§9usb protectall §cstop"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§eBegin van de opdracht protect-all. Dit kan een tijdje gaan duren."
-
-msgid "purges all abandoned islands"
-msgstr "verwijders alle verlaten eilanden"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4Je moet het aantal dagen invoeren om een purge uit te voeren!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr "§4probeert de purge te stoppen"
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr "§4Starten van de purge..."
-
-msgid "region manipulations"
-msgstr "regio manipulaties"
-
-msgid "shows the borders of the current island"
-msgstr "toont de grens aan van het huidige eiland"
-
-msgid "§eNo island found at your current location"
-msgstr "§eEr is geen eiland op je huidige locatie"
-
-msgid "shows the borders of the current chunk"
-msgstr "toont de grens aan van het huidige chunk"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "toont de grens aan van de binnenkant-chunks"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "toont de niet-chunk-align grenzen"
-
-msgid "shows the borders of the outer-chunks"
-msgstr "toont de grens aan van de buitenkant-chunks"
-
-msgid "hides the regions again"
-msgstr "verbergt de regio''s opnieuw"
-
-msgid "§eStopped displaying regions"
-msgstr "§eGestopt met het weergeven van de regio''s"
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§eEr worden geen regio''s weergegeven voor deze speler"
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§eAnimatie-tick veranderd naar {0}."
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§eAnimatie-tick moet een geldig geheel getal zijn."
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "zet een spelers eiland op mijn lokatie"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "herladen van de configuratie van het bestand"
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eDe Configuratie is herladen"
-
-msgid "advanced command for setting island-data"
-msgstr "geavanceerde command voor het instellen van island-data"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§c{0} is gezet naar ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§cKan het veld {0} niet veranderen naar ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr ""
-"§cKan het veld {0} niet veranderen naar ''{1}'', een getal werd verwacht"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§cOngeldig veld {0}"
-
-msgid "toggles maintenance mode"
-msgstr "Onderhoud-modus schakel command"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-"§cONDERHOUD: §eAlle uSkyBlock functies zijn momenteel  §auitgeschakeld§e."
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-"§cONDERHOUD: §4§eAlle uSkyBlock functies kunnen weer  §agebruikt§e worden."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr "§cOnderhoud modus kan alleen worden veranderd in het console!"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§cAFGEBROKEN:§e Protect-All was gestopped!"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr "§eVolbracht protect-all in {0}, {1} nieuwe regio''s zijn gecreeerd!"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§7- SCANNING: {0,number,##}% ({1}/{2} mislukt: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4PURGE:§9 Scanning gestopped."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-"- PURGING: {0,number,##}% ({1}/{2}), verstreken {3}, Naar schatting "
-"voltooiing ~{4}"
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4PURGE:§9 Klaar met verwijderen van verlaten eilanden."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4PURGE:§9 Verweideren van verlaten eilanden is gestopped."
-
-msgid "displays version information"
-msgstr "het weergeven van de versie-informatie"
-
-msgid "various WorldGuard utilities"
-msgstr "diverse WorldGuard utilities"
-
-msgid "refreshes the chunks around the player"
-msgstr "herlaad de chunks rondom de speler"
-
-msgid "§eResending chunks to the client"
-msgstr "§eHersturen van de chunks naar de client"
-
-msgid "load the region chunks"
-msgstr "laad de regio chunks"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eHet laden van de chunks op {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eHet ontladen van de chunks op {0}"
-
-msgid "update the WG regions"
-msgstr "Bijwerken van de WG regio''s"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§eEiland world-guard regio is bijgewerkt voor {0}"
-
-msgid "§eNo island found at your location!"
-msgstr "§eEr is geen eiland gevonden op je locatie!"
-
-msgid "refreshes the chunk around the player"
-msgstr "verfrist de chunk rond de speler"
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "laat speler-informatie zien"
-
-msgid "try to complete a challenge"
-msgstr "probeer om een uitdaging the voltooien"
-
-msgid "§cCommand only available for players."
-msgstr "§cCommando is alleen voor spelers."
-
-msgid "show information about the challenge"
-msgstr "laat de informative zien van een uitdaging"
-
-msgid "§eRank: "
-msgstr "§eRank:"
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4Deze uitdaging kan niet herhaald worden!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr "§4Je verliest alle benodigde items wanneer je deze uitdaging voltooid!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4Alle benodigde items moeten op je eiland geplaatst zijn, binnen een bereik "
-"van {0} bij jouw vandaan."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§eOm deze uitdaging te voltooien, gebruik  §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr ""
-"§4De uitdagings naam is ongeldig! Gebruik / c help voor meer informatie"
-
-msgid "complete and list challenges"
-msgstr "compleet en vermelde uitdagingen"
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr ""
-"§eDe uidagingen zijn uitgeschakeld. Neem contact op met een administrator."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4Je kan alleen uitdaginged voltooien in de skyblock wereld!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4Je kan alleen uitdaginged voltooien als je een eiland hebt!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4Je eiland is vol, of je hebt teveel uitnodigingen open staan. Je kunt "
-"niemand anders uitnodigen."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4Die speler is al eigenaar van een ander eiland.."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr ""
-"§e{0}§e probeerde je uit te nodigen, maar je bent al lid van een ander "
-"eiland."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr "§aUitnodiging gestuurd naar {0}"
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e heeft je uitgenodigd om lid te worden van zijn/haar eiland!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr ""
-"§f/island [accept/reject]§eom de uitnodiging te accepteren of te weigeren."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr ""
-"§4WAARSCHUWING: Je zult je eiland verliezen als je de uitnodiging accepteerd!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d uitgenodigd {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e heeft de uitnodiging geweigerd."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4je kunt dat command nu niet gebruiken. Verlaat eerst uw huidige party."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§aJe hebt je aangesloten bij een eiland! Gebruik /island party om alle "
-"andere leden te zien."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§eDe uitnodiging van {0}§e is verlopen of geannuleerd."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§eDe uitnodiging van {0}''s eiland  is verlopen of geannuleerd."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr ""
-"§eJe hebt een uitnodiging geaccepteerd om lid te worden van een eiland."
-
-msgid "§4You haven't been invited."
-msgstr "§4Je bent niet uitgenodigd."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eJe hebt de uitnodoging geannuleerd."
-
-msgid "accept/reject an invitation."
-msgstr "accepteren/weiger een uitnodiging."
-
-msgid "teleports you to your island (or create one)"
-msgstr "teleporteert je naar je eiland (of maakt er een aan)"
-
-msgid "ban/unban a player from your island."
-msgstr "ban/unban een speler van uw eiland."
-
-msgid "exempts user from being banned"
-msgstr "stelt de speler vrij van verbannen"
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§eDe volgende spelers zijn geblokkeert om naar uw eiland te warpen:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr ""
-"§eOm een speler te bannen/unbannen van je eiland, gebruik /island ban "
-"<speler>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4Je kunt geen leden verbannen. Verwijder ze eerst van de party!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4Je hebt geen toestemming om leden te verweideren of te verbannen."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§eKan geen onbekende speller verbannen{0}"
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4{0} probeerde je van z'n eiland te verbannen"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4{0} kan niet worden verbannen"
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eJe hebt §4{0}§e verbannen om naar uw eiland te warpen."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eJe bent §cVERBANNEN §e van {0}§e''s eiland."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§eJe hebt §a{0}§e toegang gegeven om weer naar uw eiland te warpen."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eJe bent §aONTBANNED§e van {0}§e''s ieland."
-
-msgid "change the biome of the island"
-msgstr "verander de biome van het eiland"
-
-msgid "exempt player from biome-cooldown"
-msgstr "Stelt speller vrij van biome-cooldown"
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr "Laat de speller zijn biome veranderen naar {0}"
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr ""
-"§cje hebt geen toestemming om de biome te veranderen op uw huidige eiland."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4Je hebt geen toestemming om de biome te veranderen van dit eiland!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eJe moet op je eiland zijn om de biome te veranderen!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr "§cJe hebt de biome verkeert gespeld. Het moet een van deze {0} zijn"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eJe kunt je biome weer veranderen in {0,number,#} minuten."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cJe hebt geen toestemming om de biome te veranderen van dit eiland!"
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-"§7De Pixies zijn bezig met het veranderen van de biome bij jou naar §9{0}§7, "
-"heb geduld."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-"§7De elfjes zijn bezig je eiland biome te veranderen  §9{0}§7, heb gedult."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr "§eOngeldige biome {0} ingevoerd!"
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aJe hebt je eiland biome veranderd naar {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} heeft het eiland biome veranderd naar {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr "§aJe hebt {0} blokken veranderd naar de {1} biome"
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr "{0} creëerde een gebied met {1} biome"
-
-msgid "create an island"
-msgstr "Creeer een eiland"
-
-msgid "exempt player from create-cooldown"
-msgstr "stelt speller vrij van create-cooldown"
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4Er is een eiland gevonden!§e Je heeft al een eiland. Als je een nieuw "
-"eiland wilt, type §b/is restart §eom opnieuw te beginnen"
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4Er is een eiland gevonden!§e Je bent al lid van een eiland. Om je eigen "
-"eiland te beginnen moet je eerst §b /is leave command doen."
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eJe kunt een nieuw eiland aanmaken in {0,number,#}  seconden."
-
-msgid "teleport to the island home"
-msgstr "telepoort naar je eiland "
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§cJe eiland is in het proces van het genereren, je kan nu niet naar je home "
-"lokatie teleporteren."
-
-msgid "check your or another''s island info"
-msgstr "controleer jouw of iemand anders z'n eiland informatie"
-
-msgid "allows user to see others island info"
-msgstr "Laat de gebruiker anderen eiland info zien"
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4Eiland niveau is uitgeschakeld, neem contact op met een beheerder."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eJe moet op je eiland zijn om dit commando te kunnen uitvoeren"
-
-msgid "§4You do not have an island!"
-msgstr "§4Je hebt geen eiland!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4Je hebt geen toegang tot dit commando!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4Die speler is ongeldig of heeft geen eiland!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBlokken op {0}s Eiland (pagina  {1,number} of {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Score van het aantal blokken"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aEiland niveau is {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "nodig een speler uit naar je eiland"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§eGebruik§f /island invite <spelersnaam>§e om een speler uittenodigen naar "
-"uw eiland."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4Alleen de eiland eigenaar kan spelers uitnodigen!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aJe kan nog {0} speler(s) uitnodigen"
-
-msgid "§4You can't invite any more players."
-msgstr "§4Je kan geen spelers meer uitnodigen"
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4Je hebt geen toestemming om andere spelers uit te nodigen!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4Die speller bestaat niet of is offline."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4Je kan jezelf niet uitnodigen!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4Die speler is de leider van je eiland!"
-
-msgid "remove a member from your island."
-msgstr "verwijder een speler van je eiland."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr ""
-"§4Je hebt geen toestemming om andere spelers van dit eiland te verwijderen!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4Je kan de leider niet van een eiland verwijderen!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4Je kan jezelf niet verwijderen!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0} heeft je verwijderd van zijn eiland."
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} is verwijderd van het eiland."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0} probeerde je van z'n eiland te vewijderen!"
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4{0} kan niet verwijderd worden."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4{0} heeft je van z'n eiland verwijderd!"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0} is verwijderd van het eiland."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr ""
-"§4Die speller is niet op je eiland en behoord niet tot je eiland groep,"
-
-msgid "leave your party"
-msgstr "verlaat je party"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4je kan het eiland niet verlaten als de enigste op dat eiland bent. Gebruik "
-"het command /island restart als je opnieuw wilt beginnen!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§eDit is jouw eiland, gebruik /island remove <speler> inplaats"
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr ""
-"§eJe hebt het eiland verlaten en wordt terug geplaatst op de spelers spawn."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0} heeft je eiland verlaten"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4Je moet in de skyblock wereld zijn om je party te verlaten!"
-
-msgid "check your or anothers island level"
-msgstr "Controleer je eigen of iemand anders z'n eiland niveau"
-
-msgid "allows user to query for others levels"
-msgstr "laat de speler andere spelers levels opvragen"
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eInformatie over {0}''s Eiland"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9Rank is {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "sluit het eiland af voor niet-party leden"
-
-msgid "§4You do not have permission to lock your island!"
-msgstr ""
-"§4Je hebt geen toestemming om je eiland af te sluiten voor andere spelers!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4Je hebt geen toegang tot dit commando!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4Je hebt geen toestemming om je eiland te openen voor andere spelers!"
-
-msgid "display log"
-msgstr "weergave log"
-
-msgid "transfer leadership to another member"
-msgstr "overdragen van de leiding naar een ander lid"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4Je kan alleen de leiding overdragen naar een party-lid!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e Is al de leider van je eiland!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4Alleen de leider kan het leiderschap overdragen!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} heeft geprobeerd het eiland over te nemen!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "laat party informatie zien"
-
-msgid "shows information about your party"
-msgstr "laat informatie zien over je party"
-
-msgid "show pending invites"
-msgstr "laat lopende uitnodigingen zien"
-
-msgid "§eNo pending invites"
-msgstr "§eGeen lopende uitnodigingen"
-
-msgid "withdraw an invite"
-msgstr "uitnodiging terugtrekken"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4Je hebt geen permissie om uitnodigingen in te trekken."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4Dit commando kan alleen gebruikt worden door een speler"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4Geen eiland. §eGebruik §b/is create§e om er een te maken"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "verwijder je eiland en start een nieuwe."
-
-msgid "exempt player from restart-cooldown"
-msgstr "stelt de speler vrij van herstart-cooldown"
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4Alleen de eiland eigenaar mag het eiland opnieuw starten. Verlaat dit "
-"eiland om je eigen eiland te beginnen (/island leave)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eJe moet alle spelers verwijderen voordat je je eiland opnieuw kan starten "
-"(/island kick <player>). Bekijk een lijst met huidige spelers op je eiland "
-"door gebruik te maken van /island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§eJe kunt een nieuw eiland aanmaken in {0} seconden."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§cJe eiland is in het verloop van het genereren, kan je nu herstarten."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eLET OP: Je gehele eiland en je belangen worden VERWIJDERD!"
-
-msgid "set the island-home"
-msgstr "set de thuis-lokatie"
-
-msgid "set your island''s warp location"
-msgstr "set de warp lokatie van je eiland"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cje hebt geen toestemming om je warp lokatie te zetten op je eiland!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§cJe moet op je eigen eiland zijn om de warp lokatie te zetten!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d heeft de warp lokatie verzet."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "telepoort je naar de skyblock spawn"
-
-msgid "enable/disable warping to your island."
-msgstr "zet de warping aan/uit naar je eiland"
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4Je eiland is gesloten. Je moet het eerst ongrendelen voordat je de warp "
-"kan aanzetten."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d heeft het eiland warp geactiveerd."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d heeft het eiland warp gedeactiveerd."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr "§cJe hebt geen toestemming om je eiland warp aan/uit te zetten!"
-
-msgid "display the top10 of islands"
-msgstr "laat de top 10 van alle eilanden zien"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr ""
-"Laat een speler altijd het opnieuw genereren van de top-ten (no caching)"
-
-msgid "trust/untrust a player to help on your island."
-msgstr "vertrouw/wantrouw een speler om je te helpen op je eiland."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eDe volgende spelers zijn vertrouwd op je eiland:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eJe bent vetrouwd door de volgende leiders:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr ""
-"§eOm spelers te vertrouwen/wantrouwen op je eiland, gebruik dan /island "
-"trust <speler> of /island untrust <speler>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4Leden die al vertrouwd zijn!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Onbekende speler {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eJe bent nu vertrouwed op §4{0}''s §eeiland."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} vertrouwd {1} op het eiland"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eJe bent niet meer vertrouwd op §4{0}''s §eeiland."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0} heeft het vertouwen afgenomen van {1} op het eiland."
-
-msgid "warp to another player''s island"
-msgstr "warp naar een andere speler''s eiland"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr "§aJe inkomende warp is actief, spelers kunnen naar je eiland warpen."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§4Je inkomende warp is niet actief, spelers kunnen niet naar je eiland "
-"warpen."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr "§fSet je inkomende warp op je huidige lokatie met §e/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§fSchakel je warp aan/uit met §e/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4Je hebt geen permissie om een warp te creeren op je eiland!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§fWarp naar een ander eiland met gebruik van §e/island warp <speler>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4Je hebt geen permissie om naar andere eilanden te warpen!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§cJe eiland is in het proces van het genereren, je kan op moment niet naar "
-"andere eilanden warpen."
-
-msgid "§4That player does not exist!"
-msgstr "§4Die speler bestaat niet!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4Die speler heeft geen actieve warp"
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§cDie spelers eiland is in de proces van genereren, daar kan je nu niet "
-"naartoe warpen."
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cLET OP: §9{0}§e warped naar je eiland!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4Die speler heeft je verboden om naar zijn eiland te warpen"
-
-msgid "general island command"
-msgstr "algemeen eiland command"
-
-msgid "allows user to bypass cooldowns"
-msgstr "laat de speler altijd cooldowns omzeilen"
-
-msgid "allows user to bypass visitor-protections"
-msgstr "laat de speler de bezoekers-beveiliging omzeilen"
-
-msgid "allows user to bypass teleport-delay"
-msgstr "laat de speler de teleport-vertraging omzeilen"
-
-msgid "allows user to use [usb] signs"
-msgstr "Hiermee kan de gebruiker [USB] borden gebruiken"
-
-msgid "allows user to place [usb] signs"
-msgstr "Hiermee kan de gebruiker [USB] borden te plaatsen"
+msgid "{0}''s Wither"
+msgstr "{0}''s Wither"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr ""
@@ -1757,33 +102,6 @@ msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr "§cWither verwijderd!§e Hij ging te ver we van je eiland."
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "{0}''s Wither"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eGasten kunnen geen items laten vallen!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Eigenaar: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "Je kan als gast geen items oppakken van andere spelers!"
-
-msgid "Config:"
-msgstr "Config:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§cGeen Toegang! §eJe probeert om naar het dak van de §cNETHER§e te "
-"teleporteren, dat is niet toegestaan."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr "§4Je kunt alleen obsidiaan omzetten eens per 10 seconden"
@@ -1827,19 +145,84 @@ msgstr "§eJe kan alleen spawn-eggs op je eigen eiland gebruiken."
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§cJe hebt het maximake berijkt voor je spawn-limiet"
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eGasten kunnen geen items laten vallen!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Eigenaar: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "Je kan als gast geen items oppakken van andere spelers!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cVerbannen:§e je bent verbannen van dit eiland."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cgesloten:§e Dat ieland is gesloten! Geen toegang mogelijk."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eWachten op onze beurt §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr ""
+"Er is iets mis gegaan tijdens het opslaan van het eiland en/of party data!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr "Het omzetten van gegevens naar UUID, dit kan een tijdje duren!"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§cONDERHOUD:§e uSkyBlock is op moment in onderhoud modus"
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Het creëren van je island...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"§buSkyBlock§e is afhankelijk van §9{0}§e >= §av{1}§e maar alleen §cv{2}§e is "
+"gevonden!\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e is afhankelijk van §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§eJe hebt geen toegang to dat eiland-schematic"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4Speler is al toegewezen aan dit eiland!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4Je moet dichter bij je eiland zijn om je skyblock home te zetten"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aJe skyblock home is ingesteld op uw huidige locatie."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4Je huidige locatie is niet een veilige thuis-locatie."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+"§7De elfjes zijn bezig je eiland biome te veranderen  §9{0}§7, heb gedult."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr "§cJe eiland is in het proces van het genereren, kan je nu niets maken."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "Kan je eiland niet creeren. Kontakt een server moderator"
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr "§eJe eiland word gereed gemaakt, heb geduld, dit kan even duren."
+
+msgid "§cCommand is currently disabled!"
+msgstr "§cCommando is op moment gedeactiveerd!"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eJe komt de volgende blokken tekort: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1852,9 +235,6 @@ msgid ""
 msgstr ""
 "§eHet commando §9{0}§e is §cRISKANT§e. Herhaal het commando in §a{1}§e "
 "seconden om het te accepteren!"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** je komt een beveiligde - maar verlaten - eiland regio binnen."
@@ -1889,215 +269,34 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4Je moet eiland eigenaar zijn om je eiland te ontgrendelen!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§7PlayerDB: Filtering {0} spelers van uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eWachten op onze beurt §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Het creëren van je island...§e{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lGesloten uitdaging"
+
+msgid "READY"
+msgstr "KLAAR"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§7PlayerDB: Filtered {0} names"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, mislukt:{3} ~ {5,number,##}%), "
-"{6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§7MojangAPI: Probeert om {0} spelers op te halen van Mojang"
-
-msgid "SUCCESS"
-msgstr "SUCCES"
-
-msgid "FAILED"
-msgstr "MISLUKT"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§7 - MojangAPI:§aVOLTOOID: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§7 - MojangAPI:§cERROR: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-"§eVoortgang: {0,number,##}% ({1}/{2} - succes:{3}, mislukt:{4}, overgeslage:"
-"{5}) ~ {6}"
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4Geen importuer met de naam §e{0}§4 gevonden"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§eConverted {0}/{1} files in {2}"
-
-msgid "The island has been created."
-msgstr "Je eiland is gecreeerd."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d heeft het eiland afgesloten."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§4Nu je eiland is gesloten is ook je inkomende warp gedeactiveerd."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d heeft het eiland opengesteld."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cSKY §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d is verwijderd van het eiland."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9Creëren van het eiland op jouw locatie"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9Eiland creëren §7{0}§9 van jouw"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§4DE {0} uitdaging is nog niet beschikbaar!"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
-"§cHet eiland wat bij dit stukje Nether hoort wordt nu verwijdert! Je word "
-"naar spawn gestuurd."
+"§cWAARSCHUWING:§e Kon niet alle vereiste items naar je inventaris over te "
+"dragen!"
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr ""
-"§cHet eiland waar je je op bevind word verwijderd! Je word naar spawn "
-"gestuurd."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eWALL OF FAME (pagina {0} van {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr "§4De top tien lijst is leeg! Alleen eilanden met level {0} en hoger."
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eJouw rank is: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "ONBEKEND"
-
-msgid "ANIMAL"
-msgstr "ANIMAL"
-
-msgid "MONSTER"
-msgstr "MONSTER"
-
-msgid "VILLAGER"
-msgstr "VILLAGER"
-
-msgid "GOLEM"
-msgstr "GOLEM"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (max. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "Kan geen schematic {0} vinden, neem contact op met een server-admin"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aGefeliciteerd! §eJe eiland is aangemaakt."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cLet OP:§e Constructie kan nog bezig zijn."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Gebruik §9/is h§r of het §9/is§r menu om naar je eiland te gaan."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§cWatchdog!§9 Kan geen chest vinden in {0}, process gestopt."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7Pagina {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr "§c{0,number,#}"
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr "§a+{0,number,#}"
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr "§a{0,number,#}"
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr "&aLinks:&7 Verhogen met {0}"
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr "&cRechter-Klik:&7 Zet naar {0}"
-
-msgid "Return"
-msgstr "Terug"
-
-msgid "§9Integer Editor"
-msgstr "§9Integer Editor"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eDe Configuratie is opgeslagen en herladen."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cError! §9Kan de configuratie niet opslaan!"
-
-msgid "§3First Page"
-msgstr "§3Eerste Pagina"
-
-msgid "§3Last Page"
-msgstr "§3Laatste Pagina"
-
-msgid "§cSave & Reload config"
-msgstr "§cOpslaan & Herlaad de config"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Opslaan van de gegevens\n"
-"§7naar file & herlaad weer.\n"
-"§cPas OP: §7Gebruik met zorg!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (readonly)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr "§cNiet genoeg items in je kist te om de uitdaging te voltooien!"
 
 msgid "true"
 msgstr "true"
@@ -2547,6 +746,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "§7Huidige pagina"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7Pagina {0}"
+
 msgid "§7First Page"
 msgstr "§7Eerste Pagina"
 
@@ -2854,8 +1057,8 @@ msgstr "§cKlik om te verlaten"
 msgid "Island Restart Menu"
 msgstr "Eiland Herstart Menu"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§eJe hebt geen toegang to dat eiland-schematic"
+msgid "Config:"
+msgstr "Config:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2871,116 +1074,122 @@ msgstr "§cKlik binnen §9{0}§c om te herstarten!"
 msgid "§aClick to restart!"
 msgstr "§aKlik voor herstart!"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr "§c{0,number,#}"
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr "§a+{0,number,#}"
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr "§a{0,number,#}"
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr "&aLinks:&7 Verhogen met {0}"
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr "&cRechter-Klik:&7 Zet naar {0}"
+
+msgid "Return"
+msgstr "Terug"
+
+msgid "§9Integer Editor"
+msgstr "§9Integer Editor"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9Text Editor"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eDe Configuratie is opgeslagen en herladen."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cError! §9Kan de configuratie niet opslaan!"
+
+msgid "§3First Page"
+msgstr "§3Eerste Pagina"
+
+msgid "§3Last Page"
+msgstr "§3Laatste Pagina"
+
+msgid "§cSave & Reload config"
+msgstr "§cOpslaan & Herlaad de config"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Opslaan van de gegevens\n"
+"§7naar file & herlaad weer.\n"
+"§cPas OP: §7Gebruik met zorg!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (readonly)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+"§eVoortgang: {0,number,##}% ({1}/{2} - succes:{3}, mislukt:{4}, overgeslage:"
+"{5}) ~ {6}"
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4Geen importuer met de naam §e{0}§4 gevonden"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§eConverted {0}/{1} files in {2}"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§7PlayerDB: Filtering {0} spelers van uuid2name.yml"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§7PlayerDB: Filtered {0} names"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, mislukt:{3} ~ {5,number,##}%), "
+"{6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§7MojangAPI: Probeert om {0} spelers op te halen van Mojang"
+
+msgid "SUCCESS"
+msgstr "SUCCES"
+
+msgid "FAILED"
+msgstr "MISLUKT"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§7 - MojangAPI:§aVOLTOOID: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§7 - MojangAPI:§cERROR: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "Te veel verzoeken naar Mojangs API ({0} binnen {1}), pause {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§eJe wordt naar spawn gestuurd."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§eHet eiland is §cAFGESLOTEN§e."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aJe zal in {0} seconden getelepoorteerd worden."
-
-msgid "§7Teleport cancelled"
-msgstr "§7Telepoort geannuleerd "
-
-msgid "READY"
-msgstr "KLAAR"
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-"§cWAARSCHUWING:§e Kon niet alle vereiste items naar je inventaris over te "
-"dragen!"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr "§cNiet genoeg items in je kist te om de uitdaging te voltooien!"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr ""
-"Er is iets mis gegaan tijdens het opslaan van het eiland en/of party data!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr "Het omzetten van gegevens naar UUID, dit kan een tijdje duren!"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§cONDERHOUD:§e uSkyBlock is op moment in onderhoud modus"
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"§buSkyBlock§e is afhankelijk van §9{0}§e >= §av{1}§e maar alleen §cv{2}§e is "
-"gevonden!\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e is afhankelijk van §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4Speler is al toegewezen aan dit eiland!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4Niet in staat om een veilig thuis-lokatie te vinden op je eiland!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§cWAARSCHUWING: §eJe wordt in ergens in de lucht geteleporteerd."
-
-msgid "§aTeleporting you to your island."
-msgstr "§aJe word getelepoorteerd naar je eiland."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Je kan niet naar die spelers eiland warpen!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aTeleporteren naar {0}''s eiland."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4Je moet dichter bij je eiland zijn om je skyblock home te zetten"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aJe skyblock home is ingesteld op uw huidige locatie."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4Je huidige locatie is niet een veilige thuis-locatie."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cJe eiland is in het proces van het genereren, kan je nu niets maken."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "Kan je eiland niet creeren. Kontakt een server moderator"
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr "§eJe eiland word gereed gemaakt, heb geduld, dit kan even duren."
-
-msgid "§cCommand is currently disabled!"
-msgstr "§cCommando is op moment gedeactiveerd!"
 
 msgid "North"
 msgstr "Noord"
@@ -3005,3 +1214,1790 @@ msgstr "West"
 
 msgid "North-West"
 msgstr "Noord-West"
+
+msgid "The island has been created."
+msgstr "Je eiland is gecreeerd."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d heeft het eiland afgesloten."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§4Nu je eiland is gesloten is ook je inkomende warp gedeactiveerd."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d heeft het eiland warp gedeactiveerd."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d heeft het eiland opengesteld."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cSKY §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d is verwijderd van het eiland."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9Creëren van het eiland op jouw locatie"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9Eiland creëren §7{0}§9 van jouw"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aGefeliciteerd! §eJe eiland is aangemaakt."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cLet OP:§e Constructie kan nog bezig zijn."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Gebruik §9/is h§r of het §9/is§r menu om naar je eiland te gaan."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "Kan geen schematic {0} vinden, neem contact op met een server-admin"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§cWatchdog!§9 Kan geen chest vinden in {0}, process gestopt."
+
+msgid "UNKNOWN"
+msgstr "ONBEKEND"
+
+msgid "ANIMAL"
+msgstr "ANIMAL"
+
+msgid "MONSTER"
+msgstr "MONSTER"
+
+msgid "VILLAGER"
+msgstr "VILLAGER"
+
+msgid "GOLEM"
+msgstr "GOLEM"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (max. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§cHet eiland wat bij dit stukje Nether hoort wordt nu verwijdert! Je word "
+"naar spawn gestuurd."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr ""
+"§cHet eiland waar je je op bevind word verwijderd! Je word naar spawn "
+"gestuurd."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eWALL OF FAME (pagina {0} van {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr "§4De top tien lijst is leeg! Alleen eilanden met level {0} en hoger."
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4Eiland niveau is uitgeschakeld, neem contact op met een beheerder."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eJouw rank is: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "§7Voltooi nog {0} {1} §7uitdagingen"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Voltooi {0}"
+
+msgid "to unlock this rank"
+msgstr "om de volgende rang te openen"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr "§4Je kan dit nog {0} keer voltooien."
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4De vereisten worden teruggezet in {0} dag(en)."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4De vereisten worden teruggezet in {0} uur."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4De vereisten worden teruggezet in {0} minuten."
+
+msgid "§4This challenge is currently unavailable."
+msgstr "§4Deze uitdaging is momenteel niet beschikbaar"
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr "§4Je kan dit opnieuw voltooien in {0} dagen."
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr "§4Je kan dit opnieuw voltooien in {0} uren."
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr "§4Je kan dit opnieuw voltooien in {0} minuten."
+
+msgid "§eThis challenge requires:"
+msgstr "§eDeze uitdaging vereist:"
+
+msgid "§7and more..."
+msgstr "§7en meer..."
+
+msgid "§eItems will be traded for reward."
+msgstr "§eItems worden verhandeld voor een beloning."
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr "§eMoet binnen {0} meter zijn."
+
+msgid "§6Item Reward: §a"
+msgstr "§6Item beloning: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Geld beloning: §a {0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Exp belonging: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dHet aantal keer dat je de uitdaging hebt voltooid: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr "§7Vereist {0}"
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4De uitdaging met de naam {0} kan niet worden gevonden!"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4Je moet op je eiland zijn om dat te doen!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4De {0} uitdaging kan niet herhaald worden!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr "§4Je kan de {0} challenge nog niet opnieuw voltooien!"
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§eProberen om §a{0} uitdaging te voltooien"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr "§4Je moet binnen {0} blokken staan van alle benodigde items."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "Je eiland moet level {0} hebben om deze uitdaging te voltooien!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Onbekende soort uitdaging: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§eJe komt de volgende entiteiten tekort:\n"
+" {0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eJe komt de volgende items tekort: {0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aJe hebt de {0} uitdaging volbracht!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9{0}§fheeft de §9{1}§f uitdaging volbracht!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§eItem belonging(en): §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eExp belonging: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§egeld Beloning: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eJe inventaris is §4vol§e. Je items liggen op de grond."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lKlik om deze uitdaging te voltooien."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lJe kan deze uitdaging niet herhalen."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Rang: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fVoltooi de meeste uitdagingen in"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fdeze rang om de volgende rang te openen"
+
+msgid "§eClick here to show previous page"
+msgstr "§eKlik hier om de vorige pagina te zien"
+
+msgid "§eClick here to show next page"
+msgstr "§eKlik hier om de volgende pagina te zien"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "Maar je bent HELEMAAAAAL ALLEEEEEEN!!"
+
+msgid "But you are Yelling in the wind!"
+msgstr "Maar je bent in de wind aan het Schreeuwen!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "Maar je fantasie vrienden zijn verdwenen!"
+
+msgid "But you are Talking to your self!"
+msgstr "Maar je Praat alleen tegen jezelf!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cSorry! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr "Stuur een bericht direct naar je groep, of schakel het aan/uit."
+
+msgid "party"
+msgstr "party"
+
+msgid "island"
+msgstr "eiland"
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§cChat geschakeld naar {0} §aAAN"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§cHerhaal §9{0}§c om het uit te schakelen."
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§aSchakel chat §cUIT§a voor {0}"
+
+msgid "§cCommand only available to players"
+msgstr "§cCommando alleen voor spelers"
+
+msgid "talk to your island party"
+msgstr "praat met je party leden"
+
+msgid "talk to players on your island"
+msgstr "praat met spelers op je eiland"
+
+msgid "manually update the top 10 list"
+msgstr "de top tien lijst handmatig bijwerken"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eHet genereren van de Top Tien lijst"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eHet genereren van de Top Tien lijst is klaar"
+
+msgid "purges all abandoned islands"
+msgstr "verwijders alle verlaten eilanden"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4Je moet het aantal dagen invoeren om een purge uit te voeren!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr "§4probeert de purge te stoppen"
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr "§4Starten van de purge..."
+
+msgid "Controls player-cooldowns"
+msgstr "Beheert de player-cooldowns"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "reset de cooldown op een command (* = alle)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eDe speler is niet online"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Cooldownperiode gewist op {0} voor {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Geen actieve cooldownperiode gevonden voor {1} op {0}!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Ongeldig command, alleen opnieuw starten en biome is ondersteund!"
+
+msgid "restarts the cooldown on the command"
+msgstr "reset de cooldown met het command"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eReset cooldownperiode op {0} voor {1} §e naar {2} seconden"
+
+msgid "lists all the active cooldowns"
+msgstr "lijst van alle actieve cooldowns"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCmd Cooldownperiode"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eEr zijn geen actieve cooldownperiodes voor §9{0}§e gevonden."
+
+msgid "toggles maintenance mode"
+msgstr "Onderhoud-modus schakel command"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+"§cONDERHOUD: §eAlle uSkyBlock functies zijn momenteel  §auitgeschakeld§e."
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+"§cONDERHOUD: §4§eAlle uSkyBlock functies kunnen weer  §agebruikt§e worden."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr "§cOnderhoud modus kan alleen worden veranderd in het console!"
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Baan Statistieken"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/baan"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "act"
+
+msgid "time"
+msgstr "tijd"
+
+msgid "name"
+msgstr "naam"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§eSpeler {0} heeft geen eiland!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eDe speler {0} bestaat niet."
+
+msgid "flushes all caches to files"
+msgstr "leegt alle caches naar bestanden"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+"§e§a{0} eilanden§e, §b{1} spelers en §6{2} uitdagingen-volbrenging geleegd."
+
+msgid "tries to fix the the area of flatland."
+msgstr "probeerd het flatland te repareren in de omgeving."
+
+msgid "§4No valid island found"
+msgstr "§4Er is geen geldig eiland gevonden"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4Er is geen vlakland gevonden onder {0}''s eiland"
+
+msgid "manage orphans"
+msgstr "beheer orphans"
+
+msgid "count orphans"
+msgstr "aantal orphans"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr ""
+"§e{0} oude eiland locatie zullen worden hergebruikt voordat een nieuw "
+"locatie word gekozen."
+
+msgid "clear orphans"
+msgstr "verwijder orphans"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eOpschonen van alle oude (lege) eiland locaties."
+
+msgid "list orphans"
+msgstr "orphan lijst"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eEr zijn geen orphans geregistreerd."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "leiderschap overdragen naar een andere speler"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4De speler {0} heeft geen eiland om over te dragen"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eDe speler §d{0}§e heeft al een eiland.§eGebruik §d/usb island remove "
+"<naam>§e eerst om hem/haar te verwijderen."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bEiland eigenaar overgedragen van {0}§b naar {1}"
+
+msgid "open GUI for config"
+msgstr "open de GUI voor de configuratie"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§eOngeldige configuratie naam"
+
+msgid "teleport to another players island"
+msgstr "Teleporteert naar een andere speler''s eiland"
+
+msgid "§4Only supported for players"
+msgstr "§4Alleen ondersteund voor spelers"
+
+msgid "§4That player does not have an island!"
+msgstr "§4Die speler heeft geen eiland."
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr "§aTeleporteren naar {0}''s eiland."
+
+msgid "various WorldGuard utilities"
+msgstr "diverse WorldGuard utilities"
+
+msgid "refreshes the chunks around the player"
+msgstr "herlaad de chunks rondom de speler"
+
+msgid "§eResending chunks to the client"
+msgstr "§eHersturen van de chunks naar de client"
+
+msgid "load the region chunks"
+msgstr "laad de regio chunks"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eHet laden van de chunks op {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eHet ontladen van de chunks op {0}"
+
+msgid "update the WG regions"
+msgstr "Bijwerken van de WG regio''s"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§eEiland world-guard regio is bijgewerkt voor {0}"
+
+msgid "§eNo island found at your location!"
+msgstr "§eEr is geen eiland gevonden op je locatie!"
+
+msgid "refreshes the chunk around the player"
+msgstr "verfrist de chunk rond de speler"
+
+msgid "region manipulations"
+msgstr "regio manipulaties"
+
+msgid "shows the borders of the current island"
+msgstr "toont de grens aan van het huidige eiland"
+
+msgid "§eNo island found at your current location"
+msgstr "§eEr is geen eiland op je huidige locatie"
+
+msgid "§eCan only be executed as a player"
+msgstr "§eKan alleen als speler worden uitgevoerd"
+
+msgid "shows the borders of the current chunk"
+msgstr "toont de grens aan van het huidige chunk"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "toont de grens aan van de binnenkant-chunks"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "toont de niet-chunk-align grenzen"
+
+msgid "shows the borders of the outer-chunks"
+msgstr "toont de grens aan van de buitenkant-chunks"
+
+msgid "hides the regions again"
+msgstr "verbergt de regio''s opnieuw"
+
+msgid "§eStopped displaying regions"
+msgstr "§eGestopt met het weergeven van de regio''s"
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§eEr worden geen regio''s weergegeven voor deze speler"
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§eAnimatie-tick veranderd naar {0}."
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§eAnimatie-tick moet een geldig geheel getal zijn."
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+"- PURGING: {0,number,##}% ({1}/{2}), verstreken {3}, Naar schatting "
+"voltooiing ~{4}"
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4PURGE:§9 Klaar met verwijderen van verlaten eilanden."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4PURGE:§9 Verweideren van verlaten eilanden is gestopped."
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§7- SCANNING: {0,number,##}% ({1}/{2} mislukt: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4PURGE:§9 Scanning gestopped."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§cAFGEBROKEN:§e Protect-All was gestopped!"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr "§eVolbracht protect-all in {0}, {1} nieuwe regio''s zijn gecreeerd!"
+
+msgid "control debugging"
+msgstr "debugging controle"
+
+msgid "set debug-level"
+msgstr "set debug-niveau"
+
+msgid "toggle debug-logging"
+msgstr "schakel debug-logging"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4Logging was niet actief, uitzetten is dus niet mogelijk!"
+
+msgid "flush current content of the logger to file."
+msgstr "leegt de huidige content van het log naar een bestand"
+
+msgid "§eLog-file has been flushed."
+msgstr "§eHet log-bestand is geleegd."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4Logging staat nog niet aan, gebruiken §d/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Ongeldig argument, probeer INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eLogging staat nu uit!"
+
+msgid "advanced command for setting island-data"
+msgstr "geavanceerde command voor het instellen van island-data"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§c{0} is gezet naar ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§cKan het veld {0} niet veranderen naar ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr ""
+"§cKan het veld {0} niet veranderen naar ''{1}'', een getal werd verwacht"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§cOngeldig veld {0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§eActuele waarde van {0} is ''{1}''"
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§cKan geen stand verkrijgen voor {0}"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§eGeldige velden zijn {0}"
+
+msgid "set a player''s island to your location"
+msgstr "zet een spelers eiland op mijn lokatie"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr "geavanceerde informatie over NBT materiaal"
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "toont de NBTTag voor het huidige vastgehouden item"
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§eInfo voor §9{0}"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - naam: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - nbttag: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§cJe hand is leeg!"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "zet de NBTTag voor het item in je hand"
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "§eZet §9{0}§e naar §c{1}"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "voegt de NBTTag toe op je huidig vastgehouden item"
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§eVoegt §9{0}§e aan §c{1}"
+
+msgid "Manage challenges for a player"
+msgstr "Beheer de uitdagingen voor een speler"
+
+msgid "resets the challenge for the player"
+msgstr "reset de uitdaging voor een speler"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4De uitdaging is nog nooit voltooid"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§euitdaging: {0} is gereset naar {1}"
+
+msgid "resets all challenges for the player"
+msgstr "reset alle uitdagingen voor een speler"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0} heeft al zijn uitdagingen laten resetten."
+
+msgid "complete all challenges in the rank"
+msgstr "voltooi alle uitdagingen in deze groep"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4De speler met de naam {0} kan niet worden gevonden!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4De {0} uitdaging is al voltooid"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§eDe {0} uitdaging is voltooid voor {1}"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4De uitdaging met de naam {0} kan niet worden gevonden!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4Geen rang genaamd {0} gevonden!"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "beschermd alle eilanden (dit kan veel tijd inbeslag nemen)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§cProberen om protect-all taak af te breken."
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4Sorry!§e Een protect-all is al bezig. Laat dit z'n gang gaan, of gebruik "
+"§9usb protectall §cstop"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§eBegin van de opdracht protect-all. Dit kan een tijdje gaan duren."
+
+msgid "reload configuration from file."
+msgstr "herladen van de configuratie van het bestand"
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eDe Configuratie is herladen"
+
+msgid "manage islands"
+msgstr "beheer de eilanden"
+
+msgid "protects the island"
+msgstr "bescherm het eiland"
+
+msgid "delete the island (removes the blocks)"
+msgstr "verwijder het eiland (dit verwijderd ook de blokken)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Het verlaten eiland op je huidige locatie is verwijderd."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4Het eiland op deze locatie heeft leden!\n"
+"§eGebruik §9/usb island delete <naam>§e om het eiland te verwijderen."
+
+msgid "removes the player from the island"
+msgstr "verwijderd de speler van het eiland"
+
+msgid "adds the player to the island"
+msgstr "voegt de speler toe aan het eiland"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d heeft zich aangesloten bij je eiland groep."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4Er is geen speler gevonden met de naam {0}!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+"§4Er is geen geldig eiland verstrekt, sta op een eiland, of geef een eiland "
+"naam"
+
+msgid "print out info about the island"
+msgstr "geeft informatie over het eiland"
+
+msgid "sets the biome of the island"
+msgstr "zet de biome van het eiland"
+
+msgid "§4That player has no island."
+msgstr "§4Die speler heeft geen eiland."
+
+msgid "§4No valid island at your location"
+msgstr "§4Er is geen geldig eiland op jouw locatie"
+
+msgid "purges the island"
+msgstr "verwijdert het eiland"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4Error! §9Er is geen geldig eiland gevonden om te verwijderen."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cVERWIJDER: §9Verwijderd eiland is op {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "het eiland op slot zetten."
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cZet {0}''s eiland op de negeerlijst van verwijderen en de top-tien."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cVerwijder de negeer-flag van {0}s eiland, het staat weer op de top-tien "
+"lijst en kan verwijderd worden."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Geen geldige speler-naam ingevoerd"
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "{0} is van het eiland verwijderd"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eDe biome van {0}s eiland is veranderd naar {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eDe biome van {0}s eiland is veranderd naar OCEAN."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr ""
+"§aJe moet reloggen of terug naar spawn gaan om de verandering te kunnen zien"
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} heeft zijn/haar biome veranderd naar {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} heeft zijn/haar biome veranderd naar OCEAN."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§e{0}''s eiland wordt verwijderd."
+
+msgid "Error: That player does not have an island!"
+msgstr "Error: Die speler heeft geen eiland!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§e{0}s eiland op {1} is nu beschermd"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4{0}s eiland op {1} is al beschermd"
+
+msgid "displays version information"
+msgstr "het weergeven van de versie-informatie"
+
+msgid "imports players and islands from other formats"
+msgstr "importeert spelers en eilanden van een ander formaat"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr "extra perks {0}"
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "verandert de taal van de plugin en herlaad"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aDe taal is met succes veranderd naar §e{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cHet is mislukt om de taal naar §e{0} te veranderen."
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Ondersteunde Talen:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 bij {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cKan geen talen vinden"
+
+msgid "advanced command for getting island-data"
+msgstr "geavanceerde commando voor het krijgen van island-data"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "laat speler-informatie zien"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4Je eiland is vol, of je hebt teveel uitnodigingen open staan. Je kunt "
+"niemand anders uitnodigen."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4Die speler is al eigenaar van een ander eiland.."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr ""
+"§e{0}§e probeerde je uit te nodigen, maar je bent al lid van een ander "
+"eiland."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr "§aUitnodiging gestuurd naar {0}"
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e heeft je uitgenodigd om lid te worden van zijn/haar eiland!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr ""
+"§f/island [accept/reject]§eom de uitnodiging te accepteren of te weigeren."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr ""
+"§4WAARSCHUWING: Je zult je eiland verliezen als je de uitnodiging accepteerd!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d uitgenodigd {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e heeft de uitnodiging geweigerd."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4je kunt dat command nu niet gebruiken. Verlaat eerst uw huidige party."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§aJe hebt je aangesloten bij een eiland! Gebruik /island party om alle "
+"andere leden te zien."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§eDe uitnodiging van {0}§e is verlopen of geannuleerd."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§eDe uitnodiging van {0}''s eiland  is verlopen of geannuleerd."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr ""
+"§eJe hebt een uitnodiging geaccepteerd om lid te worden van een eiland."
+
+msgid "§4You haven't been invited."
+msgstr "§4Je bent niet uitgenodigd."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eJe hebt de uitnodoging geannuleerd."
+
+msgid "general island command"
+msgstr "algemeen eiland command"
+
+msgid "allows user to bypass cooldowns"
+msgstr "laat de speler altijd cooldowns omzeilen"
+
+msgid "allows user to bypass visitor-protections"
+msgstr "laat de speler de bezoekers-beveiliging omzeilen"
+
+msgid "allows user to bypass teleport-delay"
+msgstr "laat de speler de teleport-vertraging omzeilen"
+
+msgid "allows user to use [usb] signs"
+msgstr "Hiermee kan de gebruiker [USB] borden gebruiken"
+
+msgid "allows user to place [usb] signs"
+msgstr "Hiermee kan de gebruiker [USB] borden te plaatsen"
+
+msgid "complete and list challenges"
+msgstr "compleet en vermelde uitdagingen"
+
+msgid "§cCommand only available for players."
+msgstr "§cCommando is alleen voor spelers."
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr ""
+"§eDe uidagingen zijn uitgeschakeld. Neem contact op met een administrator."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4Je kan alleen uitdaginged voltooien in de skyblock wereld!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4Je kan alleen uitdaginged voltooien als je een eiland hebt!"
+
+msgid "warp to another player''s island"
+msgstr "warp naar een andere speler''s eiland"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr "§aJe inkomende warp is actief, spelers kunnen naar je eiland warpen."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§4Je inkomende warp is niet actief, spelers kunnen niet naar je eiland "
+"warpen."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr "§fSet je inkomende warp op je huidige lokatie met §e/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§fSchakel je warp aan/uit met §e/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4Je hebt geen permissie om een warp te creeren op je eiland!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§fWarp naar een ander eiland met gebruik van §e/island warp <speler>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4Je hebt geen permissie om naar andere eilanden te warpen!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cJe eiland is in het proces van het genereren, je kan op moment niet naar "
+"andere eilanden warpen."
+
+msgid "§4That player does not exist!"
+msgstr "§4Die speler bestaat niet!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4Die speler heeft geen actieve warp"
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§cDie spelers eiland is in de proces van genereren, daar kan je nu niet "
+"naartoe warpen."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cLET OP: §9{0}§e warped naar je eiland!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4Die speler heeft je verboden om naar zijn eiland te warpen"
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4Geen eiland. §eGebruik §b/is create§e om er een te maken"
+
+msgid "accept/reject an invitation."
+msgstr "accepteren/weiger een uitnodiging."
+
+msgid "leave your party"
+msgstr "verlaat je party"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4je kan het eiland niet verlaten als de enigste op dat eiland bent. Gebruik "
+"het command /island restart als je opnieuw wilt beginnen!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§eDit is jouw eiland, gebruik /island remove <speler> inplaats"
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr ""
+"§eJe hebt het eiland verlaten en wordt terug geplaatst op de spelers spawn."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0} heeft je eiland verlaten"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4Je moet in de skyblock wereld zijn om je party te verlaten!"
+
+msgid "check your or anothers island level"
+msgstr "Controleer je eigen of iemand anders z'n eiland niveau"
+
+msgid "allows user to query for others levels"
+msgstr "laat de speler andere spelers levels opvragen"
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eJe moet op je eiland zijn om dit commando te kunnen uitvoeren"
+
+msgid "§4You do not have an island!"
+msgstr "§4Je hebt geen eiland!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4Je hebt geen toegang tot dit commando!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4Die speler is ongeldig of heeft geen eiland!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eInformatie over {0}''s Eiland"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aEiland niveau is {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9Rank is {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "Creeer een eiland"
+
+msgid "exempt player from create-cooldown"
+msgstr "stelt speller vrij van create-cooldown"
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4Er is een eiland gevonden!§e Je heeft al een eiland. Als je een nieuw "
+"eiland wilt, type §b/is restart §eom opnieuw te beginnen"
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4Er is een eiland gevonden!§e Je bent al lid van een eiland. Om je eigen "
+"eiland te beginnen moet je eerst §b /is leave command doen."
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eJe kunt een nieuw eiland aanmaken in {0,number,#}  seconden."
+
+msgid "invite a player to your island"
+msgstr "nodig een speler uit naar je eiland"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§eGebruik§f /island invite <spelersnaam>§e om een speler uittenodigen naar "
+"uw eiland."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4Alleen de eiland eigenaar kan spelers uitnodigen!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aJe kan nog {0} speler(s) uitnodigen"
+
+msgid "§4You can't invite any more players."
+msgstr "§4Je kan geen spelers meer uitnodigen"
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4Je hebt geen toestemming om andere spelers uit te nodigen!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4Die speller bestaat niet of is offline."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4Je kan jezelf niet uitnodigen!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4Die speler is de leider van je eiland!"
+
+msgid "lock your island to non-party members."
+msgstr "sluit het eiland af voor niet-party leden"
+
+msgid "§4You do not have permission to lock your island!"
+msgstr ""
+"§4Je hebt geen toestemming om je eiland af te sluiten voor andere spelers!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4Je hebt geen toegang tot dit commando!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4Je hebt geen toestemming om je eiland te openen voor andere spelers!"
+
+msgid "display the top10 of islands"
+msgstr "laat de top 10 van alle eilanden zien"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr ""
+"Laat een speler altijd het opnieuw genereren van de top-ten (no caching)"
+
+msgid "remove a member from your island."
+msgstr "verwijder een speler van je eiland."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr ""
+"§4Je hebt geen toestemming om andere spelers van dit eiland te verwijderen!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4Je kan de leider niet van een eiland verwijderen!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4Je kan jezelf niet verwijderen!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0} heeft je verwijderd van zijn eiland."
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} is verwijderd van het eiland."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4{0} probeerde je van z'n eiland te vewijderen!"
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4{0} kan niet verwijderd worden."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4{0} heeft je van z'n eiland verwijderd!"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0} is verwijderd van het eiland."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr ""
+"§4Die speller is niet op je eiland en behoord niet tot je eiland groep,"
+
+msgid "teleport to the island home"
+msgstr "telepoort naar je eiland "
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§cJe eiland is in het proces van het genereren, je kan nu niet naar je home "
+"lokatie teleporteren."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4Dit commando kan alleen gebruikt worden door een speler"
+
+msgid "transfer leadership to another member"
+msgstr "overdragen van de leiding naar een ander lid"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4Je kan alleen de leiding overdragen naar een party-lid!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e Is al de leider van je eiland!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4Alleen de leider kan het leiderschap overdragen!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} heeft geprobeerd het eiland over te nemen!"
+
+msgid "show party information"
+msgstr "laat party informatie zien"
+
+msgid "shows information about your party"
+msgstr "laat informatie zien over je party"
+
+msgid "show pending invites"
+msgstr "laat lopende uitnodigingen zien"
+
+msgid "§eNo pending invites"
+msgstr "§eGeen lopende uitnodigingen"
+
+msgid "withdraw an invite"
+msgstr "uitnodiging terugtrekken"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4Je hebt geen permissie om uitnodigingen in te trekken."
+
+msgid "check your or another''s island info"
+msgstr "controleer jouw of iemand anders z'n eiland informatie"
+
+msgid "allows user to see others island info"
+msgstr "Laat de gebruiker anderen eiland info zien"
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBlokken op {0}s Eiland (pagina  {1,number} of {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Score van het aantal blokken"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "vertrouw/wantrouw een speler om je te helpen op je eiland."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eDe volgende spelers zijn vertrouwd op je eiland:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eJe bent vetrouwd door de volgende leiders:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr ""
+"§eOm spelers te vertrouwen/wantrouwen op je eiland, gebruik dan /island "
+"trust <speler> of /island untrust <speler>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4Leden die al vertrouwd zijn!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Onbekende speler {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eJe bent nu vertrouwed op §4{0}''s §eeiland."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} vertrouwd {1} op het eiland"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eJe bent niet meer vertrouwd op §4{0}''s §eeiland."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0} heeft het vertouwen afgenomen van {1} op het eiland."
+
+msgid "delete your island and start a new one."
+msgstr "verwijder je eiland en start een nieuwe."
+
+msgid "exempt player from restart-cooldown"
+msgstr "stelt de speler vrij van herstart-cooldown"
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4Alleen de eiland eigenaar mag het eiland opnieuw starten. Verlaat dit "
+"eiland om je eigen eiland te beginnen (/island leave)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eJe moet alle spelers verwijderen voordat je je eiland opnieuw kan starten "
+"(/island kick <player>). Bekijk een lijst met huidige spelers op je eiland "
+"door gebruik te maken van /island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§eJe kunt een nieuw eiland aanmaken in {0} seconden."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr "§cJe eiland is in het verloop van het genereren, kan je nu herstarten."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§eLET OP: Je gehele eiland en je belangen worden VERWIJDERD!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "telepoort je naar de skyblock spawn"
+
+msgid "change the biome of the island"
+msgstr "verander de biome van het eiland"
+
+msgid "exempt player from biome-cooldown"
+msgstr "Stelt speller vrij van biome-cooldown"
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr "Laat de speller zijn biome veranderen naar {0}"
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr ""
+"§cje hebt geen toestemming om de biome te veranderen op uw huidige eiland."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4Je hebt geen toestemming om de biome te veranderen van dit eiland!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eJe moet op je eiland zijn om de biome te veranderen!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr "§cJe hebt de biome verkeert gespeld. Het moet een van deze {0} zijn"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eJe kunt je biome weer veranderen in {0,number,#} minuten."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§cJe hebt geen toestemming om de biome te veranderen van dit eiland!"
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+"§7De Pixies zijn bezig met het veranderen van de biome bij jou naar §9{0}§7, "
+"heb geduld."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr "§eOngeldige biome {0} ingevoerd!"
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aJe hebt je eiland biome veranderd naar {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} heeft het eiland biome veranderd naar {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr "§aJe hebt {0} blokken veranderd naar de {1} biome"
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr "{0} creëerde een gebied met {1} biome"
+
+msgid "set your island''s warp location"
+msgstr "set de warp lokatie van je eiland"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cje hebt geen toestemming om je warp lokatie te zetten op je eiland!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§cJe moet op je eigen eiland zijn om de warp lokatie te zetten!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d heeft de warp lokatie verzet."
+
+msgid "teleports you to your island (or create one)"
+msgstr "teleporteert je naar je eiland (of maakt er een aan)"
+
+msgid "ban/unban a player from your island."
+msgstr "ban/unban een speler van uw eiland."
+
+msgid "exempts user from being banned"
+msgstr "stelt de speler vrij van verbannen"
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§eDe volgende spelers zijn geblokkeert om naar uw eiland te warpen:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr ""
+"§eOm een speler te bannen/unbannen van je eiland, gebruik /island ban "
+"<speler>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4Je kunt geen leden verbannen. Verwijder ze eerst van de party!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4Je hebt geen toestemming om leden te verweideren of te verbannen."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§eKan geen onbekende speller verbannen{0}"
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4{0} probeerde je van z'n eiland te verbannen"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4{0} kan niet worden verbannen"
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eJe hebt §4{0}§e verbannen om naar uw eiland te warpen."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eJe bent §cVERBANNEN §e van {0}§e''s eiland."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§eJe hebt §a{0}§e toegang gegeven om weer naar uw eiland te warpen."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eJe bent §aONTBANNED§e van {0}§e''s ieland."
+
+msgid "display log"
+msgstr "weergave log"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "set de thuis-lokatie"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "zet de warping aan/uit naar je eiland"
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4Je eiland is gesloten. Je moet het eerst ongrendelen voordat je de warp "
+"kan aanzetten."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d heeft het eiland warp geactiveerd."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr "§cJe hebt geen toestemming om je eiland warp aan/uit te zetten!"
+
+msgid "try to complete a challenge"
+msgstr "probeer om een uitdaging the voltooien"
+
+msgid "show information about the challenge"
+msgstr "laat de informative zien van een uitdaging"
+
+msgid "§eRank: "
+msgstr "§eRank:"
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4Deze uitdaging kan niet herhaald worden!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr "§4Je verliest alle benodigde items wanneer je deze uitdaging voltooid!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4Alle benodigde items moeten op je eiland geplaatst zijn, binnen een bereik "
+"van {0} bij jouw vandaan."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§eOm deze uitdaging te voltooien, gebruik  §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr ""
+"§4De uitdagings naam is ongeldig! Gebruik / c help voor meer informatie"
+
+msgid "§eSending you to spawn."
+msgstr "§eJe wordt naar spawn gestuurd."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§eHet eiland is §cAFGESLOTEN§e."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4Niet in staat om een veilig thuis-lokatie te vinden op je eiland!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§cWAARSCHUWING: §eJe wordt in ergens in de lucht geteleporteerd."
+
+msgid "§aTeleporting you to your island."
+msgstr "§aJe word getelepoorteerd naar je eiland."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aJe zal in {0} seconden getelepoorteerd worden."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Je kan niet naar die spelers eiland warpen!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aTeleporteren naar {0}''s eiland."
+
+msgid "§7Teleport cancelled"
+msgstr "§7Telepoort geannuleerd "

--- a/uSkyBlock-Core/src/main/po/pt_BR.po
+++ b/uSkyBlock-Core/src/main/po/pt_BR.po
@@ -16,12 +16,45 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 1.8.4\n"
 
+msgid "d"
+msgstr "d"
+
+msgid "h"
+msgstr "h"
+
+msgid "m"
+msgstr "m"
+
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}"
+msgstr ""
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr ""
 
 #, java-format
 msgid "§eInvalid command: {0}"
+msgstr ""
+
+msgid "Command"
+msgstr ""
+
+msgid "Permission"
+msgstr ""
+
+msgid "Description"
 msgstr ""
 
 #, java-format
@@ -47,1671 +80,11 @@ msgstr ""
 msgid "§4Error writing documentation: {0}"
 msgstr ""
 
-msgid "Command"
+msgid "§cWither Despawned!§e It wandered too far from your island."
 msgstr ""
 
-msgid "Permission"
-msgstr ""
-
-msgid "Description"
-msgstr ""
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}"
-msgstr ""
-
-msgid "d"
-msgstr "d"
-
-msgid "h"
-msgstr "h"
-
-msgid "m"
-msgstr "m"
-
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eMantenha os seguintes blocos por perto: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4Requisitos irão resetar em {0} dias."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4Requisitos irão resetar em {0} horas."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4Requisitos irão resetar em {0} minutos."
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr ""
-
-msgid "§7and more..."
-msgstr ""
-
-msgid "§eItems will be traded for reward."
-msgstr ""
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr ""
-
-msgid "§6Item Reward: §a"
-msgstr "§6Prêmio em item: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Prêmio em dinheiro: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Prêmio em XP: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dTotal de vezes completado: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4Nenhum desafio com o nome {0} foi encontrado!"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4Você precisa estar na sua ilha para fazer isso!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr ""
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4O desafio {0} não pode ser repetido!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§eTentando completar o desafio §a{0}"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr "§4Você precisa estar ao menos {0} blocos dos items necessários. "
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4Sua ilha precisa estar no nível {0} para completar esse desafio!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Tipo de desafio desconhecido: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§eMantenha os seguintes items por perto:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr ""
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eVocê deve ter os seguintes items perto: {0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aVocê completou o desafio {0}!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9{0}§f completou o desafio §9{1}§f!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§ePrêmio em item: §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§ePrêmio em XP: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§ePrêmio em dinheiro:f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eSeu inventário está §4cheio§e. Items cairam no chão."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lClique para completar esse desafio."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lVocê não pode repetir esse desafio."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Categoria: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fComplete mais desafios nessa"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fcategoria, para liberar a próxima."
-
-msgid "§eClick here to show previous page"
-msgstr "§e§lClique aqui para ver a página anterior"
-
-msgid "§eClick here to show next page"
-msgstr "§e§lClique aqui para ver a próxima página"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lDesafio bloqueado"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr ""
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Complete {0}"
-
-msgid "to unlock this rank"
-msgstr "para desbloquear essa categoria"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "Você está sozinho na sua ilha."
-
-msgid "But you are Yelling in the wind!"
-msgstr "Não tem mais ninguém na sua ilha."
-
-msgid "But your fantasy friends are gone!"
-msgstr "Seus amigos sumiram!"
-
-msgid "But you are Talking to your self!"
-msgstr "Por que você está falando sozinho?"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cDesculpe! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr ""
-
-msgid "party"
-msgstr ""
-
-msgid "island"
-msgstr ""
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr ""
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr ""
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr ""
-
-msgid "§cCommand only available to players"
-msgstr ""
-
-msgid "talk to players on your island"
-msgstr "falar com jogadores na sua ilha"
-
-msgid "talk to your island party"
-msgstr "falar com jogadores no seu grupo"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§eJogador {0} não tem uma ilha!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eJogador  {0}  é inválido."
-
-msgid "Manage challenges for a player"
-msgstr "Gerenciar desafios para um jogador"
-
-msgid "resets the challenge for the player"
-msgstr "redefinir o desafio para o jogador"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4Desafio nunca foi concluído"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§edesafio: {0} foi resetado por {1}"
-
-msgid "resets all challenges for the player"
-msgstr "resetar todos os desafios do jogador"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0}  teve todos os desafios resetados."
-
-msgid "complete all challenges in the rank"
-msgstr ""
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4Não foi encontrado nenhum jogador com o nome {0}"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr ""
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4Desafio {0} não foi encontrado!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr ""
-
-msgid "manage islands"
-msgstr "controle de ilhas"
-
-msgid "protects the island"
-msgstr "proteger a ilha"
-
-msgid "delete the island (removes the blocks)"
-msgstr "deletar a ilha (remover os blocos)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Ilha abandonada na sua localização foi excluída."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4A ilha nessa localização tem membros!\n"
-"§eUse §9/usb island delete <nome>§e para remover."
-
-msgid "removes the player from the island"
-msgstr "remover o jogador da ilha"
-
-msgid "adds the player to the island"
-msgstr "adicionar o jogador a ilha"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d entrou no grupo da ilha."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4Nenhum jogador com o nome {0} encontrado!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr "§4Ilha inválida, mantenha-se dentro de uma ou dê o nome dela"
-
-msgid "print out info about the island"
-msgstr "print out informações sobre a ilha"
-
-msgid "sets the biome of the island"
-msgstr "definir o bioma da ilha"
-
-msgid "§4That player has no island."
-msgstr "§4Esse jogador não tem uma ilha."
-
-msgid "§4No valid island at your location"
-msgstr "§4Não tem uma ilha válida na sua localização"
-
-msgid "purges the island"
-msgstr "purgar a ilha"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Erro! §9Nenhuma ilha válida para o purge foi encontrada."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cPURGE: §9Ilha em {0} foi purgada."
-
-msgid "toggles the islands ignore status"
-msgstr "alterar o status de ignorado da ilha"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cIgnorar a ilha de {0} no top 10 e no purge."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§cA ilha de {0} não é mais ignorada, agora você pode ver ela no purge e no "
-"top 10."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Nome fornecido é inválido."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Removendo {0} da ilha"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eAlterado o bioma da ilha de {0} para {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eAlterado o bioma da ilha de {0} para OCEANO."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr "§aVocê precisa ir ao spawn ou reconectar para ver as alterações."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} teve o seu bioma alterado para {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} teve o seu bioma alterado para OCEANO."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eRemovendo a ilha de {0}."
-
-msgid "Error: That player does not have an island!"
-msgstr "Erro: Esse jogador não tem uma ilha!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§eA ilha de {0} em {1} foi protegida"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4A ilha de {0} em {1} já foi protegida"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "abrir menu de configuração"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr ""
-
-msgid "Controls player-cooldowns"
-msgstr "Controlar player-cooldowns"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "limpar o cooldown em um comando (* = todos)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eEsse jogador não está online"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Limpo cooldown em {0} para {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Nenhum cooldown em {0} para {1} detectado!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Comando fornecido é inválido, apenas restart e biome é suportado!"
-
-msgid "restarts the cooldown on the command"
-msgstr "reinicia o cooldown no comando"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eResetar cooldown em {0} para {1}§e por {2} segundos"
-
-msgid "lists all the active cooldowns"
-msgstr "listar todos os cooldowns ativos"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCmd Cooldown"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eNenhum cooldown ativo para §9{0}§e encontrado."
-
-msgid "control debugging"
-msgstr "controlar debugging"
-
-msgid "set debug-level"
-msgstr "definir debug-level"
-
-msgid "toggle debug-logging"
-msgstr "alterar debug-logging"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4Logging não está ativado, você não pode desativá-lo."
-
-msgid "flush current content of the logger to file."
-msgstr "colocar o atual log em um arquivo."
-
-msgid "§eLog-file has been flushed."
-msgstr "§eLog-file foi liberado."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4Logging não está ativado, use §d/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Argumento inválido, tente INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eLogging desativado!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "tentar reparar a área de flatland."
-
-msgid "§4No valid island found"
-msgstr "§4Não foi encontrado uma ilha válida."
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4Não foi encontrado flatland na ilha de {0}!"
-
-msgid "flushes all caches to files"
-msgstr "envia todos os caches para arquivos"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr "§eEnviados §a{0} ilhas§e, §b{1} jogadores e §6{2} desafios completos."
-
-msgid "manually update the top 10 list"
-msgstr "atualizar lista top 10 manualmente"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eGerando a lista top dez"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eA lista top dez foi gerada"
-
-msgid "advanced command for getting island-data"
-msgstr ""
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr ""
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr ""
-
-msgid "teleport to another players island"
-msgstr "teletransportar para a ilha de outros jogadores"
-
-msgid "§4Only supported for players"
-msgstr "§4Apenas suportado para jogadores"
-
-msgid "§4That player does not have an island!"
-msgstr "§4Esse jogador não tem uma ilha!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr ""
-
-msgid "imports players and islands from other formats"
-msgstr "importar jogadores e ilhas de outros formatos"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Informações de trabalho"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/job"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "act"
-
-msgid "time"
-msgstr "tempo"
-
-msgid "name"
-msgstr "nome"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "altera a linguagem do plugin e recarrega"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aLinguagem alterada para §e{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cOcorreu um erro ao alterar a linguagem para §e{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Linguagens disponíveis:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 por {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cNão foi possível localizar nenhuma linguagem."
-
-msgid "transfer leadership to another player"
-msgstr "transferir a liderança para outro jogador"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4Jogador {0} não tem uma ilha para transferir!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§eJogador §d{0}§e já tem uma ilha.§eUse §d/usb island remove <nome>§e para "
-"remover ela primeiro."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bPoder de líder transferido de {0}§b para {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr ""
-
-msgid "shows the NBTTag for the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr ""
-
-msgid "§cNo item in hand!"
-msgstr ""
-
-msgid "§eCan only be executed as a player"
-msgstr ""
-
-msgid "sets the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "adds the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "manage orphans"
-msgstr "gerenciar orphans"
-
-msgid "count orphans"
-msgstr "contar orphans"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr ""
-"§e{0} Localizações de ilhas antigas serão usadas antes de criar uma nova."
-
-msgid "clear orphans"
-msgstr "limpar orphans"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eLimpando todas as antigas (vazias) localizações de ilhas."
-
-msgid "list orphans"
-msgstr "mostrar orphans"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eNenhum orphan registrado atualmente."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr ""
-
-msgid "protects all islands (time consuming)"
-msgstr "proteger todas as ilhas (consome tempo)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr ""
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§eIniciando o protect-all. Isso pode levar algum tempo."
-
-msgid "purges all abandoned islands"
-msgstr "purgar todas as ilhas abandonadas"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4Você precisa fornecer a idade em dias para o purge!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr ""
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr ""
-
-msgid "region manipulations"
-msgstr ""
-
-msgid "shows the borders of the current island"
-msgstr ""
-
-msgid "§eNo island found at your current location"
-msgstr ""
-
-msgid "shows the borders of the current chunk"
-msgstr ""
-
-msgid "shows the borders of the inner-chunks"
-msgstr ""
-
-msgid "shows the non-chunk-aligned borders"
-msgstr ""
-
-msgid "shows the borders of the outer-chunks"
-msgstr ""
-
-msgid "hides the regions again"
-msgstr ""
-
-msgid "§eStopped displaying regions"
-msgstr ""
-
-msgid "§eNo currently shown regions for this player"
-msgstr ""
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr ""
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr ""
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "definir a ilha do jogador para a sua localização"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "recarregar configuração do arquivo."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eConfigurações  recarregadas."
-
-msgid "advanced command for setting island-data"
-msgstr ""
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr ""
-
-msgid "toggles maintenance mode"
-msgstr ""
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr ""
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr ""
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr ""
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr ""
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4PURGE:§9 Terminou o processo de purge em ilhas abandonadas."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr ""
-
-msgid "displays version information"
-msgstr "mostrar informações da versão"
-
-msgid "various WorldGuard utilities"
-msgstr "various WorldGuard utilities"
-
-msgid "refreshes the chunks around the player"
-msgstr "recarregar os chunks perto do jogador"
-
-msgid "§eResending chunks to the client"
-msgstr "§eReenviando chuncks para o client"
-
-msgid "load the region chunks"
-msgstr "carregar region chunks"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eCarregando chunks em {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eRemovendo chunks em {0}"
-
-msgid "update the WG regions"
-msgstr ""
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr ""
-
-msgid "§eNo island found at your location!"
-msgstr ""
-
-msgid "refreshes the chunk around the player"
-msgstr ""
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "mostrar informações do jogador"
-
-msgid "try to complete a challenge"
-msgstr ""
-
-msgid "§cCommand only available for players."
-msgstr ""
-
-msgid "show information about the challenge"
-msgstr ""
-
-msgid "§eRank: "
-msgstr "§eCategoria: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4Esse desafio não pode ser repetido!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr ""
-"§4Você irá perder todos os items necessários quando completar esse desafio!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4Todos os items necessários devem ser colocados na sua ilha, com até {0} "
-"blocos de distância de você."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§ePara completar esse desafio, use §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4Nome de desafio inválido! Use /c help para mais informações"
-
-msgid "complete and list challenges"
-msgstr ""
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eDesafios estão desabilitados. Contate a um administrador."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4Você só pode completar desafios na sua ilha!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4Você só pode completar desafios se tiver uma ilha!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4Sua ilha está cheia, ou você tem muitos convites pendentes. Você não pode "
-"convidar ninguém no momento."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4Esse jogador é líder de outra ilha."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e tentou te convidar, mas você já faz parte de um grupo."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e te convidou para juntar-se a ilha dele!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§f/island [accept/reject§e para aceitar ou rejeitar um convite."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4AVISO: Você vai perder sua ilha atual se você aceitar!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d convidou {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e rejeitou o convite."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4Você não pode usar esse comando agora. Saia do seu grupo atual primeiro."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§aVocê entrou em uma ilha! Use /island party para ver os outros membros."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§dConvite para {0}§e excedeu o tempo limite ou foi cancelado."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§eConvite enviado para {0}§e excedeu o tempo limite ou foi cancelado."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§eVocê aceitou o convite para entrar em uma ilha."
-
-msgid "§4You haven't been invited."
-msgstr "§4Você não foi convidado."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eVocê rejeitou o convite para entrar na ilha."
-
-msgid "accept/reject an invitation."
-msgstr "aceitar/rejeitar um convite."
-
-msgid "teleports you to your island (or create one)"
-msgstr ""
-
-msgid "ban/unban a player from your island."
-msgstr "banir/desbanir um jogador da sua ilha."
-
-msgid "exempts user from being banned"
-msgstr ""
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr ""
-"§eOs seguintes jogadores estão proibidos de teletransportar até sua ilha:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr ""
-"§ePara banir/desbanir um jogador da sua ilha, use /island ban <jogador>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4Você não pode banir membros. Expulse-os primeiro!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4Você não tem permissão para expulsar/banir jogadores do grupo."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr ""
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr ""
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eVocê proibiu §4{0} de teletransportar até sua ilha."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eVocê foi §cBANIDO§e da ilha de {0}."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§eAgora {0} pode teletransportar até sua ilha."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eVocê foi §aDESBANIDO§e da ilha de {0}."
-
-msgid "change the biome of the island"
-msgstr "alterar o bioma da ilha"
-
-msgid "exempt player from biome-cooldown"
-msgstr ""
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr ""
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr "§cVocê não tem permissão para alterar o bioma da ilha."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4Você não tem permissão para alterar o bioma da ilha!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eVocê deve estar na sua ilha para alterar o bioma!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr ""
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eVocê pode alterar o bioma novamente em {0,number,#} minutos."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cVocê não tem permissão para alterar o bioma da ilha para esse tipo."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr ""
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aVocê alterou o bioma da ilha para {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} alterou o bioma da ilha para {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr ""
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr ""
-
-msgid "create an island"
-msgstr "criar uma ilha"
-
-msgid "exempt player from create-cooldown"
-msgstr ""
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4Você já tem uma ilha!§e Caso você queira uma nova, use §b/is restart."
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4Você faz parte de um grupo. Para criar sua própria ilha primeiro use §b/is "
-"leave."
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eVocê pode criar uma nova ilha em {0,number,#} segundos."
-
-msgid "teleport to the island home"
-msgstr "teletransportar para a ilha"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§cSua ilha está em processo de criação, você não pode ir até sua ilha agora."
-
-msgid "check your or another''s island info"
-msgstr "verificar informações da sua ilha ou de outros jogadores"
-
-msgid "allows user to see others island info"
-msgstr ""
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr ""
-"§4Nível de ilha está desativado, entre em contato com um administrador."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eVocê precisa estar na sua ilha para usar esse comando."
-
-msgid "§4You do not have an island!"
-msgstr "§4Você não tem uma ilha!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4Você não tem acesso a esse comando!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4Esse jogador é inválido ou não tem uma ilha!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBlocos na ilha de {0} (pagina {1,number} de {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Pontos por bloco"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aNível: {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "convidar um jogador para sua ilha"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§eUse §f/island invite <nomedojogador>§e para convidá-lo para sua ilha."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4Apenas o dono da ilha pode convidar alguém!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aVocê pode convidar mais {0} jogadores. "
-
-msgid "§4You can't invite any more players."
-msgstr "§4Você não pode convidar mais jogadores."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4Você não tem permissão para convidar outro jogadores para a ilha!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4Esse jogador está offline ou não existe."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4Você não pode convidar você mesmo!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4Esse jogador é o líder da sua ilha!"
-
-msgid "remove a member from your island."
-msgstr "expulsar um jogador da sua ilha"
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4Você não tem permissão para expulsar jogadores dessa ilha!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4Você não pode expulsar o líder da ilha!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4Você não pode expulsar você mesmo!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0} te expulsou da ilha dele!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} foi removido da ilha."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr ""
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0} foi expulso da ilha."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr "§4Esse jogador não faz parte do seu grupo e não está na sua ilha!"
-
-msgid "leave your party"
-msgstr "sair do seu grupo"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4Você não pode sair da ilha, você é a única pessoa nela. Tente usar /island "
-"restart se você quiser uma nova!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§eVocê é dono dessa ilha, use /island remove <jogador>."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eVocê saiu da ilha e foi levado ao spawn."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0} saiu da ilha!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4Você deve estar na sua ilha para sair do seu grupo!"
-
-msgid "check your or anothers island level"
-msgstr "verificar informações do nível da sua ilha ou de outros jogadores"
-
-msgid "allows user to query for others levels"
-msgstr ""
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eInformações sobre a ilha de {0}':"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9Categoria: {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "trancar sua ilha para jogadores fora do seu grupo."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4Você não tem permissão para trancar a ilha!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4Você não tem acesso a esse comando!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4Você não tem permissão para destrancar a ilha!"
-
-msgid "display log"
-msgstr "verificar histórico"
-
-msgid "transfer leadership to another member"
-msgstr "transferir liderança para outro membro"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4Você só pode transferir a liderança para membros da ilha!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e já é o lider da ilha!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4Apenas o líder pode transferir a liderança!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} tentou roubar a ilha!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "mostrar informações do grupo"
-
-msgid "shows information about your party"
-msgstr "mostrar informações sobre o seu grupo"
-
-msgid "show pending invites"
-msgstr "mostrar convites pendentes"
-
-msgid "§eNo pending invites"
-msgstr "§eNenhum convite pendente"
-
-msgid "withdraw an invite"
-msgstr "remover um convite"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4Você não tem permissão para expulsar de jogadores."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4Esse comando só pode ser executado por um jogador"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4Você não tem uma ilha.§e Use §b/is create§e para criar uma"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "deletar sua ilha e iniciar uma nova."
-
-msgid "exempt player from restart-cooldown"
-msgstr ""
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4Apenas o dono da ilha pode reiniciar. Saia do seu grupo atual para criar "
-"uma ilha.(/island leave)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eVocê precisa remover todos os jogadores da ilha antes de reinicia-lá. (/"
-"island kick <jogador>). Veja uma lista com os jogadores do seu grupo usando "
-"island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§cVocê pode reiniciar a ilha em {0} segundos."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§cSua ilha está em processo de criação, você não pode resetar agora."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eNOTA: Toda a sua ilha e todos os seus pertences serão resetados!"
-
-msgid "set the island-home"
-msgstr "definir o ponto de spawn da ilha"
-
-msgid "set your island''s warp location"
-msgstr "definir o ponto de warp da ilha"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cVocê não tem permissão para definir o ponto de warp!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§cVocê precisa estar na sua ilha para definir o warp!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d alterou o ponto de warp da ilha."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "teletransportar você para o spawn do skyblock"
-
-msgid "enable/disable warping to your island."
-msgstr "ativar/desativar o warp até sua ilha."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4Sua ilha está trancada. Você deve destranca-lá antes de ativar o warp."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d ativou o warp da ilha."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d desativou o warp da ilha."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr "§cVocê não tem permissão para ativar/desativar o warp da ilha!"
-
-msgid "display the top10 of islands"
-msgstr "mostrar o top10 das ilhas"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr ""
-
-msgid "trust/untrust a player to help on your island."
-msgstr "confiar/remover confiança de um jogador para ajudar na sua ilha."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eOs seguintes jogadores são confiáveis na sua ilha:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eOs seguintes líderes confiam em você:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr ""
-"§ePara confiar/remover confiança de alguém na sua ilha, use /island trust "
-"<jogador>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4Membros já são confiáveis!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Jogador desconhecido {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eVocê agora é confiável na ilha de §4{0}."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} confiou {1} na ilha"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eVocê não é mais confiável na ilha de §4{0}."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0} removeu a confiança de {1} na ilha"
-
-msgid "warp to another player''s island"
-msgstr "warp para ilha de outro jogador"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr ""
-"§aO warp até ilha está ativo, outros jogadores podem visitar a sua ilha."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§4O warp da ilha está inátivo, outros jogares não podem ir até sua ilha."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr ""
-"§fDefina o ponto de warp para sua localização atual usando §e/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr ""
-"§fEscolha o warp da ilha entre ativado/desativado usando §e/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4Você não tem permissão para criar um warp para sua ilha!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§fWarp para outra ilha usando §e/island warp <jogador>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4Você não tem permissão para teletransportar até outras ilhas."
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§cSua ilha está em processo de criação, você não pode usar warp até outras "
-"ilhas agora."
-
-msgid "§4That player does not exist!"
-msgstr "§4Esse jogador não existe!"
-
-msgid "§4That player does not have an active warp."
-msgstr ""
-"§4Esse jogador não tem um ponto de warp definido ou o warp está desativado."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§cA ilha do jogador está em processo de criação, você não pode usar warp até "
-"lá agora."
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cAVISO: §9{0}§e usou warp até a sua ilha!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4Esse jogador proibiu você de teletransportar até a ilha dele."
-
-msgid "general island command"
-msgstr "comandos geral da ilha"
-
-msgid "allows user to bypass cooldowns"
-msgstr ""
-
-msgid "allows user to bypass visitor-protections"
-msgstr ""
-
-msgid "allows user to bypass teleport-delay"
-msgstr ""
-
-msgid "allows user to use [usb] signs"
-msgstr ""
-
-msgid "allows user to place [usb] signs"
+msgid "{0}''s Wither"
 msgstr ""
 
 msgid "§eYou can not use another island''s portals!"
@@ -1728,34 +101,6 @@ msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr ""
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr ""
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eVisitantes não podem dropar items!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Dono: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr ""
-"Você não pode pegar items de outros jogadores em quanto você é um visitante!"
-
-msgid "Config:"
-msgstr "Configuração:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§cSem acesso! §eVocê está tentando se teletransportar para o topo do "
-"§cNETHER§e, isso não é permitido."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr ""
@@ -1799,19 +144,82 @@ msgstr "§eVocê só pode usar spawn-eggs na sua ilha."
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§cVocê chegou no limite de spawn na sua ilha."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eVisitantes não podem dropar items!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Dono: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr ""
+"Você não pode pegar items de outros jogadores em quanto você é um visitante!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cBanido:§e Você está banido dessa ilha."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cTrancado:§e Essa ilha está trancada! Entrada não é permitida."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eEsperando por nosso turno §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "Algo ocorreu mal ao salvar a ilha e informações do grupo!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr ""
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr ""
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Criando ilha...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr ""
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr ""
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4Jogador já faz parte dessa ilha!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4Você deve estar mais perto da sua ilha para definir a home!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aSua home foi definida na sua localização atual."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4Sua localização atual não é segura."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr "§cSua ilha está sendo processada, você não pode criar agora."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "Não foi possível criar sua ilha. Por favor contate a um administrador."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+"§eGerando nova ilha, por favor seja paciente, isso pode levar alguns minutos."
+
+msgid "§cCommand is currently disabled!"
+msgstr ""
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eMantenha os seguintes blocos por perto: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1824,9 +232,6 @@ msgid ""
 msgstr ""
 "§4CUIDADO: §aUsar{0}§ é perigoso. Repita esse comando dentro de §a{1}§e "
 "segundos para confirmar!"
-
-msgid "N/A"
-msgstr ""
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** Você está entrando em uma ilha protegida porém abandonada."
@@ -1859,207 +264,32 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4Você deve ser o líder para destrancar a ilha!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eEsperando por nosso turno §c{0,number,###}%"
+
+#, java-format
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Criando ilha...§e{0,number,###}%"
+
+msgid "N/A"
+msgstr ""
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lDesafio bloqueado"
+
+msgid "READY"
 msgstr ""
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr ""
-
-#, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr ""
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr ""
-
-msgid "SUCCESS"
-msgstr ""
-
-msgid "FAILED"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4Nenhum importador com o nome §e{0}§4 encontrado"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr ""
-
-msgid "The island has been created."
-msgstr "A ilha foi criada."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d trancou a ilha."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§4O warp da ilha foi desativado, por que a ilha foi trancada."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d destrancou a ilha."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cINFO §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d foi removido do grupo."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr ""
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
+msgid "§4The {0} challenge is not available yet!"
 msgstr ""
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
-msgstr "§cA ilha original está sendo deletada! Enviando você para o spawn."
-
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§cEssa ilha está sendo deletada! Enviando você para o spawn."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "PAREDE DA FAMA (página {0} de {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
 
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eSeu rank é: §f{0}"
-
-msgid "UNKNOWN"
+msgid "§cNot enough items in chest to complete challenge!"
 msgstr ""
-
-msgid "ANIMAL"
-msgstr ""
-
-msgid "MONSTER"
-msgstr ""
-
-msgid "VILLAGER"
-msgstr ""
-
-msgid "GOLEM"
-msgstr ""
-
-#, java-format
-msgid "§c{0}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr ""
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr ""
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aParabéns! §eSua ilha apareceu."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cInfo:§e A construção ainda por estar acontecendo."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Use §9/is h§r ou o §9/is§r menu para vir aqui."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§cWatchdog!§9 Não foi possível encontrar um báu em {0}.."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr ""
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr ""
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr ""
-
-msgid "Return"
-msgstr "Voltar"
-
-msgid "§9Integer Editor"
-msgstr "§9Editor de números"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eConfiguração salva e recarregada."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cErro! §9Erro ao salvar o arquivo!"
-
-msgid "§3First Page"
-msgstr ""
-
-msgid "§3Last Page"
-msgstr ""
-
-msgid "§cSave & Reload config"
-msgstr "§cSalva e recarrega a configuração"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Salva as configurações\n"
-"§7para o arquivo e recarrega.\n"
-"§cNota: §7Use com cuidado!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (readonly)"
 
 msgid "true"
 msgstr "true"
@@ -2494,6 +724,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr ""
 
+#, java-format
+msgid "§7Page {0}"
+msgstr ""
+
 msgid "§7First Page"
 msgstr ""
 
@@ -2785,8 +1019,8 @@ msgstr ""
 msgid "Island Restart Menu"
 msgstr ""
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr ""
+msgid "Config:"
+msgstr "Configuração:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2802,111 +1036,117 @@ msgstr ""
 msgid "§aClick to restart!"
 msgstr ""
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr ""
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr ""
+
+msgid "Return"
+msgstr "Voltar"
+
+msgid "§9Integer Editor"
+msgstr "§9Editor de números"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9Editor de texto"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eConfiguração salva e recarregada."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cErro! §9Erro ao salvar o arquivo!"
+
+msgid "§3First Page"
+msgstr ""
+
+msgid "§3Last Page"
+msgstr ""
+
+msgid "§cSave & Reload config"
+msgstr "§cSalva e recarrega a configuração"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Salva as configurações\n"
+"§7para o arquivo e recarrega.\n"
+"§cNota: §7Use com cuidado!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (readonly)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4Nenhum importador com o nome §e{0}§4 encontrado"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr ""
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr ""
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr ""
+
+msgid "SUCCESS"
+msgstr ""
+
+msgid "FAILED"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr ""
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
-msgstr ""
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§eEnviando você para o spawn."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr ""
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aVocê vai ser teleportado em {0} segundos."
-
-msgid "§7Teleport cancelled"
-msgstr ""
-
-msgid "READY"
-msgstr ""
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr ""
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Algo ocorreu mal ao salvar a ilha e informações do grupo!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr ""
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr ""
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr ""
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4Jogador já faz parte dessa ilha!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr ""
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr ""
-
-msgid "§aTeleporting you to your island."
-msgstr "§aTeleportando você para sua ilha."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Impossível de teletransportar você para ilha do jogador!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aTeleportando você para a ilha de {0}."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4Você deve estar mais perto da sua ilha para definir a home!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aSua home foi definida na sua localização atual."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4Sua localização atual não é segura."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cSua ilha está sendo processada, você não pode criar agora."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "Não foi possível criar sua ilha. Por favor contate a um administrador."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-"§eGerando nova ilha, por favor seja paciente, isso pode levar alguns minutos."
-
-msgid "§cCommand is currently disabled!"
 msgstr ""
 
 msgid "North"
@@ -2931,4 +1171,1760 @@ msgid "West"
 msgstr ""
 
 msgid "North-West"
+msgstr ""
+
+msgid "The island has been created."
+msgstr "A ilha foi criada."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d trancou a ilha."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§4O warp da ilha foi desativado, por que a ilha foi trancada."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d desativou o warp da ilha."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d destrancou a ilha."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cINFO §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d foi removido do grupo."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr ""
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr ""
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aParabéns! §eSua ilha apareceu."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cInfo:§e A construção ainda por estar acontecendo."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Use §9/is h§r ou o §9/is§r menu para vir aqui."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr ""
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§cWatchdog!§9 Não foi possível encontrar um báu em {0}.."
+
+msgid "UNKNOWN"
+msgstr ""
+
+msgid "ANIMAL"
+msgstr ""
+
+msgid "MONSTER"
+msgstr ""
+
+msgid "VILLAGER"
+msgstr ""
+
+msgid "GOLEM"
+msgstr ""
+
+#, java-format
+msgid "§c{0}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr ""
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr "§cA ilha original está sendo deletada! Enviando você para o spawn."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§cEssa ilha está sendo deletada! Enviando você para o spawn."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "PAREDE DA FAMA (página {0} de {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr ""
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr ""
+"§4Nível de ilha está desativado, entre em contato com um administrador."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eSeu rank é: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr ""
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Complete {0}"
+
+msgid "to unlock this rank"
+msgstr "para desbloquear essa categoria"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Requisitos irão resetar em {0} dias."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Requisitos irão resetar em {0} horas."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4Requisitos irão resetar em {0} minutos."
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr ""
+
+msgid "§7and more..."
+msgstr ""
+
+msgid "§eItems will be traded for reward."
+msgstr ""
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr ""
+
+msgid "§6Item Reward: §a"
+msgstr "§6Prêmio em item: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Prêmio em dinheiro: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Prêmio em XP: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dTotal de vezes completado: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4Nenhum desafio com o nome {0} foi encontrado!"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4Você precisa estar na sua ilha para fazer isso!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4O desafio {0} não pode ser repetido!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§eTentando completar o desafio §a{0}"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr "§4Você precisa estar ao menos {0} blocos dos items necessários. "
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4Sua ilha precisa estar no nível {0} para completar esse desafio!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Tipo de desafio desconhecido: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§eMantenha os seguintes items por perto:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr ""
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eVocê deve ter os seguintes items perto: {0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aVocê completou o desafio {0}!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9{0}§f completou o desafio §9{1}§f!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§ePrêmio em item: §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§ePrêmio em XP: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§ePrêmio em dinheiro:f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eSeu inventário está §4cheio§e. Items cairam no chão."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lClique para completar esse desafio."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lVocê não pode repetir esse desafio."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Categoria: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fComplete mais desafios nessa"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fcategoria, para liberar a próxima."
+
+msgid "§eClick here to show previous page"
+msgstr "§e§lClique aqui para ver a página anterior"
+
+msgid "§eClick here to show next page"
+msgstr "§e§lClique aqui para ver a próxima página"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "Você está sozinho na sua ilha."
+
+msgid "But you are Yelling in the wind!"
+msgstr "Não tem mais ninguém na sua ilha."
+
+msgid "But your fantasy friends are gone!"
+msgstr "Seus amigos sumiram!"
+
+msgid "But you are Talking to your self!"
+msgstr "Por que você está falando sozinho?"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cDesculpe! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr ""
+
+msgid "party"
+msgstr ""
+
+msgid "island"
+msgstr ""
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr ""
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr ""
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr ""
+
+msgid "§cCommand only available to players"
+msgstr ""
+
+msgid "talk to your island party"
+msgstr "falar com jogadores no seu grupo"
+
+msgid "talk to players on your island"
+msgstr "falar com jogadores na sua ilha"
+
+msgid "manually update the top 10 list"
+msgstr "atualizar lista top 10 manualmente"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eGerando a lista top dez"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eA lista top dez foi gerada"
+
+msgid "purges all abandoned islands"
+msgstr "purgar todas as ilhas abandonadas"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4Você precisa fornecer a idade em dias para o purge!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr ""
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr ""
+
+msgid "Controls player-cooldowns"
+msgstr "Controlar player-cooldowns"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "limpar o cooldown em um comando (* = todos)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eEsse jogador não está online"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Limpo cooldown em {0} para {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Nenhum cooldown em {0} para {1} detectado!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Comando fornecido é inválido, apenas restart e biome é suportado!"
+
+msgid "restarts the cooldown on the command"
+msgstr "reinicia o cooldown no comando"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eResetar cooldown em {0} para {1}§e por {2} segundos"
+
+msgid "lists all the active cooldowns"
+msgstr "listar todos os cooldowns ativos"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCmd Cooldown"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eNenhum cooldown ativo para §9{0}§e encontrado."
+
+msgid "toggles maintenance mode"
+msgstr ""
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr ""
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Informações de trabalho"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/job"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "act"
+
+msgid "time"
+msgstr "tempo"
+
+msgid "name"
+msgstr "nome"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§eJogador {0} não tem uma ilha!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eJogador  {0}  é inválido."
+
+msgid "flushes all caches to files"
+msgstr "envia todos os caches para arquivos"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr "§eEnviados §a{0} ilhas§e, §b{1} jogadores e §6{2} desafios completos."
+
+msgid "tries to fix the the area of flatland."
+msgstr "tentar reparar a área de flatland."
+
+msgid "§4No valid island found"
+msgstr "§4Não foi encontrado uma ilha válida."
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4Não foi encontrado flatland na ilha de {0}!"
+
+msgid "manage orphans"
+msgstr "gerenciar orphans"
+
+msgid "count orphans"
+msgstr "contar orphans"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr ""
+"§e{0} Localizações de ilhas antigas serão usadas antes de criar uma nova."
+
+msgid "clear orphans"
+msgstr "limpar orphans"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eLimpando todas as antigas (vazias) localizações de ilhas."
+
+msgid "list orphans"
+msgstr "mostrar orphans"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eNenhum orphan registrado atualmente."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "transferir a liderança para outro jogador"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4Jogador {0} não tem uma ilha para transferir!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eJogador §d{0}§e já tem uma ilha.§eUse §d/usb island remove <nome>§e para "
+"remover ela primeiro."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bPoder de líder transferido de {0}§b para {1}"
+
+msgid "open GUI for config"
+msgstr "abrir menu de configuração"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr ""
+
+msgid "teleport to another players island"
+msgstr "teletransportar para a ilha de outros jogadores"
+
+msgid "§4Only supported for players"
+msgstr "§4Apenas suportado para jogadores"
+
+msgid "§4That player does not have an island!"
+msgstr "§4Esse jogador não tem uma ilha!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr ""
+
+msgid "various WorldGuard utilities"
+msgstr "various WorldGuard utilities"
+
+msgid "refreshes the chunks around the player"
+msgstr "recarregar os chunks perto do jogador"
+
+msgid "§eResending chunks to the client"
+msgstr "§eReenviando chuncks para o client"
+
+msgid "load the region chunks"
+msgstr "carregar region chunks"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eCarregando chunks em {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eRemovendo chunks em {0}"
+
+msgid "update the WG regions"
+msgstr ""
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr ""
+
+msgid "§eNo island found at your location!"
+msgstr ""
+
+msgid "refreshes the chunk around the player"
+msgstr ""
+
+msgid "region manipulations"
+msgstr ""
+
+msgid "shows the borders of the current island"
+msgstr ""
+
+msgid "§eNo island found at your current location"
+msgstr ""
+
+msgid "§eCan only be executed as a player"
+msgstr ""
+
+msgid "shows the borders of the current chunk"
+msgstr ""
+
+msgid "shows the borders of the inner-chunks"
+msgstr ""
+
+msgid "shows the non-chunk-aligned borders"
+msgstr ""
+
+msgid "shows the borders of the outer-chunks"
+msgstr ""
+
+msgid "hides the regions again"
+msgstr ""
+
+msgid "§eStopped displaying regions"
+msgstr ""
+
+msgid "§eNo currently shown regions for this player"
+msgstr ""
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr ""
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr ""
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4PURGE:§9 Terminou o processo de purge em ilhas abandonadas."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr ""
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr ""
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr ""
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr ""
+
+msgid "control debugging"
+msgstr "controlar debugging"
+
+msgid "set debug-level"
+msgstr "definir debug-level"
+
+msgid "toggle debug-logging"
+msgstr "alterar debug-logging"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4Logging não está ativado, você não pode desativá-lo."
+
+msgid "flush current content of the logger to file."
+msgstr "colocar o atual log em um arquivo."
+
+msgid "§eLog-file has been flushed."
+msgstr "§eLog-file foi liberado."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4Logging não está ativado, use §d/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Argumento inválido, tente INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eLogging desativado!"
+
+msgid "advanced command for setting island-data"
+msgstr ""
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr ""
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr ""
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr ""
+
+msgid "set a player''s island to your location"
+msgstr "definir a ilha do jogador para a sua localização"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr ""
+
+msgid "shows the NBTTag for the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr ""
+
+msgid "§cNo item in hand!"
+msgstr ""
+
+msgid "sets the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "adds the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "Manage challenges for a player"
+msgstr "Gerenciar desafios para um jogador"
+
+msgid "resets the challenge for the player"
+msgstr "redefinir o desafio para o jogador"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4Desafio nunca foi concluído"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§edesafio: {0} foi resetado por {1}"
+
+msgid "resets all challenges for the player"
+msgstr "resetar todos os desafios do jogador"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0}  teve todos os desafios resetados."
+
+msgid "complete all challenges in the rank"
+msgstr ""
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4Não foi encontrado nenhum jogador com o nome {0}"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr ""
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4Desafio {0} não foi encontrado!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr ""
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "proteger todas as ilhas (consome tempo)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr ""
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§eIniciando o protect-all. Isso pode levar algum tempo."
+
+msgid "reload configuration from file."
+msgstr "recarregar configuração do arquivo."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eConfigurações  recarregadas."
+
+msgid "manage islands"
+msgstr "controle de ilhas"
+
+msgid "protects the island"
+msgstr "proteger a ilha"
+
+msgid "delete the island (removes the blocks)"
+msgstr "deletar a ilha (remover os blocos)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Ilha abandonada na sua localização foi excluída."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4A ilha nessa localização tem membros!\n"
+"§eUse §9/usb island delete <nome>§e para remover."
+
+msgid "removes the player from the island"
+msgstr "remover o jogador da ilha"
+
+msgid "adds the player to the island"
+msgstr "adicionar o jogador a ilha"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d entrou no grupo da ilha."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4Nenhum jogador com o nome {0} encontrado!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr "§4Ilha inválida, mantenha-se dentro de uma ou dê o nome dela"
+
+msgid "print out info about the island"
+msgstr "print out informações sobre a ilha"
+
+msgid "sets the biome of the island"
+msgstr "definir o bioma da ilha"
+
+msgid "§4That player has no island."
+msgstr "§4Esse jogador não tem uma ilha."
+
+msgid "§4No valid island at your location"
+msgstr "§4Não tem uma ilha válida na sua localização"
+
+msgid "purges the island"
+msgstr "purgar a ilha"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4Erro! §9Nenhuma ilha válida para o purge foi encontrada."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cPURGE: §9Ilha em {0} foi purgada."
+
+msgid "toggles the islands ignore status"
+msgstr "alterar o status de ignorado da ilha"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cIgnorar a ilha de {0} no top 10 e no purge."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cA ilha de {0} não é mais ignorada, agora você pode ver ela no purge e no "
+"top 10."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Nome fornecido é inválido."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Removendo {0} da ilha"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eAlterado o bioma da ilha de {0} para {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eAlterado o bioma da ilha de {0} para OCEANO."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr "§aVocê precisa ir ao spawn ou reconectar para ver as alterações."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} teve o seu bioma alterado para {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} teve o seu bioma alterado para OCEANO."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eRemovendo a ilha de {0}."
+
+msgid "Error: That player does not have an island!"
+msgstr "Erro: Esse jogador não tem uma ilha!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§eA ilha de {0} em {1} foi protegida"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4A ilha de {0} em {1} já foi protegida"
+
+msgid "displays version information"
+msgstr "mostrar informações da versão"
+
+msgid "imports players and islands from other formats"
+msgstr "importar jogadores e ilhas de outros formatos"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr ""
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "altera a linguagem do plugin e recarrega"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aLinguagem alterada para §e{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cOcorreu um erro ao alterar a linguagem para §e{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Linguagens disponíveis:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 por {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cNão foi possível localizar nenhuma linguagem."
+
+msgid "advanced command for getting island-data"
+msgstr ""
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "mostrar informações do jogador"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4Sua ilha está cheia, ou você tem muitos convites pendentes. Você não pode "
+"convidar ninguém no momento."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4Esse jogador é líder de outra ilha."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e tentou te convidar, mas você já faz parte de um grupo."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e te convidou para juntar-se a ilha dele!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§f/island [accept/reject§e para aceitar ou rejeitar um convite."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4AVISO: Você vai perder sua ilha atual se você aceitar!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d convidou {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e rejeitou o convite."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4Você não pode usar esse comando agora. Saia do seu grupo atual primeiro."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§aVocê entrou em uma ilha! Use /island party para ver os outros membros."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§dConvite para {0}§e excedeu o tempo limite ou foi cancelado."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§eConvite enviado para {0}§e excedeu o tempo limite ou foi cancelado."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§eVocê aceitou o convite para entrar em uma ilha."
+
+msgid "§4You haven't been invited."
+msgstr "§4Você não foi convidado."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eVocê rejeitou o convite para entrar na ilha."
+
+msgid "general island command"
+msgstr "comandos geral da ilha"
+
+msgid "allows user to bypass cooldowns"
+msgstr ""
+
+msgid "allows user to bypass visitor-protections"
+msgstr ""
+
+msgid "allows user to bypass teleport-delay"
+msgstr ""
+
+msgid "allows user to use [usb] signs"
+msgstr ""
+
+msgid "allows user to place [usb] signs"
+msgstr ""
+
+msgid "complete and list challenges"
+msgstr ""
+
+msgid "§cCommand only available for players."
+msgstr ""
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eDesafios estão desabilitados. Contate a um administrador."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4Você só pode completar desafios na sua ilha!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4Você só pode completar desafios se tiver uma ilha!"
+
+msgid "warp to another player''s island"
+msgstr "warp para ilha de outro jogador"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr ""
+"§aO warp até ilha está ativo, outros jogadores podem visitar a sua ilha."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§4O warp da ilha está inátivo, outros jogares não podem ir até sua ilha."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr ""
+"§fDefina o ponto de warp para sua localização atual usando §e/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr ""
+"§fEscolha o warp da ilha entre ativado/desativado usando §e/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4Você não tem permissão para criar um warp para sua ilha!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§fWarp para outra ilha usando §e/island warp <jogador>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4Você não tem permissão para teletransportar até outras ilhas."
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cSua ilha está em processo de criação, você não pode usar warp até outras "
+"ilhas agora."
+
+msgid "§4That player does not exist!"
+msgstr "§4Esse jogador não existe!"
+
+msgid "§4That player does not have an active warp."
+msgstr ""
+"§4Esse jogador não tem um ponto de warp definido ou o warp está desativado."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§cA ilha do jogador está em processo de criação, você não pode usar warp até "
+"lá agora."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cAVISO: §9{0}§e usou warp até a sua ilha!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4Esse jogador proibiu você de teletransportar até a ilha dele."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4Você não tem uma ilha.§e Use §b/is create§e para criar uma"
+
+msgid "accept/reject an invitation."
+msgstr "aceitar/rejeitar um convite."
+
+msgid "leave your party"
+msgstr "sair do seu grupo"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4Você não pode sair da ilha, você é a única pessoa nela. Tente usar /island "
+"restart se você quiser uma nova!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§eVocê é dono dessa ilha, use /island remove <jogador>."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eVocê saiu da ilha e foi levado ao spawn."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0} saiu da ilha!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4Você deve estar na sua ilha para sair do seu grupo!"
+
+msgid "check your or anothers island level"
+msgstr "verificar informações do nível da sua ilha ou de outros jogadores"
+
+msgid "allows user to query for others levels"
+msgstr ""
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eVocê precisa estar na sua ilha para usar esse comando."
+
+msgid "§4You do not have an island!"
+msgstr "§4Você não tem uma ilha!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4Você não tem acesso a esse comando!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4Esse jogador é inválido ou não tem uma ilha!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eInformações sobre a ilha de {0}':"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aNível: {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9Categoria: {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "criar uma ilha"
+
+msgid "exempt player from create-cooldown"
+msgstr ""
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4Você já tem uma ilha!§e Caso você queira uma nova, use §b/is restart."
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4Você faz parte de um grupo. Para criar sua própria ilha primeiro use §b/is "
+"leave."
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eVocê pode criar uma nova ilha em {0,number,#} segundos."
+
+msgid "invite a player to your island"
+msgstr "convidar um jogador para sua ilha"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§eUse §f/island invite <nomedojogador>§e para convidá-lo para sua ilha."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4Apenas o dono da ilha pode convidar alguém!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aVocê pode convidar mais {0} jogadores. "
+
+msgid "§4You can't invite any more players."
+msgstr "§4Você não pode convidar mais jogadores."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4Você não tem permissão para convidar outro jogadores para a ilha!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4Esse jogador está offline ou não existe."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4Você não pode convidar você mesmo!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4Esse jogador é o líder da sua ilha!"
+
+msgid "lock your island to non-party members."
+msgstr "trancar sua ilha para jogadores fora do seu grupo."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4Você não tem permissão para trancar a ilha!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4Você não tem acesso a esse comando!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4Você não tem permissão para destrancar a ilha!"
+
+msgid "display the top10 of islands"
+msgstr "mostrar o top10 das ilhas"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr ""
+
+msgid "remove a member from your island."
+msgstr "expulsar um jogador da sua ilha"
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4Você não tem permissão para expulsar jogadores dessa ilha!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4Você não pode expulsar o líder da ilha!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4Você não pode expulsar você mesmo!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0} te expulsou da ilha dele!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} foi removido da ilha."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr ""
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0} foi expulso da ilha."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr "§4Esse jogador não faz parte do seu grupo e não está na sua ilha!"
+
+msgid "teleport to the island home"
+msgstr "teletransportar para a ilha"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§cSua ilha está em processo de criação, você não pode ir até sua ilha agora."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4Esse comando só pode ser executado por um jogador"
+
+msgid "transfer leadership to another member"
+msgstr "transferir liderança para outro membro"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4Você só pode transferir a liderança para membros da ilha!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e já é o lider da ilha!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4Apenas o líder pode transferir a liderança!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} tentou roubar a ilha!"
+
+msgid "show party information"
+msgstr "mostrar informações do grupo"
+
+msgid "shows information about your party"
+msgstr "mostrar informações sobre o seu grupo"
+
+msgid "show pending invites"
+msgstr "mostrar convites pendentes"
+
+msgid "§eNo pending invites"
+msgstr "§eNenhum convite pendente"
+
+msgid "withdraw an invite"
+msgstr "remover um convite"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4Você não tem permissão para expulsar de jogadores."
+
+msgid "check your or another''s island info"
+msgstr "verificar informações da sua ilha ou de outros jogadores"
+
+msgid "allows user to see others island info"
+msgstr ""
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBlocos na ilha de {0} (pagina {1,number} de {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Pontos por bloco"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "confiar/remover confiança de um jogador para ajudar na sua ilha."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eOs seguintes jogadores são confiáveis na sua ilha:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eOs seguintes líderes confiam em você:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr ""
+"§ePara confiar/remover confiança de alguém na sua ilha, use /island trust "
+"<jogador>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4Membros já são confiáveis!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Jogador desconhecido {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eVocê agora é confiável na ilha de §4{0}."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} confiou {1} na ilha"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eVocê não é mais confiável na ilha de §4{0}."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0} removeu a confiança de {1} na ilha"
+
+msgid "delete your island and start a new one."
+msgstr "deletar sua ilha e iniciar uma nova."
+
+msgid "exempt player from restart-cooldown"
+msgstr ""
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4Apenas o dono da ilha pode reiniciar. Saia do seu grupo atual para criar "
+"uma ilha.(/island leave)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eVocê precisa remover todos os jogadores da ilha antes de reinicia-lá. (/"
+"island kick <jogador>). Veja uma lista com os jogadores do seu grupo usando "
+"island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§cVocê pode reiniciar a ilha em {0} segundos."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr "§cSua ilha está em processo de criação, você não pode resetar agora."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§eNOTA: Toda a sua ilha e todos os seus pertences serão resetados!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "teletransportar você para o spawn do skyblock"
+
+msgid "change the biome of the island"
+msgstr "alterar o bioma da ilha"
+
+msgid "exempt player from biome-cooldown"
+msgstr ""
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr ""
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr "§cVocê não tem permissão para alterar o bioma da ilha."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4Você não tem permissão para alterar o bioma da ilha!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eVocê deve estar na sua ilha para alterar o bioma!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr ""
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eVocê pode alterar o bioma novamente em {0,number,#} minutos."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§cVocê não tem permissão para alterar o bioma da ilha para esse tipo."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr ""
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aVocê alterou o bioma da ilha para {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} alterou o bioma da ilha para {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr ""
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr ""
+
+msgid "set your island''s warp location"
+msgstr "definir o ponto de warp da ilha"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cVocê não tem permissão para definir o ponto de warp!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§cVocê precisa estar na sua ilha para definir o warp!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d alterou o ponto de warp da ilha."
+
+msgid "teleports you to your island (or create one)"
+msgstr ""
+
+msgid "ban/unban a player from your island."
+msgstr "banir/desbanir um jogador da sua ilha."
+
+msgid "exempts user from being banned"
+msgstr ""
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr ""
+"§eOs seguintes jogadores estão proibidos de teletransportar até sua ilha:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr ""
+"§ePara banir/desbanir um jogador da sua ilha, use /island ban <jogador>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4Você não pode banir membros. Expulse-os primeiro!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4Você não tem permissão para expulsar/banir jogadores do grupo."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr ""
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr ""
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eVocê proibiu §4{0} de teletransportar até sua ilha."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eVocê foi §cBANIDO§e da ilha de {0}."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§eAgora {0} pode teletransportar até sua ilha."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eVocê foi §aDESBANIDO§e da ilha de {0}."
+
+msgid "display log"
+msgstr "verificar histórico"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "definir o ponto de spawn da ilha"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "ativar/desativar o warp até sua ilha."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4Sua ilha está trancada. Você deve destranca-lá antes de ativar o warp."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d ativou o warp da ilha."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr "§cVocê não tem permissão para ativar/desativar o warp da ilha!"
+
+msgid "try to complete a challenge"
+msgstr ""
+
+msgid "show information about the challenge"
+msgstr ""
+
+msgid "§eRank: "
+msgstr "§eCategoria: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4Esse desafio não pode ser repetido!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr ""
+"§4Você irá perder todos os items necessários quando completar esse desafio!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4Todos os items necessários devem ser colocados na sua ilha, com até {0} "
+"blocos de distância de você."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§ePara completar esse desafio, use §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4Nome de desafio inválido! Use /c help para mais informações"
+
+msgid "§eSending you to spawn."
+msgstr "§eEnviando você para o spawn."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr ""
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr ""
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr ""
+
+msgid "§aTeleporting you to your island."
+msgstr "§aTeleportando você para sua ilha."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aVocê vai ser teleportado em {0} segundos."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Impossível de teletransportar você para ilha do jogador!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aTeleportando você para a ilha de {0}."
+
+msgid "§7Teleport cancelled"
 msgstr ""

--- a/uSkyBlock-Core/src/main/po/ru.po
+++ b/uSkyBlock-Core/src/main/po/ru.po
@@ -16,12 +16,45 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
+msgid "d"
+msgstr "д"
+
+msgid "h"
+msgstr "ч"
+
+msgid "m"
+msgstr "м"
+
+msgid "s"
+msgstr "с"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr ""
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}"
+msgstr ""
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr ""
 
 #, java-format
 msgid "§eInvalid command: {0}"
+msgstr ""
+
+msgid "Command"
+msgstr ""
+
+msgid "Permission"
+msgstr ""
+
+msgid "Description"
 msgstr ""
 
 #, java-format
@@ -47,1679 +80,11 @@ msgstr ""
 msgid "§4Error writing documentation: {0}"
 msgstr ""
 
-msgid "Command"
+msgid "§cWither Despawned!§e It wandered too far from your island."
 msgstr ""
 
-msgid "Permission"
-msgstr ""
-
-msgid "Description"
-msgstr ""
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}"
-msgstr ""
-
-msgid "d"
-msgstr "д"
-
-msgid "h"
-msgstr "ч"
-
-msgid "m"
-msgstr "м"
-
-msgid "s"
-msgstr "с"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr ""
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eПо прежнему мало блоков: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4Требования будут сброшены через {0} д."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4Требования будут сброшены через {0} ч."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4Требования будут сброшены через {0} мин."
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr ""
-
-msgid "§7and more..."
-msgstr ""
-
-msgid "§eItems will be traded for reward."
-msgstr ""
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr ""
-
-msgid "§6Item Reward: §a"
-msgstr "§6Награда предметами: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Награда деньгами: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Награда опыт: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dПолное время выполнения: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4Не найдено задание {0}"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4Вам надо быть на острове, чтобы сделать это!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr ""
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4Задание {0} нельзя повторить!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr ""
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr "§4Должно быть {0} блоков из всех требуемых предметов."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4Для завершения задания остров должен иметь уровень {0}!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Неизвестный тип задания: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§eПо прежнему мало существ:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr ""
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eУ вас мало предметов:{0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aВы выполнили задание {0} !"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9 {0} §f завершил § 9 {1} §f вызов!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§eНаграда: §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eНаграда опыт: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eНаграда деньгами: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eВаш инвентарь §4переполнен§e. Предметы брошены на землю."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lНажмите для завершения задания."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lВы не можете повторить задание."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Звание: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fЗавершено большинство заданий в"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fэто звание разблокировало следующее."
-
-msgid "§eClick here to show previous page"
-msgstr "§eНажмите для просмотра предыдущей страницы"
-
-msgid "§eClick here to show next page"
-msgstr "§eНажмите для просмотра следующей страницы"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lЗадание заблокировано"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr ""
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Выполнено {0}"
-
-msgid "to unlock this rank"
-msgstr "для разблокировки звания"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "Но вы в полном одиночестве!"
-
-msgid "But you are Yelling in the wind!"
-msgstr "Но вы кричите ветру!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "Но ваши придуманные друзья ушли!"
-
-msgid "But you are Talking to your self!"
-msgstr "Но вы разговариваете сами с собой!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cИзвините! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr ""
-
-msgid "party"
-msgstr ""
-
-msgid "island"
-msgstr ""
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr ""
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr ""
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr ""
-
-msgid "§cCommand only available to players"
-msgstr ""
-
-msgid "talk to players on your island"
-msgstr "говорить с игроками на своем острове"
-
-msgid "talk to your island party"
-msgstr "говорить с участниками вашего острова"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§eИгрок {0} не имеет острова!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eНекорректный игрок {0}."
-
-msgid "Manage challenges for a player"
-msgstr "Управлять заданиями для игрока"
-
-msgid "resets the challenge for the player"
-msgstr "сбросить задание для игрока"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4Задание никогда не будет выполнено"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§eзадание: {0} сброшено для игрока {1}"
-
-msgid "resets all challenges for the player"
-msgstr "сбросить все задания для игрока"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§eУ игрока {0} сброшены все задания."
-
-msgid "complete all challenges in the rank"
-msgstr ""
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4Игрок с именем {0} не найден!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr ""
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4Задание с названием {0} не найдено!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr ""
-
-msgid "manage islands"
-msgstr "управление островом"
-
-msgid "protects the island"
-msgstr "защита острова"
-
-msgid "delete the island (removes the blocks)"
-msgstr "удалить остров (убрать блоки)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Удален заброшенный остров по вашим координатам."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4Остров в этом месте имеет участников!\n"
-"§eВведите §9/usb island delete <name>§e для его удаления."
-
-msgid "removes the player from the island"
-msgstr "удаление игрока с острова"
-
-msgid "adds the player to the island"
-msgstr "добавляет игроку острова"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d присоединился к вашему острову."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§ 4 Ни один игрок с именем {0} не найдено!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-"§4No действительный остров при условии, либо стоять в пределах одного, или "
-"предоставить имя острова"
-
-msgid "print out info about the island"
-msgstr "вывод информации об острове"
-
-msgid "sets the biome of the island"
-msgstr "установка биома для острова"
-
-msgid "§4That player has no island."
-msgstr "§4Этот игрок не имеет острова."
-
-msgid "§4No valid island at your location"
-msgstr "§4В этом месте нет подходящих островов"
-
-msgid "purges the island"
-msgstr "очистка острова"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Ошибка! §9Нет подходящих островов для очистки."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cОЧИСТКА: §9Очищен остров {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "переключения статуса игнорирования"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cПереключение острова {0} в игнорирование для ТОП10 и очистки."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§cОтмена игнорирования острова  {0}, теперь он показывается в ТОП10 и "
-"очистке."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Имя игрока недействительно."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Удаление {0} с острова"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eИзменен биом острова {0} на {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eИзменен биом острова {0} на Океан."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr ""
-"§aВы должны отправится на спавн или перезайти, чтобы увидеть изменения."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} изменил биом на  {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} изменил биом на Океан."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eУдаление острова  {0}."
-
-msgid "Error: That player does not have an island!"
-msgstr "Ошибка: Игрок не имеет острова"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§eОстров {0} в {1} защищен"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4Остров {0} в {1} уже был защищен"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "открыт графический интерфейс для конфигурации"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr ""
-
-msgid "Controls player-cooldowns"
-msgstr "Controls player-cooldowns"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "clears the cooldown on a command (* = all)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eИгрок в оффлайн"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Cleared cooldown on {0} for {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "No active cooldown on {0} for {1} detected!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Неверная команда, только перезапуск и биом поддерживаются"
-
-msgid "restarts the cooldown on the command"
-msgstr "перезапускает время перезарядки по команде"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eReset cooldown on {0} for {1}§e to {2} seconds"
-
-msgid "lists all the active cooldowns"
-msgstr "lists all the active cooldowns"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCmd Cooldown"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eNo active cooldowns for §9{0}§e found."
-
-msgid "control debugging"
-msgstr "управление отладкой"
-
-msgid "set debug-level"
-msgstr "установка уровня отладки"
-
-msgid "toggle debug-logging"
-msgstr "переключение журнала отладки"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4Ведение журнал отключено, вы не можете отключить его!"
-
-msgid "flush current content of the logger to file."
-msgstr "сбросить текущее содержание журнала в файл"
-
-msgid "§eLog-file has been flushed."
-msgstr "§eФайл журнала обновлен."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4Ведение журнала не включено, введите §d/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Некорректные аргументы, попробуйте INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eВедение журнала отключено!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "попытка исправить территорию на равнине"
-
-msgid "§4No valid island found"
-msgstr "§4Подходящего острова не найдено"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4Равнина не найдена на острове {0}!"
-
-msgid "flushes all caches to files"
-msgstr "очистить все кэши к файлам"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-"§eПромываемое §a {0} острова§e, §b {1} игроков и § 6 {2} вызов-пополнений."
-
-msgid "manually update the top 10 list"
-msgstr "ручное обновление списка ТОП 10"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eГенерирование списка ТОП 10"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eгенерация списка ТОП 10 завершена"
-
-msgid "advanced command for getting island-data"
-msgstr ""
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr ""
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr ""
-
-msgid "teleport to another players island"
-msgstr "телепортация на остров другого игрока"
-
-msgid "§4Only supported for players"
-msgstr "§4Поддерживается только для игроков"
-
-msgid "§4That player does not have an island!"
-msgstr "§4Этот игрок не имеет острова!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr ""
-
-msgid "imports players and islands from other formats"
-msgstr "импортирование игроков и островов в другие форматы"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Job Статистика"
-
-msgid "§7----------------"
-msgstr "§7------------------------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/работа"
-
-msgid "ms/tick"
-msgstr "ms/ТИК"
-
-msgid "ticks"
-msgstr "тиков"
-
-msgid "act"
-msgstr "акт"
-
-msgid "time"
-msgstr "время"
-
-msgid "name"
-msgstr "имя"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "изменяет язык плагина, и перезагружается"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aуспешно изменен язык §e {0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cНе удалось изменить язык §e{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Поддерживаемые Языки:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cНе удалось найти каких-либо языков."
-
-msgid "transfer leadership to another player"
-msgstr "сделать хозяином другого игрока"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4Игрок {0} не имеет острова для передачи!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§eИгрок §d{0}§e уже имеет остров.§eСначала введите §d/usb island remove "
-"<name>§e для его удаления."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bХозяин изменен у {0}§b на {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr ""
-
-msgid "shows the NBTTag for the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr ""
-
-msgid "§cNo item in hand!"
-msgstr ""
-
-msgid "§eCan only be executed as a player"
-msgstr ""
-
-msgid "sets the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "adds the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "manage orphans"
-msgstr "управления сиротами"
-
-msgid "count orphans"
-msgstr "количество сирот"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr ""
-"§eСтарое место острова {0} будет использоваться, пока не появится новое."
-
-msgid "clear orphans"
-msgstr "очистить сирот"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eОчистка всех старых (пустых) островов."
-
-msgid "list orphans"
-msgstr "список сирот"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eСироты не зарегистрированы."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr ""
-
-msgid "protects all islands (time consuming)"
-msgstr "защита всех островов (затратно по времени)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr ""
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§eЗапуск защиты всего. Это займет немного времени."
-
-msgid "purges all abandoned islands"
-msgstr "очистка всех заброшенных островов"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4Вам нужно указать возраст в днях для очистки!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr ""
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr ""
-
-msgid "region manipulations"
-msgstr ""
-
-msgid "shows the borders of the current island"
-msgstr ""
-
-msgid "§eNo island found at your current location"
-msgstr ""
-
-msgid "shows the borders of the current chunk"
-msgstr ""
-
-msgid "shows the borders of the inner-chunks"
-msgstr ""
-
-msgid "shows the non-chunk-aligned borders"
-msgstr ""
-
-msgid "shows the borders of the outer-chunks"
-msgstr ""
-
-msgid "hides the regions again"
-msgstr ""
-
-msgid "§eStopped displaying regions"
-msgstr ""
-
-msgid "§eNo currently shown regions for this player"
-msgstr ""
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr ""
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr ""
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "установка острова игрока в вашей позиции"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "перезагрузка конфигурации из файла"
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eКонфигурация перезагружена из файла."
-
-msgid "advanced command for setting island-data"
-msgstr ""
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr ""
-
-msgid "toggles maintenance mode"
-msgstr ""
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr ""
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr ""
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr ""
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr ""
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4ПРОДУВКА: §9 Закончено продувкой заброшенных островов."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr ""
-
-msgid "displays version information"
-msgstr "показать информацию о версии"
-
-msgid "various WorldGuard utilities"
-msgstr "различные утилиты WorldGuard"
-
-msgid "refreshes the chunks around the player"
-msgstr "обновление чанков вокруг игрока"
-
-msgid "§eResending chunks to the client"
-msgstr "§eСброс чанков в клиенте"
-
-msgid "load the region chunks"
-msgstr "загрузка чанков региона"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eЗагрузка чанков у {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eВыгрузка чанков у {0}"
-
-msgid "update the WG regions"
-msgstr ""
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr ""
-
-msgid "§eNo island found at your location!"
-msgstr ""
-
-msgid "refreshes the chunk around the player"
-msgstr ""
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "показать информацию по игроку"
-
-msgid "try to complete a challenge"
-msgstr ""
-
-msgid "§cCommand only available for players."
-msgstr ""
-
-msgid "show information about the challenge"
-msgstr ""
-
-msgid "§eRank: "
-msgstr "§eЗвание: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4Это задание нельзя повторить!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr "§4У вас заберут все необходимые предметы, если вы завершите задание!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4Все требуемые предметы должны быть размещены на вашем острове в {0} блоках."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§eДля завершения задания введите §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4Неверное название задания! Введите /c help для подробной информации"
-
-msgid "complete and list challenges"
-msgstr ""
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eЗадания выключены. Свяжитесь с администратором."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4Отправить задания возможно только в мире skyblock!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4Отправить задание можно только если у вас есть остров!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4Ваш остров заполнен или вы больше не можете приглашать новых участников."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4Этот игрок уже владеет другим островом."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e пытался пригласить вас, но вы уже приглашены."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e пригласил вас присоединится к острову!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr ""
-"§f/island [accept/reject]§e для согласия или отказа на предложения "
-"присоединится."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr ""
-"§4ВНИМАНИЕ: Вы потеряете свой текущий остров, если согласитесь "
-"присоединиться!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d приглашен игроком {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e отклонил предложение."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4Вы не можете использовать эту команду сейчас. Откажитесь от участия на "
-"другом острове сначала."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§aВы присоединились к острову! Введите /island party для просмотра других "
-"участников."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§eПриглашение для {0}§e было просрочено или отменено."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§eПриглашение на остров игрока {0} было просрочено или отменено."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§eВы приняли приглашения о присоединении к острову."
-
-msgid "§4You haven't been invited."
-msgstr "§4Вы не были приглашены."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eВы отклонили предложение о присоединении к острову"
-
-msgid "accept/reject an invitation."
-msgstr "принять/отклонить приглашение."
-
-msgid "teleports you to your island (or create one)"
-msgstr ""
-
-msgid "ban/unban a player from your island."
-msgstr "блокировать/разблокировать игрока на вашем острове."
-
-msgid "exempts user from being banned"
-msgstr ""
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§eУказанным игрокам запрещено появляться на вашем острове:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr ""
-"§eДля блокировки/разблокировки игроков на вашем острове используйте /island "
-"ban <player>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4Вы не можете заблокировать участника. Сначала исключите его!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4у вас недостаточно прав, чтобы выбрасывать или блокировать игроков."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr ""
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr ""
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eВы запретили игроку §4{0}§e посещать ваш остров."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eВы были §cзапретило §eот {0} §eострова'' s."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§eВы разрешили игроку §a{0}§e посещать ваш остров."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eВы были §aUNBANNED§e из {0}§e''s остров."
-
-msgid "change the biome of the island"
-msgstr "изменение биома острова"
-
-msgid "exempt player from biome-cooldown"
-msgstr ""
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr ""
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr "§cУ вас недостаточно прав для изменения биома вашего текущего острова."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4У вас недостаточно прав для изменения биома острова!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eДля изменения биома вы должны быть на своем острове!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr ""
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eВы сможете изменить биом снова через {0,number,#} мин."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cУ вас недостаточно прав для изменения биома острова на указанный."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr ""
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aВы изменили биом острова на {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} изменил биом острова на {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr ""
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr ""
-
-msgid "create an island"
-msgstr "создание острова"
-
-msgid "exempt player from create-cooldown"
-msgstr ""
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4Остров найден!§e Вы уже имеете остров. Если хотите очистить его, "
-"введите§b /is restart"
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4Остров найден!§e Вы уже участник этого острова. Чтобы создать свой, "
-"сначала введите §b /is leave"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eВы сможете создать новый остров через {0,number,#} сек."
-
-msgid "teleport to the island home"
-msgstr "телепортация на остров"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§cВаш остров в процессе создания, вы не можете пока на него "
-"телепортироваться."
-
-msgid "check your or another''s island info"
-msgstr "проверить информацию вашего или другого острова"
-
-msgid "allows user to see others island info"
-msgstr ""
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4Уровень острова отключен, свяжитесь с администратором."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eДля выполнения этой команды нужно быть на своем острове."
-
-msgid "§4You do not have an island!"
-msgstr "§4У вас нет острова!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4У вас нет доступа к этой команде!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4Неверно указан игрок или у него нет острова!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eБлоки на острове игрока {0} (страница {1,number} из {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Score Count Block"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aУровень острова {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "пригласить игрока на свой остров"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§eВведите§f /island invite <playername>§e для отправки приглашения игроку на "
-"свой остров."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4Только хозяин острова может приглашать!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aВы можете пригласить еще {0} игроков."
-
-msgid "§4You can't invite any more players."
-msgstr "§4Вы больше не можете приглашать игроков."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4У вас недостаточно прав для приглашения других на остров!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4Этот игрок оффлайн или не существует."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4Вы не можете пригласить себя!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4Этот игрок - лидер вашего острова!"
-
-msgid "remove a member from your island."
-msgstr "удаление участников острова."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4У вас недостаточно прав, чтобы выбрасывать игроков с этого острова!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4Вы не можете убрать лидера острова!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4Прекратите себя выбрасывать!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0} удалил вас со своего острова!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} удален с острова."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr ""
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0} выброшен с острова."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr "§4Этот игрок не участник вашего острова и не на вашем острове!"
-
-msgid "leave your party"
-msgstr "выход из группы"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4Вы не можете покинуть остров, если вы единственный участник. Введите /"
-"island restart, чтобы получить новый остров!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§eВы владелец острова, введите /island remove <player>."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eВы покинули остров и возвращены на спавн."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0} покинул ваш остров!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4Чтобы отказаться от членства на острове нужно быть в мире skyblock!"
-
-msgid "check your or anothers island level"
-msgstr "проверка уровня своего и чужого острова"
-
-msgid "allows user to query for others levels"
-msgstr ""
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eИнформация об острове {0}:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9Ранг {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "блокировать остров от посторонних игроков."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4У вас недостаточно прав для блокировки вашего острова!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4У вас недостаточно прав для выполнения этой команды!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4У вас недостаточно прав для разблокировки вашего острова!"
-
-msgid "display log"
-msgstr "журнал дисплей"
-
-msgid "transfer leadership to another member"
-msgstr "передать лидерство другому игроку"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4Владение островом можно передать только участнику острова!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e уже владелец этого острова!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4Только хозяин может передать управление!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} пытался захватить остров!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "информация об участниках острова"
-
-msgid "shows information about your party"
-msgstr "показать информацию об участниках острова"
-
-msgid "show pending invites"
-msgstr "ожидающие приглашения"
-
-msgid "§eNo pending invites"
-msgstr "§eНет ожидающих приглашения"
-
-msgid "withdraw an invite"
-msgstr "вывести приглашение"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4У вас недостаточно прав для отмены приглашений."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4Это команда может быть запущена только игроком"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4Нет острова. §eВведите §b/is create§e для создания острова"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "удаление вашего острова и создание нового"
-
-msgid "exempt player from restart-cooldown"
-msgstr ""
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4Только владелец может перезапустить остров. Покиньте этот остров, чтобы "
-"создать свой (/island leave)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eВы должны выбросить всех участников с острова, чтобы перезапустить его (/"
-"island kick <player>). Список участников острова /island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§cВы можете перезапустить свой остров через {0} сек."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§cВаш остров в процессе создания. Вы не можете перезапустить его."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eВНИМАНИЕ: Ваш остров и все ваши вещи будут сброшены!"
-
-msgid "set the island-home"
-msgstr "установка точки дома"
-
-msgid "set your island''s warp location"
-msgstr "установка точки перемещения"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cУ вас недостаточно прав для установки точки перемещения на острове!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr ""
-"§cВы должны быть владельцем острова, чтобы установить точку перемещения!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d изменил точку перемещения на острове."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "телепортация на спавн"
-
-msgid "enable/disable warping to your island."
-msgstr "вкл/выкл точки перемещения на ваш остров"
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4Ваш остров закрыт. Вы должны открыть его перед включением точек "
-"перемещения."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d активировал остров перекос."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d деактивировал точку перемещения на острове."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr "§cУ вас недостаточно прав для вкл/выкл точек перемещения на острове!"
-
-msgid "display the top10 of islands"
-msgstr "показать ТОП 10 островов"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr ""
-
-msgid "trust/untrust a player to help on your island."
-msgstr "доверять/не доверять игроку на вашем острове"
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eЭтим игрокам доверяют на вашем острове:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eЭти хозяева доверяют вам:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr "§eДля доверия/не доверия на острове введите /island trust <player>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4Игрок уже в доверенных!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Неизвестный игрок {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eВам не доверяют на острове §4{0}."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a {0} доверенный {1} на острове"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eВам больше не доверяют на острове §4{0}."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0} отозвана доверие {1} на острове"
-
-msgid "warp to another player''s island"
-msgstr "перемещение на остров другого игрока"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr ""
-"§aВаша точка перемещения активна, игроки могут перемещаться к вам на остров."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§4Ваша точка перемещения отключена, игроки не могут перемещаться к вам на "
-"остров."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr "§fУстановите точку перемещения в этом месте командой §e/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr ""
-"§fПереключение вкл/выкл точки перемещения командой §e/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr ""
-"§4У вас недостаточно прав для создания точки перемещения на ваш остров!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr ""
-"§fПереместиться на другой остров можно командой §e/island warp <player>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4У вас недостаточно прав для перемещения на другой остров!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§cВаш остров в процессе создания. Вы не можете сейчас переместиться на "
-"острова других игроков."
-
-msgid "§4That player does not exist!"
-msgstr "§4Игрок не существует!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4Игрок не имеет активных точек перемещения."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§cОстров этого игрока в процессе создания. Вы не можете переместиться сейчас."
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cВНИМАНИЕ: §9{0}§e переместился на ваш остров!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4Этот игрок запретил вам перемещаться на свой остров."
-
-msgid "general island command"
-msgstr "основные команды острова"
-
-msgid "allows user to bypass cooldowns"
-msgstr ""
-
-msgid "allows user to bypass visitor-protections"
-msgstr ""
-
-msgid "allows user to bypass teleport-delay"
-msgstr ""
-
-msgid "allows user to use [usb] signs"
-msgstr ""
-
-msgid "allows user to place [usb] signs"
+msgid "{0}''s Wither"
 msgstr ""
 
 msgid "§eYou can not use another island''s portals!"
@@ -1736,33 +101,6 @@ msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr ""
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr ""
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eПосетители не могут упасть детали!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "владелец: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "Вы не можете забрать награбленное других игроков, когда вы гость!"
-
-msgid "Config:"
-msgstr "конфиг:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§cНет доступа! §eYou пытаются телепортироваться на крышу §cNETHER§e, что не "
-"допускается."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr ""
@@ -1806,6 +144,16 @@ msgstr "§eВы можете использовать спавн-яйца тол
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§cВы достигли предела спавнов на вашем острове."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eПосетители не могут упасть детали!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "владелец: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "Вы не можете забрать награбленное других игроков, когда вы гость!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cBanned:§e Вы запрещены с этого острова."
 
@@ -1813,13 +161,66 @@ msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr ""
 "§cзапертый:§e Этот остров заблокирован! Ни одна из записей не допускается."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eВ ожидании своей очереди §c{0,number,##.#}"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr ""
+"Что-то пошло не так, при сохранении острова и/или данных по участникам "
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr ""
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr ""
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Создание острова... §e{0,number,##.#}"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr ""
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr ""
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4Игрок уже прикреплен к острову!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4Вы должны быть ближе к острову, чтобы установить на нем точку дома!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aТочка дома на вашем острове установлена в текущем месте."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4Ваше текущее место не безопасно для точки дома."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr "§cВаш остров в процессе создания. Вы не можете создать сейчас."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "Невозможно создать остров. Свяжитесь с администратором сервера."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+"§eСоздание острова началось, подождите, это может занять некоторое время."
+
+msgid "§cCommand is currently disabled!"
+msgstr ""
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eПо прежнему мало блоков: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1832,9 +233,6 @@ msgid ""
 msgstr ""
 "§eДелать §9{0}§e §cРИСКОВАННО§e. Повторите команду через §a{1}§e сек. для "
 "подтверждения!"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** Вы входите на защищенный, но заброшенный остров."
@@ -1868,210 +266,32 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4Вы должны быть хозяином острова, чтобы открыть его!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eВ ожидании своей очереди §c{0,number,##.#}"
+
+#, java-format
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Создание острова... §e{0,number,##.#}"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lЗадание заблокировано"
+
+msgid "READY"
 msgstr ""
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr ""
-
-#, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr ""
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr ""
-
-msgid "SUCCESS"
-msgstr ""
-
-msgid "FAILED"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4Не найден импортер с именем §e{0}"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr ""
-
-msgid "The island has been created."
-msgstr "Остров был создан."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d запер остров."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§4С момента закрытия острова точка перемещения деактивирована."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d разблокировать остров."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cSKY §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d удален из участников острова."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr ""
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
+msgid "§4The {0} challenge is not available yet!"
 msgstr ""
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
-msgstr ""
-"§cОстров владеющим этот кусок тартарары время удаления! Отправка вам на "
-"нерест."
-
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§cОстров, на котором вы находитесь - удален! Телепортация на спавн."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eWALL OF FAME (страница {0} из {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
 
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eВаш ранг: §f{0}"
-
-msgid "UNKNOWN"
+msgid "§cNot enough items in chest to complete challenge!"
 msgstr ""
-
-msgid "ANIMAL"
-msgstr ""
-
-msgid "MONSTER"
-msgstr ""
-
-msgid "VILLAGER"
-msgstr ""
-
-msgid "GOLEM"
-msgstr ""
-
-#, java-format
-msgid "§c{0}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr ""
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr ""
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aПоздравления! §eВаш остров появился."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cЗаметка:§e Строительство все еще может быть на постоянной основе."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "использование §9/is h§r или §9/is§r меню, чтобы пойти туда."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr ""
-"§cСторожевая собака!§9 Не удалось найти сундук в пределах {0}, выручая."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr ""
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr ""
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr ""
-
-msgid "Return"
-msgstr "Вернуть"
-
-msgid "§9Integer Editor"
-msgstr "§9Integer редактор"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eКонфигурация сохранена и перезагружается."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cошибка! §9Unable to save config file!"
-
-msgid "§3First Page"
-msgstr ""
-
-msgid "§3Last Page"
-msgstr ""
-
-msgid "§cSave & Reload config"
-msgstr "§cСохранить & Перезагрузить конфигурации"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Сохранение настроек в\n"
-"§7файл и перезагружает снова.\n"
-"§cЗаметка: §7Используйте с осторожностью!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (только для чтения)"
 
 msgid "true"
 msgstr "правда"
@@ -2496,6 +716,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr ""
 
+#, java-format
+msgid "§7Page {0}"
+msgstr ""
+
 msgid "§7First Page"
 msgstr ""
 
@@ -2785,8 +1009,8 @@ msgstr ""
 msgid "Island Restart Menu"
 msgstr ""
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr ""
+msgid "Config:"
+msgstr "конфиг:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2802,112 +1026,117 @@ msgstr ""
 msgid "§aClick to restart!"
 msgstr ""
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr ""
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr ""
+
+msgid "Return"
+msgstr "Вернуть"
+
+msgid "§9Integer Editor"
+msgstr "§9Integer редактор"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9Текстовый редактор"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eКонфигурация сохранена и перезагружается."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cошибка! §9Unable to save config file!"
+
+msgid "§3First Page"
+msgstr ""
+
+msgid "§3Last Page"
+msgstr ""
+
+msgid "§cSave & Reload config"
+msgstr "§cСохранить & Перезагрузить конфигурации"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Сохранение настроек в\n"
+"§7файл и перезагружает снова.\n"
+"§cЗаметка: §7Используйте с осторожностью!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (только для чтения)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4Не найден импортер с именем §e{0}"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr ""
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr ""
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr ""
+
+msgid "SUCCESS"
+msgstr ""
+
+msgid "FAILED"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr ""
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
-msgstr ""
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§eОтправка вам на нерест."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr ""
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aВы будете телепортированы через {0} сек."
-
-msgid "§7Teleport cancelled"
-msgstr ""
-
-msgid "READY"
-msgstr ""
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr ""
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr ""
-"Что-то пошло не так, при сохранении острова и/или данных по участникам "
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr ""
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr ""
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr ""
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4Игрок уже прикреплен к острову!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr ""
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr ""
-
-msgid "§aTeleporting you to your island."
-msgstr "§aТелепортация на ваш остров."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Невозможно переместить вас на остров этого игрока!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aТелепортация на остров игрока {0}."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4Вы должны быть ближе к острову, чтобы установить на нем точку дома!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aТочка дома на вашем острове установлена в текущем месте."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4Ваше текущее место не безопасно для точки дома."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cВаш остров в процессе создания. Вы не можете создать сейчас."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "Невозможно создать остров. Свяжитесь с администратором сервера."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-"§eСоздание острова началось, подождите, это может занять некоторое время."
-
-msgid "§cCommand is currently disabled!"
 msgstr ""
 
 msgid "North"
@@ -2932,4 +1161,1771 @@ msgid "West"
 msgstr ""
 
 msgid "North-West"
+msgstr ""
+
+msgid "The island has been created."
+msgstr "Остров был создан."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d запер остров."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§4С момента закрытия острова точка перемещения деактивирована."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d деактивировал точку перемещения на острове."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d разблокировать остров."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cSKY §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d удален из участников острова."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr ""
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr ""
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aПоздравления! §eВаш остров появился."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cЗаметка:§e Строительство все еще может быть на постоянной основе."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "использование §9/is h§r или §9/is§r меню, чтобы пойти туда."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr ""
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr ""
+"§cСторожевая собака!§9 Не удалось найти сундук в пределах {0}, выручая."
+
+msgid "UNKNOWN"
+msgstr ""
+
+msgid "ANIMAL"
+msgstr ""
+
+msgid "MONSTER"
+msgstr ""
+
+msgid "VILLAGER"
+msgstr ""
+
+msgid "GOLEM"
+msgstr ""
+
+#, java-format
+msgid "§c{0}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr ""
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§cОстров владеющим этот кусок тартарары время удаления! Отправка вам на "
+"нерест."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§cОстров, на котором вы находитесь - удален! Телепортация на спавн."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eWALL OF FAME (страница {0} из {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr ""
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4Уровень острова отключен, свяжитесь с администратором."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eВаш ранг: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr ""
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Выполнено {0}"
+
+msgid "to unlock this rank"
+msgstr "для разблокировки звания"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Требования будут сброшены через {0} д."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Требования будут сброшены через {0} ч."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4Требования будут сброшены через {0} мин."
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr ""
+
+msgid "§7and more..."
+msgstr ""
+
+msgid "§eItems will be traded for reward."
+msgstr ""
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr ""
+
+msgid "§6Item Reward: §a"
+msgstr "§6Награда предметами: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Награда деньгами: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Награда опыт: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dПолное время выполнения: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4Не найдено задание {0}"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4Вам надо быть на острове, чтобы сделать это!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4Задание {0} нельзя повторить!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr ""
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr "§4Должно быть {0} блоков из всех требуемых предметов."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4Для завершения задания остров должен иметь уровень {0}!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Неизвестный тип задания: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§eПо прежнему мало существ:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr ""
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eУ вас мало предметов:{0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aВы выполнили задание {0} !"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9 {0} §f завершил § 9 {1} §f вызов!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§eНаграда: §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eНаграда опыт: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eНаграда деньгами: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eВаш инвентарь §4переполнен§e. Предметы брошены на землю."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lНажмите для завершения задания."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lВы не можете повторить задание."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Звание: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fЗавершено большинство заданий в"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fэто звание разблокировало следующее."
+
+msgid "§eClick here to show previous page"
+msgstr "§eНажмите для просмотра предыдущей страницы"
+
+msgid "§eClick here to show next page"
+msgstr "§eНажмите для просмотра следующей страницы"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "Но вы в полном одиночестве!"
+
+msgid "But you are Yelling in the wind!"
+msgstr "Но вы кричите ветру!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "Но ваши придуманные друзья ушли!"
+
+msgid "But you are Talking to your self!"
+msgstr "Но вы разговариваете сами с собой!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cИзвините! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr ""
+
+msgid "party"
+msgstr ""
+
+msgid "island"
+msgstr ""
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr ""
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr ""
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr ""
+
+msgid "§cCommand only available to players"
+msgstr ""
+
+msgid "talk to your island party"
+msgstr "говорить с участниками вашего острова"
+
+msgid "talk to players on your island"
+msgstr "говорить с игроками на своем острове"
+
+msgid "manually update the top 10 list"
+msgstr "ручное обновление списка ТОП 10"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eГенерирование списка ТОП 10"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eгенерация списка ТОП 10 завершена"
+
+msgid "purges all abandoned islands"
+msgstr "очистка всех заброшенных островов"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4Вам нужно указать возраст в днях для очистки!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr ""
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr ""
+
+msgid "Controls player-cooldowns"
+msgstr "Controls player-cooldowns"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "clears the cooldown on a command (* = all)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eИгрок в оффлайн"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Cleared cooldown on {0} for {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "No active cooldown on {0} for {1} detected!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Неверная команда, только перезапуск и биом поддерживаются"
+
+msgid "restarts the cooldown on the command"
+msgstr "перезапускает время перезарядки по команде"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eReset cooldown on {0} for {1}§e to {2} seconds"
+
+msgid "lists all the active cooldowns"
+msgstr "lists all the active cooldowns"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCmd Cooldown"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eNo active cooldowns for §9{0}§e found."
+
+msgid "toggles maintenance mode"
+msgstr ""
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr ""
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Job Статистика"
+
+msgid "§7----------------"
+msgstr "§7------------------------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/работа"
+
+msgid "ms/tick"
+msgstr "ms/ТИК"
+
+msgid "ticks"
+msgstr "тиков"
+
+msgid "act"
+msgstr "акт"
+
+msgid "time"
+msgstr "время"
+
+msgid "name"
+msgstr "имя"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§eИгрок {0} не имеет острова!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eНекорректный игрок {0}."
+
+msgid "flushes all caches to files"
+msgstr "очистить все кэши к файлам"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+"§eПромываемое §a {0} острова§e, §b {1} игроков и § 6 {2} вызов-пополнений."
+
+msgid "tries to fix the the area of flatland."
+msgstr "попытка исправить территорию на равнине"
+
+msgid "§4No valid island found"
+msgstr "§4Подходящего острова не найдено"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4Равнина не найдена на острове {0}!"
+
+msgid "manage orphans"
+msgstr "управления сиротами"
+
+msgid "count orphans"
+msgstr "количество сирот"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr ""
+"§eСтарое место острова {0} будет использоваться, пока не появится новое."
+
+msgid "clear orphans"
+msgstr "очистить сирот"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eОчистка всех старых (пустых) островов."
+
+msgid "list orphans"
+msgstr "список сирот"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eСироты не зарегистрированы."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "сделать хозяином другого игрока"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4Игрок {0} не имеет острова для передачи!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eИгрок §d{0}§e уже имеет остров.§eСначала введите §d/usb island remove "
+"<name>§e для его удаления."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bХозяин изменен у {0}§b на {1}"
+
+msgid "open GUI for config"
+msgstr "открыт графический интерфейс для конфигурации"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr ""
+
+msgid "teleport to another players island"
+msgstr "телепортация на остров другого игрока"
+
+msgid "§4Only supported for players"
+msgstr "§4Поддерживается только для игроков"
+
+msgid "§4That player does not have an island!"
+msgstr "§4Этот игрок не имеет острова!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr ""
+
+msgid "various WorldGuard utilities"
+msgstr "различные утилиты WorldGuard"
+
+msgid "refreshes the chunks around the player"
+msgstr "обновление чанков вокруг игрока"
+
+msgid "§eResending chunks to the client"
+msgstr "§eСброс чанков в клиенте"
+
+msgid "load the region chunks"
+msgstr "загрузка чанков региона"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eЗагрузка чанков у {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eВыгрузка чанков у {0}"
+
+msgid "update the WG regions"
+msgstr ""
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr ""
+
+msgid "§eNo island found at your location!"
+msgstr ""
+
+msgid "refreshes the chunk around the player"
+msgstr ""
+
+msgid "region manipulations"
+msgstr ""
+
+msgid "shows the borders of the current island"
+msgstr ""
+
+msgid "§eNo island found at your current location"
+msgstr ""
+
+msgid "§eCan only be executed as a player"
+msgstr ""
+
+msgid "shows the borders of the current chunk"
+msgstr ""
+
+msgid "shows the borders of the inner-chunks"
+msgstr ""
+
+msgid "shows the non-chunk-aligned borders"
+msgstr ""
+
+msgid "shows the borders of the outer-chunks"
+msgstr ""
+
+msgid "hides the regions again"
+msgstr ""
+
+msgid "§eStopped displaying regions"
+msgstr ""
+
+msgid "§eNo currently shown regions for this player"
+msgstr ""
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr ""
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr ""
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4ПРОДУВКА: §9 Закончено продувкой заброшенных островов."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr ""
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr ""
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr ""
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr ""
+
+msgid "control debugging"
+msgstr "управление отладкой"
+
+msgid "set debug-level"
+msgstr "установка уровня отладки"
+
+msgid "toggle debug-logging"
+msgstr "переключение журнала отладки"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4Ведение журнал отключено, вы не можете отключить его!"
+
+msgid "flush current content of the logger to file."
+msgstr "сбросить текущее содержание журнала в файл"
+
+msgid "§eLog-file has been flushed."
+msgstr "§eФайл журнала обновлен."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4Ведение журнала не включено, введите §d/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Некорректные аргументы, попробуйте INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eВедение журнала отключено!"
+
+msgid "advanced command for setting island-data"
+msgstr ""
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr ""
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr ""
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr ""
+
+msgid "set a player''s island to your location"
+msgstr "установка острова игрока в вашей позиции"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr ""
+
+msgid "shows the NBTTag for the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr ""
+
+msgid "§cNo item in hand!"
+msgstr ""
+
+msgid "sets the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "adds the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "Manage challenges for a player"
+msgstr "Управлять заданиями для игрока"
+
+msgid "resets the challenge for the player"
+msgstr "сбросить задание для игрока"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4Задание никогда не будет выполнено"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§eзадание: {0} сброшено для игрока {1}"
+
+msgid "resets all challenges for the player"
+msgstr "сбросить все задания для игрока"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§eУ игрока {0} сброшены все задания."
+
+msgid "complete all challenges in the rank"
+msgstr ""
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4Игрок с именем {0} не найден!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr ""
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4Задание с названием {0} не найдено!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr ""
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "защита всех островов (затратно по времени)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr ""
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§eЗапуск защиты всего. Это займет немного времени."
+
+msgid "reload configuration from file."
+msgstr "перезагрузка конфигурации из файла"
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eКонфигурация перезагружена из файла."
+
+msgid "manage islands"
+msgstr "управление островом"
+
+msgid "protects the island"
+msgstr "защита острова"
+
+msgid "delete the island (removes the blocks)"
+msgstr "удалить остров (убрать блоки)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Удален заброшенный остров по вашим координатам."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4Остров в этом месте имеет участников!\n"
+"§eВведите §9/usb island delete <name>§e для его удаления."
+
+msgid "removes the player from the island"
+msgstr "удаление игрока с острова"
+
+msgid "adds the player to the island"
+msgstr "добавляет игроку острова"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d присоединился к вашему острову."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§ 4 Ни один игрок с именем {0} не найдено!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+"§4No действительный остров при условии, либо стоять в пределах одного, или "
+"предоставить имя острова"
+
+msgid "print out info about the island"
+msgstr "вывод информации об острове"
+
+msgid "sets the biome of the island"
+msgstr "установка биома для острова"
+
+msgid "§4That player has no island."
+msgstr "§4Этот игрок не имеет острова."
+
+msgid "§4No valid island at your location"
+msgstr "§4В этом месте нет подходящих островов"
+
+msgid "purges the island"
+msgstr "очистка острова"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4Ошибка! §9Нет подходящих островов для очистки."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cОЧИСТКА: §9Очищен остров {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "переключения статуса игнорирования"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cПереключение острова {0} в игнорирование для ТОП10 и очистки."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cОтмена игнорирования острова  {0}, теперь он показывается в ТОП10 и "
+"очистке."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Имя игрока недействительно."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Удаление {0} с острова"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eИзменен биом острова {0} на {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eИзменен биом острова {0} на Океан."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr ""
+"§aВы должны отправится на спавн или перезайти, чтобы увидеть изменения."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} изменил биом на  {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} изменил биом на Океан."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eУдаление острова  {0}."
+
+msgid "Error: That player does not have an island!"
+msgstr "Ошибка: Игрок не имеет острова"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§eОстров {0} в {1} защищен"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4Остров {0} в {1} уже был защищен"
+
+msgid "displays version information"
+msgstr "показать информацию о версии"
+
+msgid "imports players and islands from other formats"
+msgstr "импортирование игроков и островов в другие форматы"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr ""
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "изменяет язык плагина, и перезагружается"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aуспешно изменен язык §e {0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cНе удалось изменить язык §e{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Поддерживаемые Языки:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cНе удалось найти каких-либо языков."
+
+msgid "advanced command for getting island-data"
+msgstr ""
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "показать информацию по игроку"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4Ваш остров заполнен или вы больше не можете приглашать новых участников."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4Этот игрок уже владеет другим островом."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e пытался пригласить вас, но вы уже приглашены."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e пригласил вас присоединится к острову!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr ""
+"§f/island [accept/reject]§e для согласия или отказа на предложения "
+"присоединится."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr ""
+"§4ВНИМАНИЕ: Вы потеряете свой текущий остров, если согласитесь "
+"присоединиться!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d приглашен игроком {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e отклонил предложение."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4Вы не можете использовать эту команду сейчас. Откажитесь от участия на "
+"другом острове сначала."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§aВы присоединились к острову! Введите /island party для просмотра других "
+"участников."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§eПриглашение для {0}§e было просрочено или отменено."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§eПриглашение на остров игрока {0} было просрочено или отменено."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§eВы приняли приглашения о присоединении к острову."
+
+msgid "§4You haven't been invited."
+msgstr "§4Вы не были приглашены."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eВы отклонили предложение о присоединении к острову"
+
+msgid "general island command"
+msgstr "основные команды острова"
+
+msgid "allows user to bypass cooldowns"
+msgstr ""
+
+msgid "allows user to bypass visitor-protections"
+msgstr ""
+
+msgid "allows user to bypass teleport-delay"
+msgstr ""
+
+msgid "allows user to use [usb] signs"
+msgstr ""
+
+msgid "allows user to place [usb] signs"
+msgstr ""
+
+msgid "complete and list challenges"
+msgstr ""
+
+msgid "§cCommand only available for players."
+msgstr ""
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eЗадания выключены. Свяжитесь с администратором."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4Отправить задания возможно только в мире skyblock!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4Отправить задание можно только если у вас есть остров!"
+
+msgid "warp to another player''s island"
+msgstr "перемещение на остров другого игрока"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr ""
+"§aВаша точка перемещения активна, игроки могут перемещаться к вам на остров."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§4Ваша точка перемещения отключена, игроки не могут перемещаться к вам на "
+"остров."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr "§fУстановите точку перемещения в этом месте командой §e/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr ""
+"§fПереключение вкл/выкл точки перемещения командой §e/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr ""
+"§4У вас недостаточно прав для создания точки перемещения на ваш остров!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr ""
+"§fПереместиться на другой остров можно командой §e/island warp <player>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4У вас недостаточно прав для перемещения на другой остров!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cВаш остров в процессе создания. Вы не можете сейчас переместиться на "
+"острова других игроков."
+
+msgid "§4That player does not exist!"
+msgstr "§4Игрок не существует!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4Игрок не имеет активных точек перемещения."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§cОстров этого игрока в процессе создания. Вы не можете переместиться сейчас."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cВНИМАНИЕ: §9{0}§e переместился на ваш остров!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4Этот игрок запретил вам перемещаться на свой остров."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4Нет острова. §eВведите §b/is create§e для создания острова"
+
+msgid "accept/reject an invitation."
+msgstr "принять/отклонить приглашение."
+
+msgid "leave your party"
+msgstr "выход из группы"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4Вы не можете покинуть остров, если вы единственный участник. Введите /"
+"island restart, чтобы получить новый остров!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§eВы владелец острова, введите /island remove <player>."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eВы покинули остров и возвращены на спавн."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0} покинул ваш остров!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4Чтобы отказаться от членства на острове нужно быть в мире skyblock!"
+
+msgid "check your or anothers island level"
+msgstr "проверка уровня своего и чужого острова"
+
+msgid "allows user to query for others levels"
+msgstr ""
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eДля выполнения этой команды нужно быть на своем острове."
+
+msgid "§4You do not have an island!"
+msgstr "§4У вас нет острова!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4У вас нет доступа к этой команде!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4Неверно указан игрок или у него нет острова!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eИнформация об острове {0}:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aУровень острова {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9Ранг {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "создание острова"
+
+msgid "exempt player from create-cooldown"
+msgstr ""
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4Остров найден!§e Вы уже имеете остров. Если хотите очистить его, "
+"введите§b /is restart"
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4Остров найден!§e Вы уже участник этого острова. Чтобы создать свой, "
+"сначала введите §b /is leave"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eВы сможете создать новый остров через {0,number,#} сек."
+
+msgid "invite a player to your island"
+msgstr "пригласить игрока на свой остров"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§eВведите§f /island invite <playername>§e для отправки приглашения игроку на "
+"свой остров."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4Только хозяин острова может приглашать!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aВы можете пригласить еще {0} игроков."
+
+msgid "§4You can't invite any more players."
+msgstr "§4Вы больше не можете приглашать игроков."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4У вас недостаточно прав для приглашения других на остров!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4Этот игрок оффлайн или не существует."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4Вы не можете пригласить себя!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4Этот игрок - лидер вашего острова!"
+
+msgid "lock your island to non-party members."
+msgstr "блокировать остров от посторонних игроков."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4У вас недостаточно прав для блокировки вашего острова!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4У вас недостаточно прав для выполнения этой команды!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4У вас недостаточно прав для разблокировки вашего острова!"
+
+msgid "display the top10 of islands"
+msgstr "показать ТОП 10 островов"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr ""
+
+msgid "remove a member from your island."
+msgstr "удаление участников острова."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4У вас недостаточно прав, чтобы выбрасывать игроков с этого острова!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4Вы не можете убрать лидера острова!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4Прекратите себя выбрасывать!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0} удалил вас со своего острова!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} удален с острова."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr ""
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0} выброшен с острова."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr "§4Этот игрок не участник вашего острова и не на вашем острове!"
+
+msgid "teleport to the island home"
+msgstr "телепортация на остров"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§cВаш остров в процессе создания, вы не можете пока на него "
+"телепортироваться."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4Это команда может быть запущена только игроком"
+
+msgid "transfer leadership to another member"
+msgstr "передать лидерство другому игроку"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4Владение островом можно передать только участнику острова!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e уже владелец этого острова!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4Только хозяин может передать управление!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} пытался захватить остров!"
+
+msgid "show party information"
+msgstr "информация об участниках острова"
+
+msgid "shows information about your party"
+msgstr "показать информацию об участниках острова"
+
+msgid "show pending invites"
+msgstr "ожидающие приглашения"
+
+msgid "§eNo pending invites"
+msgstr "§eНет ожидающих приглашения"
+
+msgid "withdraw an invite"
+msgstr "вывести приглашение"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4У вас недостаточно прав для отмены приглашений."
+
+msgid "check your or another''s island info"
+msgstr "проверить информацию вашего или другого острова"
+
+msgid "allows user to see others island info"
+msgstr ""
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eБлоки на острове игрока {0} (страница {1,number} из {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Score Count Block"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "доверять/не доверять игроку на вашем острове"
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eЭтим игрокам доверяют на вашем острове:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eЭти хозяева доверяют вам:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr "§eДля доверия/не доверия на острове введите /island trust <player>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4Игрок уже в доверенных!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Неизвестный игрок {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eВам не доверяют на острове §4{0}."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a {0} доверенный {1} на острове"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eВам больше не доверяют на острове §4{0}."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0} отозвана доверие {1} на острове"
+
+msgid "delete your island and start a new one."
+msgstr "удаление вашего острова и создание нового"
+
+msgid "exempt player from restart-cooldown"
+msgstr ""
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4Только владелец может перезапустить остров. Покиньте этот остров, чтобы "
+"создать свой (/island leave)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eВы должны выбросить всех участников с острова, чтобы перезапустить его (/"
+"island kick <player>). Список участников острова /island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§cВы можете перезапустить свой остров через {0} сек."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr "§cВаш остров в процессе создания. Вы не можете перезапустить его."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§eВНИМАНИЕ: Ваш остров и все ваши вещи будут сброшены!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "телепортация на спавн"
+
+msgid "change the biome of the island"
+msgstr "изменение биома острова"
+
+msgid "exempt player from biome-cooldown"
+msgstr ""
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr ""
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr "§cУ вас недостаточно прав для изменения биома вашего текущего острова."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4У вас недостаточно прав для изменения биома острова!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eДля изменения биома вы должны быть на своем острове!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr ""
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eВы сможете изменить биом снова через {0,number,#} мин."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§cУ вас недостаточно прав для изменения биома острова на указанный."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr ""
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aВы изменили биом острова на {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} изменил биом острова на {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr ""
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr ""
+
+msgid "set your island''s warp location"
+msgstr "установка точки перемещения"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cУ вас недостаточно прав для установки точки перемещения на острове!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr ""
+"§cВы должны быть владельцем острова, чтобы установить точку перемещения!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d изменил точку перемещения на острове."
+
+msgid "teleports you to your island (or create one)"
+msgstr ""
+
+msgid "ban/unban a player from your island."
+msgstr "блокировать/разблокировать игрока на вашем острове."
+
+msgid "exempts user from being banned"
+msgstr ""
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§eУказанным игрокам запрещено появляться на вашем острове:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr ""
+"§eДля блокировки/разблокировки игроков на вашем острове используйте /island "
+"ban <player>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4Вы не можете заблокировать участника. Сначала исключите его!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4у вас недостаточно прав, чтобы выбрасывать или блокировать игроков."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr ""
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr ""
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eВы запретили игроку §4{0}§e посещать ваш остров."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eВы были §cзапретило §eот {0} §eострова'' s."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§eВы разрешили игроку §a{0}§e посещать ваш остров."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eВы были §aUNBANNED§e из {0}§e''s остров."
+
+msgid "display log"
+msgstr "журнал дисплей"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "установка точки дома"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "вкл/выкл точки перемещения на ваш остров"
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4Ваш остров закрыт. Вы должны открыть его перед включением точек "
+"перемещения."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d активировал остров перекос."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr "§cУ вас недостаточно прав для вкл/выкл точек перемещения на острове!"
+
+msgid "try to complete a challenge"
+msgstr ""
+
+msgid "show information about the challenge"
+msgstr ""
+
+msgid "§eRank: "
+msgstr "§eЗвание: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4Это задание нельзя повторить!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr "§4У вас заберут все необходимые предметы, если вы завершите задание!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4Все требуемые предметы должны быть размещены на вашем острове в {0} блоках."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§eДля завершения задания введите §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4Неверное название задания! Введите /c help для подробной информации"
+
+msgid "§eSending you to spawn."
+msgstr "§eОтправка вам на нерест."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr ""
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr ""
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr ""
+
+msgid "§aTeleporting you to your island."
+msgstr "§aТелепортация на ваш остров."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aВы будете телепортированы через {0} сек."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Невозможно переместить вас на остров этого игрока!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aТелепортация на остров игрока {0}."
+
+msgid "§7Teleport cancelled"
 msgstr ""

--- a/uSkyBlock-Core/src/main/po/sv.po
+++ b/uSkyBlock-Core/src/main/po/sv.po
@@ -21,6 +21,34 @@ msgstr ""
 "X-Loco-Target-Locale: zz_ZZ\n"
 "X-Generator: Poedit 1.8.9\n"
 
+# ???
+msgid "d"
+msgstr "d"
+
+# ???
+msgid "h"
+msgstr "h"
+
+# ???
+msgid "m"
+msgstr "m"
+
+# ???
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§eDu har inte tillgång (§4{0}§e)"
@@ -28,6 +56,15 @@ msgstr "§eDu har inte tillgång (§4{0}§e)"
 #, java-format
 msgid "§eInvalid command: {0}"
 msgstr "§eOgiltigt kommando: {0}"
+
+msgid "Command"
+msgstr "Kommando"
+
+msgid "Permission"
+msgstr "Rättighet"
+
+msgid "Description"
+msgstr "Beskrivning"
 
 #, java-format
 msgid "§7Usage: {0}"
@@ -52,1672 +89,12 @@ msgstr "Skrev dokumentation till {0}"
 msgid "§4Error writing documentation: {0}"
 msgstr "§4Kunde inte skriva dokumentation: {0}"
 
-msgid "Command"
-msgstr "Kommando"
+msgid "§cWither Despawned!§e It wandered too far from your island."
+msgstr "§cWither har despawnat! §eDen gick för långt ifrån din ö."
 
-msgid "Permission"
-msgstr "Rättighet"
-
-msgid "Description"
-msgstr "Beskrivning"
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-# ???
-msgid "d"
-msgstr "d"
-
-# ???
-msgid "h"
-msgstr "h"
-
-# ???
-msgid "m"
-msgstr "m"
-
-# ???
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eFöljande block saknas: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§cKraven kommer att återställas om {0} dagar."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§cKraven kommer att återställas om {0} timmar."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§cKraven kommer att återställas om {0} minuter."
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr "§eDetta uppdrag kräver:"
-
-msgid "§7and more..."
-msgstr "§7och mer..."
-
-msgid "§eItems will be traded for reward."
-msgstr "§eSakerna byts ut mot en belöning."
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr "§eMåste vara inom {0} block."
-
-msgid "§6Item Reward: §a"
-msgstr "§6Belöning: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Belöning (valuta): §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Belöning (exp): §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dAntal gånger genomfört: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr "§7Kräver {0}"
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§cInget uppdrag kallat {0} hittades"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§cDu måste vara på din ö för att göra detta!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§cUppdraget {0} är inte tillgängligt än!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§cUppdraget {0} är inte repeterbart!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§eFörsöker att klara uppdraget §a{0}"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr "§cDu måste stå inom minst {0} block ifrån allt krävda material."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§cDin skyblock level måste vara minst {0} för att göra detta uppdrag."
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§cOkänt typ av uppdrag: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr "§eFöljande enheter saknas: {0}"
-
-# ???
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eFöljande material saknas: {0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aDu har genomfört uppdraget {0}!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9{0}§f har klarat av uppdraget {1}!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§eBelöning: §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eBelöning (exp): §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eBelöning (valuta): §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eDitt inventarie är fullt. Belöningen kastades ut där du står."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lKlicka här för att göra detta uppdrag."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§c§lDu kan inte repetera detta uppdrag."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Rank: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fGenomför de flesta uppdragen i"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fdenna rank för att låsa upp nästa rank."
-
-msgid "§eClick here to show previous page"
-msgstr "§eKlicka här för att visa föregående sida"
-
-msgid "§eClick here to show next page"
-msgstr "§eKlicka här för att visa nästa sida"
-
-msgid "§4§lLocked Challenge"
-msgstr "§c§lLåst uppdrag"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "§7Slutför {0} fler {1} §7uppdrag"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Slutför {0}"
-
-msgid "to unlock this rank"
-msgstr "för att låsa upp denna rank"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "Men du är HELT ENSAM! :("
-
-msgid "But you are Yelling in the wind!"
-msgstr "Men du ropar i vinden!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "Dina fantasikompisar är inte online!"
-
-msgid "But you are Talking to your self!"
-msgstr "Men du pratar med dig själv!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cLedsen! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr ""
-"Skicka antingen ett meddelande direkt till gruppen, eller skifta det på/av."
-
-msgid "party"
-msgstr "party"
-
-msgid "island"
-msgstr "ö"
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§cSkiftade chatten till {0} §aPÅ"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§cRepetera §9{0}§c för att inaktivera de"
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§aSkiftade chatten till §cAV§a för {0}"
-
-msgid "§cCommand only available to players"
-msgstr "§cKommandot är endast tillgängligt för spelare"
-
-msgid "talk to players on your island"
-msgstr "prata med spelare på ön"
-
-msgid "talk to your island party"
-msgstr "prata med skyblockgruppen"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§eSpelaren {0} har ingen ö!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eFelaktigt spelarnamn {0} angivet."
-
-msgid "Manage challenges for a player"
-msgstr "Hantera uppdrag för en spelare"
-
-msgid "resets the challenge for the player"
-msgstr "återställer uppdraget för spelaren"
-
-msgid "§4Challenge has never been completed"
-msgstr "§cUppdraget har aldrig genomförts"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§euppdrag: {0} har återställts för {1}"
-
-msgid "resets all challenges for the player"
-msgstr "återställer alla uppdrag för spelaren"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0} har fått alla uppdrag återställda."
-
-msgid "complete all challenges in the rank"
-msgstr "slutför alla uppdrag i ranken"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§cIngen spelare med namnet {0} hittades!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§cUppdraget {0} har redan slutförts"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§eUppdraget {0} har slutförts för {1}"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§cInget uppdrag med namnet {0} hittades!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§cIngen rank kallad {0} hittades!"
-
-msgid "manage islands"
-msgstr "hantera öar"
-
-msgid "protects the island"
-msgstr "skyddar ön"
-
-msgid "delete the island (removes the blocks)"
-msgstr "tar bort ön (endast blocken)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Raderade ön som var kopplad till din nuvarande position."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§cÖn vid denna position har medlemmar!\n"
-"§eAnvänd §9/usb island delete <namn>§e för att ta bort den."
-
-msgid "removes the player from the island"
-msgstr "tar bort spelaren från ön"
-
-msgid "adds the player to the island"
-msgstr "lägger till spelaren till ön"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d har gått med din grupp."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§cIngen spelare kallad {0} hittades!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr "§cIngen giltig ö försedd, antingen stå inom en eller förse med en namn"
-
-msgid "print out info about the island"
-msgstr "skriver ut information om ön"
-
-msgid "sets the biome of the island"
-msgstr "sätter öns biome"
-
-msgid "§4That player has no island."
-msgstr "§cDen spelaren har ingen ö."
-
-msgid "§4No valid island at your location"
-msgstr "§cIngen giltig ö vid din position"
-
-msgid "purges the island"
-msgstr "rensar ön"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§cFel! §9Ingen giltig ö hittades för rensning."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cRENSNING: §9Rensade ön vid {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "aktiverar eller inaktiverar öns ignoransstatus"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cSätt {0}s ö till att bli ignorerad från topp 10 och från rensning."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§cTog bort ignorans-flaggan från {0}s ö, den kommer nu visas i topp 10 och "
-"rensas."
-
-msgid "§4No valid player-name supplied."
-msgstr "§cInget giltigt spelarnamn angavs."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Tar bort {0} från ön"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eBytte biome på {0}s ö till {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eBytte biome på {0}s ö till OCEAN."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr "§aDu måste gå till spawn eller relogga för att se ändringarna."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} har fått sitt biome ändrat till {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} har fått sitt biome ändrat till OCEAN."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eTar bort {0}s ö."
-
-msgid "Error: That player does not have an island!"
-msgstr "Fel: Den spelaren har ingen ö!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§e{0}s ö vid {1} har skyddats"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§c{0}s ö vid {1} var redan skyddad"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "öppna GUI för konfiguration"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§eOgiltigt konfigurationsnamn"
-
-msgid "Controls player-cooldowns"
-msgstr "Kontrollerar spelares cooldowns"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "rensar cooldown för ett kommando (* = alla)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eDen spelaren är inte online just nu"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Tog bort cooldown på {0} för {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Ingen aktiv cooldown på {0} för {1} hittades!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Felaktigt kommando angivet, endast restart och biome stöds!"
-
-msgid "restarts the cooldown on the command"
-msgstr "börjar om cooldownen på ett kommando"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eÅterställer cooldown på {0} för {1}§e till {2} sekunder"
-
-msgid "lists all the active cooldowns"
-msgstr "listar alla aktiva cooldowns"
-
-# ???
-msgid "§eCmd Cooldown"
-msgstr "§eCmd Cooldown"
-
-# ???
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eIngen aktiv cooldown för §9{0}§e hittades."
-
-msgid "control debugging"
-msgstr "kontrollera felsökning"
-
-msgid "set debug-level"
-msgstr "sätt felsökningsnivå"
-
-# ???
-msgid "toggle debug-logging"
-msgstr "aktivera eller inaktivera felsökningsloggning"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§cLoggning var inte aktivt, så du kan inte stänga av det!"
-
-msgid "flush current content of the logger to file."
-msgstr "flytta nuvarande innehåll från loggen till en fil."
-
-msgid "§eLog-file has been flushed."
-msgstr "§eLogg-fil har blivit skapad."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr ""
-"§cLoggning är inte aktivt, använd §d/usb debug enable§4 för att aktivera"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§cFelaktigt argument, prova INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eLoggning inaktiverat!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "gör ett försök att fixa arean för flatland."
-
-msgid "§4No valid island found"
-msgstr "§cIngen giltig ö hittades"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§cIngen flatland hittades på {0}s ö!"
-
-msgid "flushes all caches to files"
-msgstr "flyttade alla caches till en fil"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr "§eFlyttade §a{0}s ö§e, §b{1} spelare och §6{2} uppdrag-slutförande."
-
-msgid "manually update the top 10 list"
-msgstr "uppdatera topp 10 manuellt"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eGenererar topp 10 listan"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eSlutförde generation av topp 10 listan"
-
-msgid "advanced command for getting island-data"
-msgstr "advancerat kommando för att hämta data om ö"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§eNuvarande värde för {0} är ''{1}''"
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§cKunde inte hämta tillstånd för {0}"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§eGiltiga fält är {0}"
-
-msgid "teleport to another players island"
-msgstr "teleportera till en annan spelares ö"
-
-msgid "§4Only supported for players"
-msgstr "§cStöds endast för spelare"
-
-msgid "§4That player does not have an island!"
-msgstr "§cDen spelaren har ingen ö!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr "§aTeleporterar dig till {0}§as ö"
-
-msgid "imports players and islands from other formats"
-msgstr "importerar spelare och öar från andra format"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Jobb statistik"
-
-# ???
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/job"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "akt"
-
-msgid "time"
-msgstr "tid"
-
-msgid "name"
-msgstr "namn"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "byter språk på pluginet och laddar om"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aSpråket har ändrats till §e{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cMisslyckades att byta språk till §e{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Språk som stöds:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 av {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cKan inte lokalisera några språk."
-
-msgid "transfer leadership to another player"
-msgstr "flytta ledarskap till en annan spelare"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§cSpelaren {0} har ingen ö att flytta!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§eSpelaren §f{0}§e har redan en ö. §eAnvänd §f/usb island remove <namn>§e "
-"för att ta bort spelaren först."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bLedarskap flyttat av {0}§b till {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr "advancerad info om NBT saker"
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "visar NBT taggen för saken du håller i"
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§eInformation för §9{0}"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - namn: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - nbttag: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§cDu måste hålla i något!"
-
-msgid "§eCan only be executed as a player"
-msgstr "§eKan endast utföras av spelare"
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "sätter NBT taggen för saken du håller i"
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "§eSatte §9{0}§e till §c{1}"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "lägger till NBT taggen för saken du håller i"
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§eLade till §9{0}§e till §c{1}"
-
-msgid "manage orphans"
-msgstr "hantera orphans"
-
-msgid "count orphans"
-msgstr "räkna orphans"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§e{0}gamla öars positioner kommer att användas för nya."
-
-msgid "clear orphans"
-msgstr "rensa orphans"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eRensar alla gamla (tomma) öars positioner."
-
-msgid "list orphans"
-msgstr "lista orphans"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eInga orphans är registrerade."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr "ytterligare förmåner {0}"
-
-msgid "protects all islands (time consuming)"
-msgstr "skyddar alla öar (tar tid)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§cFörsöker att ångra en protect-all"
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-"§4Tyvärr!§e En protect-all körs redan. Låt mig slutföra den först, eller "
-"använd §9usb protectall §cstop"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§ePåbörjar en protect-all . Detta kan ta en stund."
-
-msgid "purges all abandoned islands"
-msgstr "tar bort alla övergivna öar"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§cDu måste ange åldern i hur många dagar du vill rensa!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr "§cFörsöker att avbryta rensning"
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr "§cPåbörjar rensning..."
-
-msgid "region manipulations"
-msgstr "region manipulationer"
-
-msgid "shows the borders of the current island"
-msgstr "visar borders för nuvarande ön"
-
-msgid "§eNo island found at your current location"
-msgstr "§eIngen ö hittades vid nuvarande position"
-
-msgid "shows the borders of the current chunk"
-msgstr "visar borders för nuvarande chunk"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "visar borders för nuvarande inner-chunks"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "visar non-chunk-aligned borders"
-
-msgid "shows the borders of the outer-chunks"
-msgstr "visar borders för outer-chunks"
-
-msgid "hides the regions again"
-msgstr "döljer regionen igen"
-
-msgid "§eStopped displaying regions"
-msgstr "§eSlutade att visa regioner"
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§eIngen nuvarande visad region för denna spelare"
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§eAnimation-tick ändrades till {0}"
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§eAnimation-tick måste vara ett giltigt heltal."
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "sätt en spelares ö till din nuvarande position"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "ladda om konfiguration från filen."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eKonfigurationen har laddats om från filen."
-
-msgid "advanced command for setting island-data"
-msgstr "advancerat kommando för att sätta island-data"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§c{0} har ändrats till ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§cKunde inte sätta fältet {0} till ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr "§cKunde inte sätta fältet {0} till ''{1}'', en siffra förväntades"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§cOgiltigt fält {0}"
-
-msgid "toggles maintenance mode"
-msgstr "skiftar underhållsläge"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr "§cUNDERHÅLL: §aAktiverade§e alla uSkyBlocks funktioner."
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr "§cUNDERHÅLL: §4Inaktiverade§e alla uSkyBlocks funktioner."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr "§cUnderhållsläge kan endast ändras från konsolen!"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§cAVBRÖTS:§e Protect-all har avbrutits!"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr "§eSlutförde protect-all på {0}, {1} nya regioner har skapats!"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§7- SKANNAR: {0,number,##}% ({1}/{2} misslyckades: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4RENSNING:§9 Skanning avbröts."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-"- RENSNING: {0,number,##}% ({1}/{2}), förflutit {3}, förväntas att slutföras "
-"~{4}"
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§cRENSNING:§9 Genomförde rensning av övergivna öar."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4RENSNING:§9 Avbröt rensning av öar."
-
-msgid "displays version information"
-msgstr "visar version information"
-
-msgid "various WorldGuard utilities"
-msgstr "olika WorldGuard verktyg"
-
-msgid "refreshes the chunks around the player"
-msgstr "uppdaterar alla chunks runt spelaren"
-
-msgid "§eResending chunks to the client"
-msgstr "§eSkickar alla chunks till klienten på nytt"
-
-msgid "load the region chunks"
-msgstr "ladda regionens chunks"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eLaddar chunks vid {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eAvladdar chunks vid {0}"
-
-msgid "update the WG regions"
-msgstr "uppdaterar WorldGuard-regioner"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§eÖns WorldGuard region uppdaterades för {0}"
-
-msgid "§eNo island found at your location!"
-msgstr "§eIngen ö hittades vid din position!"
-
-msgid "refreshes the chunk around the player"
-msgstr "uppdaterar chunken vid spelaren"
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "visa information om spelare"
-
-msgid "try to complete a challenge"
-msgstr "försök att slutför uppdraget"
-
-msgid "§cCommand only available for players."
-msgstr "§cKommandot är endast tillgängligt för spelare."
-
-msgid "show information about the challenge"
-msgstr "visa information om uppdraget"
-
-msgid "§eRank: "
-msgstr "§eRank:"
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§cDetta uppdrag är ej repeterbart!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr "§cDu kommer att förlora allt krävda material när du gör detta uppdrag!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§cAllt krävda material måste vara placerat på din ö, minst {0} blocks ifrån "
-"dig."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§e§lFör att genomföra detta uppdrag, använda §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§cFelaktigt namn på uppdraget! Använd /c help för mer information."
-
-msgid "complete and list challenges"
-msgstr "slutför och visa uppdragen"
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eUppdrag är inaktiverat. Vänligen kontakta en administratör."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§cDu kan endast göra uppdrag i Skyblockvärlden!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§cDu kan endast göra uppdrag när du har en ö!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§cDin ö är full, eller så har du för många väntande inbjudningar. Du kan "
-"inte bjuda in fler just nu."
-
-msgid "§4That player is already leader on another island."
-msgstr "§cDen spelaren är redan ledare för en annan ö."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e försökte att bjuda in dig men du är redan med i en grupp."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e har bjudit in dig till att gå med i deras ö!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§f/island [accept/reject]§e för att tacka ja eller nej till inbjudan."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§cVARNING: Du kommer att förlora din nuvarande ö om du tackar ja!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d bjöd in {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e har tackat nej till din inbjudan."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§cDu kan inte använda det kommandot just nu. Lämna din nuvarande grupp först."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§aDu har gått med en ö! Använd /island party för att visa andra "
-"gruppmedlemmar."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§eInbjudan för {0}§e har gjort timeout eller blivit avbruten."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§eInbjudan för {0}s ö har gjort timeout eller blivit avbruten."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§eDu har tackat ja till en inbjudan att gå med i en ö."
-
-msgid "§4You haven't been invited."
-msgstr "§4Du har inte blivit inbjuden."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eDu har tackat nej till en inbjudan att gå med i en ö."
-
-msgid "accept/reject an invitation."
-msgstr "tacka ja eller nej till en inbjudan."
-
-msgid "teleports you to your island (or create one)"
-msgstr "teleporterar dig till din ö (eller skapar en)"
-
-msgid "ban/unban a player from your island."
-msgstr "banna eller unbanna en spelare från din ö."
-
-msgid "exempts user from being banned"
-msgstr "undantar spelaren från att bli bannad"
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§eFöljande spelare är bannad från att warpa till din ö:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr "§eFör att banna eller unbanna från din ö, använd /island ban <namn>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§cDu kan inte banna gruppmedlemmar. Ta bort dem från ön först!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§cDu saknar rättighet att kicka eller banna spelare."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§eKunde inte banna okänd spelare {0}"
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§c{0} försökte att banna dig från din ö!"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§c{0} undantas från att bli bannad."
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eDu har bannat §c{0}§e från att warpa till din ö."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eDu har blivit bannad från att warpa till {0}s ö."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§eDu har unbannat §a{0}§e från att warpa till din ö."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eDu har blivit unbannad från att warpa till {0}s ö."
-
-msgid "change the biome of the island"
-msgstr "byt öns biome"
-
-msgid "exempt player from biome-cooldown"
-msgstr "undanta spelaren från biome-cooldown"
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr "Låt spelaren byta deras biome till {0}"
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr "§cDu saknar rättighet att byta biome på nuvarande ö."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§cDu får inte byta biome på denna ö!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eDu måste vara på din ö för att kunna byta biome!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr "§cDu har felstavat biomets namn. Måste vara en av {0}"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eDu kan byta biome igen om {0,number,#} minuter."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cDu saknar rättighet att byta öns biome till den typen."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr "§7Byter biome nära dig till {0}, vänligen vänta."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr "§7Byter biome på din ö till {0}, vänligen vänta."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr "§eOgiltigt biome {0} angavs"
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aDu har bytt öns biome till {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} bytte öns biome till {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr ""
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr "{0} skapade en area med {1} biome"
-
-msgid "create an island"
-msgstr "skapa en ö"
-
-msgid "exempt player from create-cooldown"
-msgstr "undanta spelare från skapa-cooldown"
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§cEn ö hittades!§e Du har redan en ö. Om du vill ha en ny, skriv§b /island "
-"reset§e för att få en."
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§cEn ö hittades!§e Du är redan medlem i en grupp. För att starta en egen, så "
-"måste du först lämna med §b/island leave"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eDu kan skapa en ny ö om {0,number,#} sekunder."
-
-msgid "teleport to the island home"
-msgstr "teleportera till ön"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr "§cDin ö håller på att genereras, du kan inte teleportera hem just nu."
-
-msgid "check your or another''s island info"
-msgstr "kolla din eller en annans ös info"
-
-msgid "allows user to see others island info"
-msgstr "tillåter spelaren att se andra öars info"
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§cSkyblock level är inaktiverat. Vänligen kontakta en administratör."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eDu måste vara på din ö för att använda detta kommando."
-
-msgid "§4You do not have an island!"
-msgstr "§cDu har ingen ö!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§cDu har inte tillgång till det kommandot!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§cDen spelaren är ogiltig eller har ingen ö!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBlock på {0}s ö (sida {1,number} av {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Poäng Antal Blocktyp"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aSkyblock level är {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "bjud in en spelare till din ö"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§eAnvänd§f /island invite <namn§e för att bjuda in spelaren till din ö."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§cEndast gruppledaren kan bjuda in spelare till ön!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aDu kan bjuda in {0} spelare till."
-
-msgid "§4You can't invite any more players."
-msgstr "§cDu kan inte bjuda in fler spelare."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§cDu saknar rättighet att bjuda in spelare till ön!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§cDen spelaren är inte online just nu."
-
-msgid "§4You can't invite yourself!"
-msgstr "§cDu kan inte bjuda in dig själv!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§cDen spelaren är öns ledare!"
-
-msgid "remove a member from your island."
-msgstr "ta bort en spelare från ön."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§cDu saknar rättighet att kicka andra från ön!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§cDu kan inte ta bort gruppledaren från ön!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§cDu kan inte kicka dig själv!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§c{0} har tagit bort dig från ön!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§c{0} har tagits bort från ön."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§c{0} försökte att kicka dig från deras ö!"
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§c{0} undantas från att bli kickad."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§c{0} har kickat dig från deras ö!"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§c{0} har blivit kickad från ön."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr "§cDen spelaren är inte del av din grupp och är inte på din ö!"
-
-msgid "leave your party"
-msgstr "lämna din grupp"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§cDu kan inte lämna din ö om du är den enda personen. Använd /reset om du "
-"vill ha en ny!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§eDu är gruppledaren, använd /island kick <namn> istället."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eDu har lämnat ön och återvänt till spawnen."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§c{0} har lämnat din ö!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§cDu måste vara i Skyblockvärlden för att lämna din grupp!"
-
-msgid "check your or anothers island level"
-msgstr "kolla din ös eller någon annans ös skyblock level"
-
-msgid "allows user to query for others levels"
-msgstr "tillåter spelaren att kolla andra öars level"
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eInformation om {0}s ö:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9Rank är {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "lås din ö för spelare som inte är gruppmedlemmar."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§cDu saknar rättighet att låsa ön!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§cDu har inte tillgång till det kommandot."
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§cDu saknar rättighet att låsa upp ön!"
-
-msgid "display log"
-msgstr "visa loggen"
-
-msgid "transfer leadership to another member"
-msgstr "flytta ledarskap till en annan spelare"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§cDu kan endast flytta ledarskapet till gruppmedlemmar!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e är redan gruppledare!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§cEndast gruppledaren kan flytta ledarskapet!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} försökte att ge sig själv ledarskapet!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "visa gruppinformation"
-
-msgid "shows information about your party"
-msgstr "visar information om din grupp"
-
-msgid "show pending invites"
-msgstr "visa väntande inbjudningar"
-
-msgid "§eNo pending invites"
-msgstr "§eInga väntande inbjudningar"
-
-msgid "withdraw an invite"
-msgstr "dra tillbaka en inbjudan"
-
-# ???
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§cDu saknar rättighet att dra tillbaka inbjudningar."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§cDetta kommando kan endast användas av spelare."
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§cIngen ö hittades! §eAnvänd §b/island create§e för att få en"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "ta bort din ö och starta en ny."
-
-msgid "exempt player from restart-cooldown"
-msgstr "undantar spelaren från restart-cooldown"
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§cEndast gruppledaren kan starta om ön. Lämna ön för att starta din egna (/"
-"island leave)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eDu måste ta bort alla medlemmar från ön innan du kan starta om den (/"
-"island kick <namn>). Visa en lista av gruppmedlemmar med /is party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§eDu kan starta om din ö om {0} sekunder."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§cDin ö håller på att genereras, du kan inte börja om just nu."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eVIKTIGT: Hela din ö och alla dina ägodelar kommer att ÅTERSTÄLLAS!"
-
-msgid "set the island-home"
-msgstr "ställer in öns hem"
-
-msgid "set your island''s warp location"
-msgstr "ställer in öns warp position"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cDu saknar rättighet att ställa in öns warp position!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§cDu måste vara på ön för att ställa in öns warp!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d flyttade öns warp position."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "teleporterar dig till skyblock spawnen"
-
-msgid "enable/disable warping to your island."
-msgstr "aktiverar eller inaktiverar warpande till din ö."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr "§cDin ö är låst. Du måste låsa upp den innan du kan aktivera din warp."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d aktiverade öns warp."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d inaktiverade öns warp."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr "§cDu saknar rättighet att aktivera/inaktivera öns warp!"
-
-msgid "display the top10 of islands"
-msgstr "visar topp 10 av alla öar"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr "tillåter spelaren att alltid generera top10 på nytt (ingen cache)"
-
-msgid "trust/untrust a player to help on your island."
-msgstr "litar på en annan spelare att hjälpa dig på ön."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eFöljande spelare är betrodda på ön:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eFöljande ledare litar på dig:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr "§eFör att lita på en annan spelare, använd /island trust <namn>"
-
-msgid "§4Members are already trusted!"
-msgstr "§cSpelarna är redan betrodda!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§cOkänd spelare {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eDu är nu betrodd på §4{0}s ö."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} betrodde {1} på ön"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eDu är inte längre betrodd på §4{0}s ö."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§e{0} återkallade förtroendet för {1} på ön"
-
-msgid "warp to another player''s island"
-msgstr "warpa till en annan spelares ö"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr "§aDin warp är aktiv, spelare kan warpa till din ö."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr "§cDin warp är inaktiv, spelare kan inte längre arpa till din ö."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr "§fStäll in warpen till nuvarande position med §e/sättwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§fAktivera eller inaktivera öns warp med §e/warp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4Du saknar rättighet att skapa en warp på ön!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§fWarpa till en annan spelare "
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§cDu får inte warpa till andra öar!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§cDin ö håller på att generaras, du kan inte warpa till andra öar just nu."
-
-msgid "§4That player does not exist!"
-msgstr "§cDen spelaren existerar inte."
-
-msgid "§4That player does not have an active warp."
-msgstr "§cDen spelaren har warpen inaktiverad."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§cDen spelarens ö håller på att genereras så du kan inte warpa till den "
-"precis just nu."
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§e{0} warpar till din ö just nu!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§cDen spelaren har förbjudig dig från att warpa till sin ö."
-
-msgid "general island command"
-msgstr "allmänt skyblock kommando"
-
-msgid "allows user to bypass cooldowns"
-msgstr "tillåter spelaren att förbigå cooldowns"
-
-msgid "allows user to bypass visitor-protections"
-msgstr "tillåter spelaren att förbigå besökares skydd"
-
-msgid "allows user to bypass teleport-delay"
-msgstr "tillåter spelaren att förbigå teleport-delay"
-
-msgid "allows user to use [usb] signs"
-msgstr "tillåter spelaren att använda [usb] skyltar"
-
-msgid "allows user to place [usb] signs"
-msgstr "tillåter spelaren att lägga ut [usb] skyltar"
+msgid "{0}''s Wither"
+msgstr "{0}s Wither"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr ""
@@ -1733,32 +110,6 @@ msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr "§cWither har despawnat! §eDen gick för långt ifrån din ö."
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "{0}s Wither"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eBesökare kan inte kasta ut saker!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Ägare: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "§eDu kan inte ta upp saker när du är en besökare!"
-
-msgid "Config:"
-msgstr "Konfiguration:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§eDu försöker att teleportera till taket av Nether, vilket inte är tillåtet."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr ""
@@ -1802,19 +153,80 @@ msgstr "§eDu kan använda spawnägg endast på din egna ö."
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§cDu har nått din spawn-limit för ön."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eBesökare kan inte kasta ut saker!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Ägare: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "§eDu kan inte ta upp saker när du är en besökare!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cDu är bannad från denna ö."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cLåst:§e Den ön är låst! Beträdelse nekas."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eWaiting for our turn §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "Något gick fel när när data skulle sparas!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr "Konverterar data till UUID, detta kan ta en stund!"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§cUNDERHÅLL:§e uSkyBlock är i underhållsläge"
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Skapar ön... §e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e kräver §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§eDu har inte tillgång till detta schematic!"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§cSpelaren är redan tilldelad denna ö!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§cDu måste vara på din ö för att ställa in hemposition."
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aDin hemposition har ställts in till nuvarande position."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§cDin nuvarande position är inte en säker hemposition."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr "§7Byter biome på din ö till {0}, vänligen vänta."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr "§cDin ö håller på att genereras, du kan inte skapa en just nu."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "Kan inte skapa din ö. Vänligen kontakta en administratör."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr "§eFörbereder din ö, vänligen vänta lite..."
+
+msgid "§cCommand is currently disabled!"
+msgstr "§cKommandor är inaktiverat!"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eFöljande block saknas: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1827,9 +239,6 @@ msgid ""
 msgstr ""
 "§eAnvändande av §9{0}§e är §cRISKFULLT§e. Repetera kommandot inom §a{1}§e "
 "sekunder för att acceptera!"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§c** Du beträder du en skyddad, men övergiven, Skyblock."
@@ -1862,211 +271,32 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§cEndast gruppledaren kan låsa upp ön!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§7PlayerDB: Filtrerar {0} spelare från uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eWaiting for our turn §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Skapar ön... §e{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§c§lLåst uppdrag"
+
+msgid "READY"
+msgstr "REDO"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§7PlayerDB: Filtrerade {0} namn"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, misslyckades: {3} ~ "
-"{5,number,##}%), {6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§7MojangAPI: Försöker att fetcha {0} spelare från Mojang"
-
-msgid "SUCCESS"
-msgstr "LYCKADES"
-
-msgid "FAILED"
-msgstr "MISSLYCKADES"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§7 - MojangAPI:§aSLUTFÖRDE: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§7 - MojangAPI:§cFEL: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§cIngen importer kallad §e{0}§4 hittades."
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§eKonverterade {0}/{1} filer på {2}"
-
-msgid "The island has been created."
-msgstr "Ön har skapats."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d låste ön."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§cEftersom ön är låst så har din warp inaktiverats."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d låste upp ön."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d har tagits bort från gruppen."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9Skapar en ö vid din position"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9Skapar ön §7{0}§9 åt dig"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§cUppdraget {0} är inte tillgängligt än!"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
-msgstr ""
-"§cÖn som äger denna del av Nether tas bort. Teleporterar dig till spawnen."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
+msgstr "§cVARNING:§e Kunde inte flytta alla krävda saker till ditt inventarie!"
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§cÖn du är på tas bort! Teleporterar dig till spawnen."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eTOPPLISTAN (Sida {0} av {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr "§cTopplistan är tom! Endast öar ovanför {0} visas."
-
-# ???
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eDin rank är: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "OKÄND"
-
-msgid "ANIMAL"
-msgstr "DJUR"
-
-msgid "MONSTER"
-msgstr "MONSTER"
-
-msgid "VILLAGER"
-msgstr "BYBO"
-
-msgid "GOLEM"
-msgstr "GOLEM"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (högst {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "Kunde inte hitta schematic {0}, kontakta en Administratör"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aGrattis! §eDin ö har skapats."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cViktigt:§e Konstruktion kan fortfarande pågå."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Använd §9/is h§r för att komma till ön."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§cVakthund!§9 Kan inte lokalisera en kista inom {0}."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7Sida {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr "§c{0,number,#}"
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr "§a+{0,number,#}"
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr "§a{0,number,#}"
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr "&aVänsterklick:&7 Ökning med {0}"
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr "&cHögerklick:&7 Ändra till {0}"
-
-msgid "Return"
-msgstr "Återvänd"
-
-msgid "§9Integer Editor"
-msgstr "§9Integer Editor"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eKonfigurationen sparad och omladdad."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cFel! §9Kan inte spara konfigurationsfilen!"
-
-msgid "§3First Page"
-msgstr "§3Första sidan"
-
-msgid "§3Last Page"
-msgstr "§3Sista sidan"
-
-msgid "§cSave & Reload config"
-msgstr "§cSpara & ladda om"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Sparar inställningarna till\n"
-"§7filen och laddar om..\n"
-"§cViktigt: §7Använd försiktigt!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (readonly)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr "§cInte tlilräckligt med saker i kistan för att slutföra uppdraget!"
 
 msgid "true"
 msgstr "sant"
@@ -2498,6 +728,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr ""
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7Sida {0}"
+
 msgid "§7First Page"
 msgstr ""
 
@@ -2790,8 +1024,8 @@ msgstr "§cKlicka för att lämna"
 msgid "Island Restart Menu"
 msgstr "Restart meny"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§eDu har inte tillgång till detta schematic!"
+msgid "Config:"
+msgstr "Konfiguration:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2807,111 +1041,120 @@ msgstr "§cKlicka inom §9{0}§c för att börja om!"
 msgid "§aClick to restart!"
 msgstr "§aKlicka för att börja om!"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr "§c{0,number,#}"
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr "§a+{0,number,#}"
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr "§a{0,number,#}"
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr "&aVänsterklick:&7 Ökning med {0}"
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr "&cHögerklick:&7 Ändra till {0}"
+
+msgid "Return"
+msgstr "Återvänd"
+
+msgid "§9Integer Editor"
+msgstr "§9Integer Editor"
+
 msgid "Caps On"
 msgstr "Caps På"
 
 msgid "§9Text Editor"
 msgstr "§9Textredigerare"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eKonfigurationen sparad och omladdad."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cFel! §9Kan inte spara konfigurationsfilen!"
+
+msgid "§3First Page"
+msgstr "§3Första sidan"
+
+msgid "§3Last Page"
+msgstr "§3Sista sidan"
+
+msgid "§cSave & Reload config"
+msgstr "§cSpara & ladda om"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Sparar inställningarna till\n"
+"§7filen och laddar om..\n"
+"§cViktigt: §7Använd försiktigt!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (readonly)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§cIngen importer kallad §e{0}§4 hittades."
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§eKonverterade {0}/{1} filer på {2}"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§7PlayerDB: Filtrerar {0} spelare från uuid2name.yml"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§7PlayerDB: Filtrerade {0} namn"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, misslyckades: {3} ~ "
+"{5,number,##}%), {6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§7MojangAPI: Försöker att fetcha {0} spelare från Mojang"
+
+msgid "SUCCESS"
+msgstr "LYCKADES"
+
+msgid "FAILED"
+msgstr "MISSLYCKADES"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§7 - MojangAPI:§aSLUTFÖRDE: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§7 - MojangAPI:§cFEL: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "För många förfrågningar till Mojangs API ({0} inom {1}), väntar {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§eSkickar dig till spawn."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§eÖn har blivit §cLÅST§e."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aDu kommer att teleporteras om {0} sekunder."
-
-msgid "§7Teleport cancelled"
-msgstr "§7Teleportering avbruten"
-
-msgid "READY"
-msgstr "REDO"
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr "§cVARNING:§e Kunde inte flytta alla krävda saker till ditt inventarie!"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr "§cInte tlilräckligt med saker i kistan för att slutföra uppdraget!"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Något gick fel när när data skulle sparas!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr "Konverterar data till UUID, detta kan ta en stund!"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§cUNDERHÅLL:§e uSkyBlock är i underhållsläge"
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e kräver §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§cSpelaren är redan tilldelad denna ö!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§cKunde inte hitta en säker hem-position på din ö!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§cVARNING: §eTeleporterar dig till luften."
-
-msgid "§aTeleporting you to your island."
-msgstr "§aTeleporterar dig till din ö."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Kan inte warpa till den spelarens ö!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aTeleporterar dig till {0}s ö."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§cDu måste vara på din ö för att ställa in hemposition."
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aDin hemposition har ställts in till nuvarande position."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§cDin nuvarande position är inte en säker hemposition."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cDin ö håller på att genereras, du kan inte skapa en just nu."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "Kan inte skapa din ö. Vänligen kontakta en administratör."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr "§eFörbereder din ö, vänligen vänta lite..."
-
-msgid "§cCommand is currently disabled!"
-msgstr "§cKommandor är inaktiverat!"
 
 msgid "North"
 msgstr "Norr"
@@ -2936,3 +1179,1757 @@ msgstr "Väst"
 
 msgid "North-West"
 msgstr "Nordväst"
+
+msgid "The island has been created."
+msgstr "Ön har skapats."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d låste ön."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§cEftersom ön är låst så har din warp inaktiverats."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d inaktiverade öns warp."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d låste upp ön."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d har tagits bort från gruppen."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9Skapar en ö vid din position"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9Skapar ön §7{0}§9 åt dig"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aGrattis! §eDin ö har skapats."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cViktigt:§e Konstruktion kan fortfarande pågå."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Använd §9/is h§r för att komma till ön."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "Kunde inte hitta schematic {0}, kontakta en Administratör"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§cVakthund!§9 Kan inte lokalisera en kista inom {0}."
+
+msgid "UNKNOWN"
+msgstr "OKÄND"
+
+msgid "ANIMAL"
+msgstr "DJUR"
+
+msgid "MONSTER"
+msgstr "MONSTER"
+
+msgid "VILLAGER"
+msgstr "BYBO"
+
+msgid "GOLEM"
+msgstr "GOLEM"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (högst {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§cÖn som äger denna del av Nether tas bort. Teleporterar dig till spawnen."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§cÖn du är på tas bort! Teleporterar dig till spawnen."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eTOPPLISTAN (Sida {0} av {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr "§cTopplistan är tom! Endast öar ovanför {0} visas."
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§cSkyblock level är inaktiverat. Vänligen kontakta en administratör."
+
+# ???
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eDin rank är: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "§7Slutför {0} fler {1} §7uppdrag"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Slutför {0}"
+
+msgid "to unlock this rank"
+msgstr "för att låsa upp denna rank"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§cKraven kommer att återställas om {0} dagar."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§cKraven kommer att återställas om {0} timmar."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§cKraven kommer att återställas om {0} minuter."
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr "§eDetta uppdrag kräver:"
+
+msgid "§7and more..."
+msgstr "§7och mer..."
+
+msgid "§eItems will be traded for reward."
+msgstr "§eSakerna byts ut mot en belöning."
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr "§eMåste vara inom {0} block."
+
+msgid "§6Item Reward: §a"
+msgstr "§6Belöning: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Belöning (valuta): §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Belöning (exp): §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dAntal gånger genomfört: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr "§7Kräver {0}"
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§cInget uppdrag kallat {0} hittades"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§cDu måste vara på din ö för att göra detta!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§cUppdraget {0} är inte repeterbart!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§eFörsöker att klara uppdraget §a{0}"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr "§cDu måste stå inom minst {0} block ifrån allt krävda material."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§cDin skyblock level måste vara minst {0} för att göra detta uppdrag."
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§cOkänt typ av uppdrag: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr "§eFöljande enheter saknas: {0}"
+
+# ???
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eFöljande material saknas: {0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aDu har genomfört uppdraget {0}!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9{0}§f har klarat av uppdraget {1}!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§eBelöning: §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eBelöning (exp): §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eBelöning (valuta): §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eDitt inventarie är fullt. Belöningen kastades ut där du står."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lKlicka här för att göra detta uppdrag."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§c§lDu kan inte repetera detta uppdrag."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Rank: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fGenomför de flesta uppdragen i"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fdenna rank för att låsa upp nästa rank."
+
+msgid "§eClick here to show previous page"
+msgstr "§eKlicka här för att visa föregående sida"
+
+msgid "§eClick here to show next page"
+msgstr "§eKlicka här för att visa nästa sida"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "Men du är HELT ENSAM! :("
+
+msgid "But you are Yelling in the wind!"
+msgstr "Men du ropar i vinden!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "Dina fantasikompisar är inte online!"
+
+msgid "But you are Talking to your self!"
+msgstr "Men du pratar med dig själv!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cLedsen! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr ""
+"Skicka antingen ett meddelande direkt till gruppen, eller skifta det på/av."
+
+msgid "party"
+msgstr "party"
+
+msgid "island"
+msgstr "ö"
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§cSkiftade chatten till {0} §aPÅ"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§cRepetera §9{0}§c för att inaktivera de"
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§aSkiftade chatten till §cAV§a för {0}"
+
+msgid "§cCommand only available to players"
+msgstr "§cKommandot är endast tillgängligt för spelare"
+
+msgid "talk to your island party"
+msgstr "prata med skyblockgruppen"
+
+msgid "talk to players on your island"
+msgstr "prata med spelare på ön"
+
+msgid "manually update the top 10 list"
+msgstr "uppdatera topp 10 manuellt"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eGenererar topp 10 listan"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eSlutförde generation av topp 10 listan"
+
+msgid "purges all abandoned islands"
+msgstr "tar bort alla övergivna öar"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§cDu måste ange åldern i hur många dagar du vill rensa!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr "§cFörsöker att avbryta rensning"
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr "§cPåbörjar rensning..."
+
+msgid "Controls player-cooldowns"
+msgstr "Kontrollerar spelares cooldowns"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "rensar cooldown för ett kommando (* = alla)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eDen spelaren är inte online just nu"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Tog bort cooldown på {0} för {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Ingen aktiv cooldown på {0} för {1} hittades!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Felaktigt kommando angivet, endast restart och biome stöds!"
+
+msgid "restarts the cooldown on the command"
+msgstr "börjar om cooldownen på ett kommando"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eÅterställer cooldown på {0} för {1}§e till {2} sekunder"
+
+msgid "lists all the active cooldowns"
+msgstr "listar alla aktiva cooldowns"
+
+# ???
+msgid "§eCmd Cooldown"
+msgstr "§eCmd Cooldown"
+
+# ???
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eIngen aktiv cooldown för §9{0}§e hittades."
+
+msgid "toggles maintenance mode"
+msgstr "skiftar underhållsläge"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr "§cUNDERHÅLL: §aAktiverade§e alla uSkyBlocks funktioner."
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr "§cUNDERHÅLL: §4Inaktiverade§e alla uSkyBlocks funktioner."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr "§cUnderhållsläge kan endast ändras från konsolen!"
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Jobb statistik"
+
+# ???
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/job"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "akt"
+
+msgid "time"
+msgstr "tid"
+
+msgid "name"
+msgstr "namn"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§eSpelaren {0} har ingen ö!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eFelaktigt spelarnamn {0} angivet."
+
+msgid "flushes all caches to files"
+msgstr "flyttade alla caches till en fil"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr "§eFlyttade §a{0}s ö§e, §b{1} spelare och §6{2} uppdrag-slutförande."
+
+msgid "tries to fix the the area of flatland."
+msgstr "gör ett försök att fixa arean för flatland."
+
+msgid "§4No valid island found"
+msgstr "§cIngen giltig ö hittades"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§cIngen flatland hittades på {0}s ö!"
+
+msgid "manage orphans"
+msgstr "hantera orphans"
+
+msgid "count orphans"
+msgstr "räkna orphans"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§e{0}gamla öars positioner kommer att användas för nya."
+
+msgid "clear orphans"
+msgstr "rensa orphans"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eRensar alla gamla (tomma) öars positioner."
+
+msgid "list orphans"
+msgstr "lista orphans"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eInga orphans är registrerade."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "flytta ledarskap till en annan spelare"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§cSpelaren {0} har ingen ö att flytta!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eSpelaren §f{0}§e har redan en ö. §eAnvänd §f/usb island remove <namn>§e "
+"för att ta bort spelaren först."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bLedarskap flyttat av {0}§b till {1}"
+
+msgid "open GUI for config"
+msgstr "öppna GUI för konfiguration"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§eOgiltigt konfigurationsnamn"
+
+msgid "teleport to another players island"
+msgstr "teleportera till en annan spelares ö"
+
+msgid "§4Only supported for players"
+msgstr "§cStöds endast för spelare"
+
+msgid "§4That player does not have an island!"
+msgstr "§cDen spelaren har ingen ö!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr "§aTeleporterar dig till {0}§as ö"
+
+msgid "various WorldGuard utilities"
+msgstr "olika WorldGuard verktyg"
+
+msgid "refreshes the chunks around the player"
+msgstr "uppdaterar alla chunks runt spelaren"
+
+msgid "§eResending chunks to the client"
+msgstr "§eSkickar alla chunks till klienten på nytt"
+
+msgid "load the region chunks"
+msgstr "ladda regionens chunks"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eLaddar chunks vid {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eAvladdar chunks vid {0}"
+
+msgid "update the WG regions"
+msgstr "uppdaterar WorldGuard-regioner"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§eÖns WorldGuard region uppdaterades för {0}"
+
+msgid "§eNo island found at your location!"
+msgstr "§eIngen ö hittades vid din position!"
+
+msgid "refreshes the chunk around the player"
+msgstr "uppdaterar chunken vid spelaren"
+
+msgid "region manipulations"
+msgstr "region manipulationer"
+
+msgid "shows the borders of the current island"
+msgstr "visar borders för nuvarande ön"
+
+msgid "§eNo island found at your current location"
+msgstr "§eIngen ö hittades vid nuvarande position"
+
+msgid "§eCan only be executed as a player"
+msgstr "§eKan endast utföras av spelare"
+
+msgid "shows the borders of the current chunk"
+msgstr "visar borders för nuvarande chunk"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "visar borders för nuvarande inner-chunks"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "visar non-chunk-aligned borders"
+
+msgid "shows the borders of the outer-chunks"
+msgstr "visar borders för outer-chunks"
+
+msgid "hides the regions again"
+msgstr "döljer regionen igen"
+
+msgid "§eStopped displaying regions"
+msgstr "§eSlutade att visa regioner"
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§eIngen nuvarande visad region för denna spelare"
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§eAnimation-tick ändrades till {0}"
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§eAnimation-tick måste vara ett giltigt heltal."
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+"- RENSNING: {0,number,##}% ({1}/{2}), förflutit {3}, förväntas att slutföras "
+"~{4}"
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§cRENSNING:§9 Genomförde rensning av övergivna öar."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4RENSNING:§9 Avbröt rensning av öar."
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§7- SKANNAR: {0,number,##}% ({1}/{2} misslyckades: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4RENSNING:§9 Skanning avbröts."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§cAVBRÖTS:§e Protect-all har avbrutits!"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr "§eSlutförde protect-all på {0}, {1} nya regioner har skapats!"
+
+msgid "control debugging"
+msgstr "kontrollera felsökning"
+
+msgid "set debug-level"
+msgstr "sätt felsökningsnivå"
+
+# ???
+msgid "toggle debug-logging"
+msgstr "aktivera eller inaktivera felsökningsloggning"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§cLoggning var inte aktivt, så du kan inte stänga av det!"
+
+msgid "flush current content of the logger to file."
+msgstr "flytta nuvarande innehåll från loggen till en fil."
+
+msgid "§eLog-file has been flushed."
+msgstr "§eLogg-fil har blivit skapad."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr ""
+"§cLoggning är inte aktivt, använd §d/usb debug enable§4 för att aktivera"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§cFelaktigt argument, prova INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eLoggning inaktiverat!"
+
+msgid "advanced command for setting island-data"
+msgstr "advancerat kommando för att sätta island-data"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§c{0} har ändrats till ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§cKunde inte sätta fältet {0} till ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr "§cKunde inte sätta fältet {0} till ''{1}'', en siffra förväntades"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§cOgiltigt fält {0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§eNuvarande värde för {0} är ''{1}''"
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§cKunde inte hämta tillstånd för {0}"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§eGiltiga fält är {0}"
+
+msgid "set a player''s island to your location"
+msgstr "sätt en spelares ö till din nuvarande position"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr "advancerad info om NBT saker"
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "visar NBT taggen för saken du håller i"
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§eInformation för §9{0}"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - namn: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - nbttag: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§cDu måste hålla i något!"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "sätter NBT taggen för saken du håller i"
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "§eSatte §9{0}§e till §c{1}"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "lägger till NBT taggen för saken du håller i"
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§eLade till §9{0}§e till §c{1}"
+
+msgid "Manage challenges for a player"
+msgstr "Hantera uppdrag för en spelare"
+
+msgid "resets the challenge for the player"
+msgstr "återställer uppdraget för spelaren"
+
+msgid "§4Challenge has never been completed"
+msgstr "§cUppdraget har aldrig genomförts"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§euppdrag: {0} har återställts för {1}"
+
+msgid "resets all challenges for the player"
+msgstr "återställer alla uppdrag för spelaren"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0} har fått alla uppdrag återställda."
+
+msgid "complete all challenges in the rank"
+msgstr "slutför alla uppdrag i ranken"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§cIngen spelare med namnet {0} hittades!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§cUppdraget {0} har redan slutförts"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§eUppdraget {0} har slutförts för {1}"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§cInget uppdrag med namnet {0} hittades!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§cIngen rank kallad {0} hittades!"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "skyddar alla öar (tar tid)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§cFörsöker att ångra en protect-all"
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4Tyvärr!§e En protect-all körs redan. Låt mig slutföra den först, eller "
+"använd §9usb protectall §cstop"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§ePåbörjar en protect-all . Detta kan ta en stund."
+
+msgid "reload configuration from file."
+msgstr "ladda om konfiguration från filen."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eKonfigurationen har laddats om från filen."
+
+msgid "manage islands"
+msgstr "hantera öar"
+
+msgid "protects the island"
+msgstr "skyddar ön"
+
+msgid "delete the island (removes the blocks)"
+msgstr "tar bort ön (endast blocken)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Raderade ön som var kopplad till din nuvarande position."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§cÖn vid denna position har medlemmar!\n"
+"§eAnvänd §9/usb island delete <namn>§e för att ta bort den."
+
+msgid "removes the player from the island"
+msgstr "tar bort spelaren från ön"
+
+msgid "adds the player to the island"
+msgstr "lägger till spelaren till ön"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d har gått med din grupp."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§cIngen spelare kallad {0} hittades!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr "§cIngen giltig ö försedd, antingen stå inom en eller förse med en namn"
+
+msgid "print out info about the island"
+msgstr "skriver ut information om ön"
+
+msgid "sets the biome of the island"
+msgstr "sätter öns biome"
+
+msgid "§4That player has no island."
+msgstr "§cDen spelaren har ingen ö."
+
+msgid "§4No valid island at your location"
+msgstr "§cIngen giltig ö vid din position"
+
+msgid "purges the island"
+msgstr "rensar ön"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§cFel! §9Ingen giltig ö hittades för rensning."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cRENSNING: §9Rensade ön vid {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "aktiverar eller inaktiverar öns ignoransstatus"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cSätt {0}s ö till att bli ignorerad från topp 10 och från rensning."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cTog bort ignorans-flaggan från {0}s ö, den kommer nu visas i topp 10 och "
+"rensas."
+
+msgid "§4No valid player-name supplied."
+msgstr "§cInget giltigt spelarnamn angavs."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Tar bort {0} från ön"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eBytte biome på {0}s ö till {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eBytte biome på {0}s ö till OCEAN."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr "§aDu måste gå till spawn eller relogga för att se ändringarna."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} har fått sitt biome ändrat till {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} har fått sitt biome ändrat till OCEAN."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eTar bort {0}s ö."
+
+msgid "Error: That player does not have an island!"
+msgstr "Fel: Den spelaren har ingen ö!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§e{0}s ö vid {1} har skyddats"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§c{0}s ö vid {1} var redan skyddad"
+
+msgid "displays version information"
+msgstr "visar version information"
+
+msgid "imports players and islands from other formats"
+msgstr "importerar spelare och öar från andra format"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr "ytterligare förmåner {0}"
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "byter språk på pluginet och laddar om"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aSpråket har ändrats till §e{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cMisslyckades att byta språk till §e{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Språk som stöds:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 av {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cKan inte lokalisera några språk."
+
+msgid "advanced command for getting island-data"
+msgstr "advancerat kommando för att hämta data om ö"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "visa information om spelare"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§cDin ö är full, eller så har du för många väntande inbjudningar. Du kan "
+"inte bjuda in fler just nu."
+
+msgid "§4That player is already leader on another island."
+msgstr "§cDen spelaren är redan ledare för en annan ö."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e försökte att bjuda in dig men du är redan med i en grupp."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e har bjudit in dig till att gå med i deras ö!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§f/island [accept/reject]§e för att tacka ja eller nej till inbjudan."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§cVARNING: Du kommer att förlora din nuvarande ö om du tackar ja!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d bjöd in {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e har tackat nej till din inbjudan."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§cDu kan inte använda det kommandot just nu. Lämna din nuvarande grupp först."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§aDu har gått med en ö! Använd /island party för att visa andra "
+"gruppmedlemmar."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§eInbjudan för {0}§e har gjort timeout eller blivit avbruten."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§eInbjudan för {0}s ö har gjort timeout eller blivit avbruten."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§eDu har tackat ja till en inbjudan att gå med i en ö."
+
+msgid "§4You haven't been invited."
+msgstr "§4Du har inte blivit inbjuden."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eDu har tackat nej till en inbjudan att gå med i en ö."
+
+msgid "general island command"
+msgstr "allmänt skyblock kommando"
+
+msgid "allows user to bypass cooldowns"
+msgstr "tillåter spelaren att förbigå cooldowns"
+
+msgid "allows user to bypass visitor-protections"
+msgstr "tillåter spelaren att förbigå besökares skydd"
+
+msgid "allows user to bypass teleport-delay"
+msgstr "tillåter spelaren att förbigå teleport-delay"
+
+msgid "allows user to use [usb] signs"
+msgstr "tillåter spelaren att använda [usb] skyltar"
+
+msgid "allows user to place [usb] signs"
+msgstr "tillåter spelaren att lägga ut [usb] skyltar"
+
+msgid "complete and list challenges"
+msgstr "slutför och visa uppdragen"
+
+msgid "§cCommand only available for players."
+msgstr "§cKommandot är endast tillgängligt för spelare."
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eUppdrag är inaktiverat. Vänligen kontakta en administratör."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§cDu kan endast göra uppdrag i Skyblockvärlden!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§cDu kan endast göra uppdrag när du har en ö!"
+
+msgid "warp to another player''s island"
+msgstr "warpa till en annan spelares ö"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr "§aDin warp är aktiv, spelare kan warpa till din ö."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr "§cDin warp är inaktiv, spelare kan inte längre arpa till din ö."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr "§fStäll in warpen till nuvarande position med §e/sättwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§fAktivera eller inaktivera öns warp med §e/warp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4Du saknar rättighet att skapa en warp på ön!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§fWarpa till en annan spelare "
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§cDu får inte warpa till andra öar!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cDin ö håller på att generaras, du kan inte warpa till andra öar just nu."
+
+msgid "§4That player does not exist!"
+msgstr "§cDen spelaren existerar inte."
+
+msgid "§4That player does not have an active warp."
+msgstr "§cDen spelaren har warpen inaktiverad."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§cDen spelarens ö håller på att genereras så du kan inte warpa till den "
+"precis just nu."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§e{0} warpar till din ö just nu!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§cDen spelaren har förbjudig dig från att warpa till sin ö."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§cIngen ö hittades! §eAnvänd §b/island create§e för att få en"
+
+msgid "accept/reject an invitation."
+msgstr "tacka ja eller nej till en inbjudan."
+
+msgid "leave your party"
+msgstr "lämna din grupp"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§cDu kan inte lämna din ö om du är den enda personen. Använd /reset om du "
+"vill ha en ny!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§eDu är gruppledaren, använd /island kick <namn> istället."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eDu har lämnat ön och återvänt till spawnen."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§c{0} har lämnat din ö!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§cDu måste vara i Skyblockvärlden för att lämna din grupp!"
+
+msgid "check your or anothers island level"
+msgstr "kolla din ös eller någon annans ös skyblock level"
+
+msgid "allows user to query for others levels"
+msgstr "tillåter spelaren att kolla andra öars level"
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eDu måste vara på din ö för att använda detta kommando."
+
+msgid "§4You do not have an island!"
+msgstr "§cDu har ingen ö!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§cDu har inte tillgång till det kommandot!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§cDen spelaren är ogiltig eller har ingen ö!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eInformation om {0}s ö:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aSkyblock level är {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9Rank är {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "skapa en ö"
+
+msgid "exempt player from create-cooldown"
+msgstr "undanta spelare från skapa-cooldown"
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§cEn ö hittades!§e Du har redan en ö. Om du vill ha en ny, skriv§b /island "
+"reset§e för att få en."
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§cEn ö hittades!§e Du är redan medlem i en grupp. För att starta en egen, så "
+"måste du först lämna med §b/island leave"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eDu kan skapa en ny ö om {0,number,#} sekunder."
+
+msgid "invite a player to your island"
+msgstr "bjud in en spelare till din ö"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§eAnvänd§f /island invite <namn§e för att bjuda in spelaren till din ö."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§cEndast gruppledaren kan bjuda in spelare till ön!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aDu kan bjuda in {0} spelare till."
+
+msgid "§4You can't invite any more players."
+msgstr "§cDu kan inte bjuda in fler spelare."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§cDu saknar rättighet att bjuda in spelare till ön!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§cDen spelaren är inte online just nu."
+
+msgid "§4You can't invite yourself!"
+msgstr "§cDu kan inte bjuda in dig själv!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§cDen spelaren är öns ledare!"
+
+msgid "lock your island to non-party members."
+msgstr "lås din ö för spelare som inte är gruppmedlemmar."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§cDu saknar rättighet att låsa ön!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§cDu har inte tillgång till det kommandot."
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§cDu saknar rättighet att låsa upp ön!"
+
+msgid "display the top10 of islands"
+msgstr "visar topp 10 av alla öar"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr "tillåter spelaren att alltid generera top10 på nytt (ingen cache)"
+
+msgid "remove a member from your island."
+msgstr "ta bort en spelare från ön."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§cDu saknar rättighet att kicka andra från ön!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§cDu kan inte ta bort gruppledaren från ön!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§cDu kan inte kicka dig själv!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§c{0} har tagit bort dig från ön!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§c{0} har tagits bort från ön."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§c{0} försökte att kicka dig från deras ö!"
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§c{0} undantas från att bli kickad."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§c{0} har kickat dig från deras ö!"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§c{0} har blivit kickad från ön."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr "§cDen spelaren är inte del av din grupp och är inte på din ö!"
+
+msgid "teleport to the island home"
+msgstr "teleportera till ön"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr "§cDin ö håller på att genereras, du kan inte teleportera hem just nu."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§cDetta kommando kan endast användas av spelare."
+
+msgid "transfer leadership to another member"
+msgstr "flytta ledarskap till en annan spelare"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§cDu kan endast flytta ledarskapet till gruppmedlemmar!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e är redan gruppledare!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§cEndast gruppledaren kan flytta ledarskapet!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} försökte att ge sig själv ledarskapet!"
+
+msgid "show party information"
+msgstr "visa gruppinformation"
+
+msgid "shows information about your party"
+msgstr "visar information om din grupp"
+
+msgid "show pending invites"
+msgstr "visa väntande inbjudningar"
+
+msgid "§eNo pending invites"
+msgstr "§eInga väntande inbjudningar"
+
+msgid "withdraw an invite"
+msgstr "dra tillbaka en inbjudan"
+
+# ???
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§cDu saknar rättighet att dra tillbaka inbjudningar."
+
+msgid "check your or another''s island info"
+msgstr "kolla din eller en annans ös info"
+
+msgid "allows user to see others island info"
+msgstr "tillåter spelaren att se andra öars info"
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBlock på {0}s ö (sida {1,number} av {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Poäng Antal Blocktyp"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "litar på en annan spelare att hjälpa dig på ön."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eFöljande spelare är betrodda på ön:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eFöljande ledare litar på dig:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr "§eFör att lita på en annan spelare, använd /island trust <namn>"
+
+msgid "§4Members are already trusted!"
+msgstr "§cSpelarna är redan betrodda!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§cOkänd spelare {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eDu är nu betrodd på §4{0}s ö."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} betrodde {1} på ön"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eDu är inte längre betrodd på §4{0}s ö."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§e{0} återkallade förtroendet för {1} på ön"
+
+msgid "delete your island and start a new one."
+msgstr "ta bort din ö och starta en ny."
+
+msgid "exempt player from restart-cooldown"
+msgstr "undantar spelaren från restart-cooldown"
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§cEndast gruppledaren kan starta om ön. Lämna ön för att starta din egna (/"
+"island leave)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eDu måste ta bort alla medlemmar från ön innan du kan starta om den (/"
+"island kick <namn>). Visa en lista av gruppmedlemmar med /is party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§eDu kan starta om din ö om {0} sekunder."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr "§cDin ö håller på att genereras, du kan inte börja om just nu."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§eVIKTIGT: Hela din ö och alla dina ägodelar kommer att ÅTERSTÄLLAS!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "teleporterar dig till skyblock spawnen"
+
+msgid "change the biome of the island"
+msgstr "byt öns biome"
+
+msgid "exempt player from biome-cooldown"
+msgstr "undanta spelaren från biome-cooldown"
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr "Låt spelaren byta deras biome till {0}"
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr "§cDu saknar rättighet att byta biome på nuvarande ö."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§cDu får inte byta biome på denna ö!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eDu måste vara på din ö för att kunna byta biome!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr "§cDu har felstavat biomets namn. Måste vara en av {0}"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eDu kan byta biome igen om {0,number,#} minuter."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§cDu saknar rättighet att byta öns biome till den typen."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr "§7Byter biome nära dig till {0}, vänligen vänta."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr "§eOgiltigt biome {0} angavs"
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aDu har bytt öns biome till {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} bytte öns biome till {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr ""
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr "{0} skapade en area med {1} biome"
+
+msgid "set your island''s warp location"
+msgstr "ställer in öns warp position"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cDu saknar rättighet att ställa in öns warp position!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§cDu måste vara på ön för att ställa in öns warp!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d flyttade öns warp position."
+
+msgid "teleports you to your island (or create one)"
+msgstr "teleporterar dig till din ö (eller skapar en)"
+
+msgid "ban/unban a player from your island."
+msgstr "banna eller unbanna en spelare från din ö."
+
+msgid "exempts user from being banned"
+msgstr "undantar spelaren från att bli bannad"
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§eFöljande spelare är bannad från att warpa till din ö:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr "§eFör att banna eller unbanna från din ö, använd /island ban <namn>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§cDu kan inte banna gruppmedlemmar. Ta bort dem från ön först!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§cDu saknar rättighet att kicka eller banna spelare."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§eKunde inte banna okänd spelare {0}"
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§c{0} försökte att banna dig från din ö!"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§c{0} undantas från att bli bannad."
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eDu har bannat §c{0}§e från att warpa till din ö."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eDu har blivit bannad från att warpa till {0}s ö."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§eDu har unbannat §a{0}§e från att warpa till din ö."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eDu har blivit unbannad från att warpa till {0}s ö."
+
+msgid "display log"
+msgstr "visa loggen"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "ställer in öns hem"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "aktiverar eller inaktiverar warpande till din ö."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr "§cDin ö är låst. Du måste låsa upp den innan du kan aktivera din warp."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d aktiverade öns warp."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr "§cDu saknar rättighet att aktivera/inaktivera öns warp!"
+
+msgid "try to complete a challenge"
+msgstr "försök att slutför uppdraget"
+
+msgid "show information about the challenge"
+msgstr "visa information om uppdraget"
+
+msgid "§eRank: "
+msgstr "§eRank:"
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§cDetta uppdrag är ej repeterbart!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr "§cDu kommer att förlora allt krävda material när du gör detta uppdrag!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§cAllt krävda material måste vara placerat på din ö, minst {0} blocks ifrån "
+"dig."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§e§lFör att genomföra detta uppdrag, använda §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§cFelaktigt namn på uppdraget! Använd /c help för mer information."
+
+msgid "§eSending you to spawn."
+msgstr "§eSkickar dig till spawn."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§eÖn har blivit §cLÅST§e."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§cKunde inte hitta en säker hem-position på din ö!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§cVARNING: §eTeleporterar dig till luften."
+
+msgid "§aTeleporting you to your island."
+msgstr "§aTeleporterar dig till din ö."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aDu kommer att teleporteras om {0} sekunder."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Kan inte warpa till den spelarens ö!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aTeleporterar dig till {0}s ö."
+
+msgid "§7Teleport cancelled"
+msgstr "§7Teleportering avbruten"

--- a/uSkyBlock-Core/src/main/po/vi_VN.po
+++ b/uSkyBlock-Core/src/main/po/vi_VN.po
@@ -12,6 +12,30 @@ msgstr ""
 "X-Generator: Poedit 1.8.8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+msgid "d"
+msgstr "ngày"
+
+msgid "h"
+msgstr "giờ"
+
+msgid "m"
+msgstr "phút"
+
+msgid "s"
+msgstr "giây"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr ""
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}"
+msgstr ""
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§eBạn không có quyền (§4{0}§e)"
@@ -19,6 +43,15 @@ msgstr "§eBạn không có quyền (§4{0}§e)"
 #, java-format
 msgid "§eInvalid command: {0}"
 msgstr "§eLệnh không hợp lệ: {0}"
+
+msgid "Command"
+msgstr "Lệnh"
+
+msgid "Permission"
+msgstr "Quyền"
+
+msgid "Description"
+msgstr "Mô tả"
 
 #, java-format
 msgid "§7Usage: {0}"
@@ -43,1658 +76,12 @@ msgstr "Đã ghi thông tin vào {0}"
 msgid "§4Error writing documentation: {0}"
 msgstr "§4Lỗi khi ghi thông tin: {0}"
 
-msgid "Command"
-msgstr "Lệnh"
+msgid "§cWither Despawned!§e It wandered too far from your island."
+msgstr "§cTử hồn khô héo tân biến§e do di chuyển quá xa khỏi đảo"
 
-msgid "Permission"
-msgstr "Quyền"
-
-msgid "Description"
-msgstr "Mô tả"
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}"
-msgstr ""
-
-msgid "d"
-msgstr "ngày"
-
-msgid "h"
-msgstr "giờ"
-
-msgid "m"
-msgstr "phút"
-
-msgid "s"
-msgstr "giây"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr ""
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eThiếu các block sau: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr "§4Bạn có thể hoàn thành cái này {0} lần nữa."
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4Điều kiện hoàn thành sẽ được thiếp lập lại trong {0} ngày."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4Điều kiện hoàn thành sẽ được thiếp lập lại trong {0} giờ."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4Điều kiện hoàn thành sẽ được thiếp lập lại trong {0} phút."
-
-msgid "§4This challenge is currently unavailable."
-msgstr "§4Thử thách hiện thời không có sẵn."
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr "§4Bạn có thể hoàn thành cái này sau {0} ngày."
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr "§4Bạn có thể hoàn thành cái này sau {0} giờ."
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr "§4Bạn có thể hoàn thành cái này sau {0} phút"
-
-msgid "§eThis challenge requires:"
-msgstr "§eThử thách này cần:"
-
-msgid "§7and more..."
-msgstr "§7và còn nữa"
-
-msgid "§eItems will be traded for reward."
-msgstr "§eVật phẩm sẽ được trao đổi như phần thưởng."
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr "§ePhải trong phạm vi {0} mét."
-
-msgid "§6Item Reward: §a"
-msgstr "§6Phần thưởng: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Tiền thưởng: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Kinh nghiệm được thưởng: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dTổng số lần hoàn thành: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr "§7Cần {0}"
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4Không tìm thấy nhiệm vụ {0} "
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4Yêu cầu bạn phải ở trên skyblock của bạn để thao tác!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§4Nhiệm vụ {0} chưa xuất hiện!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4Nhiệm vụ {0} không thể hoàn thành nhiều lần!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr "§4Bạn chưa thể hoàn thành nhiệm vụ {0} lần nữa!"
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§eĐang thử hoàn thành nhiệm vụ §a{0}"
-
-#, java-format
-msgid "§4{0}"
-msgstr ""
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr ""
-"§4Bạn phải đứng trong phạm vi {0} block đối với những nguyên liệu của nhiệm "
-"vụ."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4Skyblock phải được {0} level để hoàn thành nhiệm vụ!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Chưa mở nhiệm vụ: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§eThiếu những vật thể sau:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr ""
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eBanj thiếu những nguyên liệu sau:{0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aBạn đã hoàn thành nhiệm vụ {0} !"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9{0}§f đã hoàn thành nhiệm vụ §9{1}§f!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§ePhần thưởng: §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eThưởng kinh nghiệm: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eTiền thưởng: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eKho linh kiện đã §4đầy§e. Phần thưởng rơi xuông dưới chân."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lClick để hoàn thành nhiệm vụ."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lBạn không thể làm lại nhiệm vụ này."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Xếp hạng: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fHoàn thành nhiều nhiệm vụ nhất ở "
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fMốc này để mở mốc nhiệm vụ sau."
-
-msgid "§eClick here to show previous page"
-msgstr "§eClick để xem trang trước"
-
-msgid "§eClick here to show next page"
-msgstr "§eClick để xem trang sau"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lNhiệm vụ bị khóa"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "Hoàn thành {0} hơn {1} lần"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Hoàn thành nhiệm vụ {0}"
-
-msgid "to unlock this rank"
-msgstr "Để mở mốc này"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "Bạn vẫn CÔÔÔÔÔÔÔÔ ĐƠNNNNNNNNNN"
-
-msgid "But you are Yelling in the wind!"
-msgstr "Gào thét trong cùng cuồng phong"
-
-msgid "But your fantasy friends are gone!"
-msgstr "Người bạn thú vị của bạn đã rời khỏi"
-
-msgid "But you are Talking to your self!"
-msgstr "Bạn đang độc thoại"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cXin lỗi! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr "Gửi tin nhắn trực tiếp đến nhóm của bạn, hoặc tùy chọn tắt/mở."
-
-msgid "party"
-msgstr ""
-
-msgid "island"
-msgstr ""
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§cTin nhắn đến {0} đã §aBẬT"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§cDùng §9{0}§c lần nữa để tắt nó"
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§aTin nhắn đã §cTẮT§a cho {0}"
-
-msgid "§cCommand only available to players"
-msgstr "§cLệnh chỉ có thể dùng bởi người chơi"
-
-msgid "talk to players on your island"
-msgstr "trò chuyện với người chơi trên đảo"
-
-msgid "talk to your island party"
-msgstr "trò chuyện với thành viên trong đảo"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§eNgười chơi {0} không có đảo!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eKhông có người chơi {0} ."
-
-msgid "Manage challenges for a player"
-msgstr "Chỉnh nhiệm vụ cho 1 người chơi"
-
-msgid "resets the challenge for the player"
-msgstr "làm mới nhiệm vụ cho người chơi"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4Nhiệm vụ chưa bao giờ được hoàn thành"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§eNhiệm vụ: {0} đã được làm mới cho {1}"
-
-msgid "resets all challenges for the player"
-msgstr "làm mới toàn bộ nhiệm vụ cho người chơi"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§eNhiệm vụ của {0} đã được làm mới toàn bộ "
-
-msgid "complete all challenges in the rank"
-msgstr "làm mới toàn bộ nhiệm vụ trong xêp hạng"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4Không tìm thấy người chơi tên {0} !"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4Nhiệm vụ {0} đã được hoàn thành"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§enhiệm vụ: {0} đã được hoàn thành bởi {1}"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4Không có nhiệm vụ tên {0} !"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4Nhiệm vụ cấp {0} không được tìm thấy!"
-
-msgid "manage islands"
-msgstr "tùy chỉnh skyblock"
-
-msgid "protects the island"
-msgstr "bảo vệ skyblock"
-
-msgid "delete the island (removes the blocks)"
-msgstr "xóa đảo skyblock "
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Xóa skyblock đang bị bỏ hoang ở vị trí của bạn"
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4Skyblock này đang có người chơi\n"
-"§eGõ lệnh §9/usb island delete <tên>§e để xóa."
-
-msgid "removes the player from the island"
-msgstr "loại bỏ người chơi ra khỏi skyblock"
-
-msgid "adds the player to the island"
-msgstr "Thêm người chơi vào skyblock"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d đã tham gia skyblock của bạn"
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4Không tìm thấy người chơi tên {0} !"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-"§4Không tìm thấy skyblock hợp lê, hay đứng trên 1 cái, hoắc đưa ra tên gọi "
-"của skyblock"
-
-msgid "print out info about the island"
-msgstr "xem thông tin về skyblock đó"
-
-msgid "sets the biome of the island"
-msgstr "chuyển môi trường (biome) cua skyblock"
-
-msgid "§4That player has no island."
-msgstr "§4Người chơi đó không có skyblock."
-
-msgid "§4No valid island at your location"
-msgstr "§4Không có đảo hợp lệ ở vị trí của bạn"
-
-msgid "purges the island"
-msgstr "lọc skyblock"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Lỗi! §9Không có dảo hợp lệ để lọc."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cBỘ LỌC: §9Đã lọc skyblock tại {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "chuyển đổi trạng thái phớt lờ cho skyblock"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cĐưa skyblock của {0} được phớt lờ bởi bộ lọc và danh sách top 10."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§cBỏ trạng thái phơt lờ cho đảo của {0} nó sẽ được liệt vào danh sách top 10 "
-"và bộ lọc."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Tên người chơi không đúng."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Loại bỏ {0} khỏi skyblock"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eĐã chuyển môi trường đảo của {0}s thành {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eĐã chuyển môi trường đảo của {0} sang OCEAN."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr ""
-"§aBạn có thể phải ra spawn server hoặc vào lại server để thấy sự thay đổi."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} đã chuyển môi trường đảo sang {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} đã chuyển môi trường đảo sang OCEAN"
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eĐang xóa skyblock của {0}."
-
-msgid "Error: That player does not have an island!"
-msgstr "Lỗi: Người chơi đó không có skyblock!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§eĐảo của {0} ở {1} đã được bảo vệ"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4Đảo của {0} ở {1} đã được bảo vệ"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "Mở menu tùy chỉnh"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§eTùy chỉnh không hợp lệ"
-
-msgid "Controls player-cooldowns"
-msgstr "Điều khiển thời gian dung lại command của người chơi"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "bỏ thời gian dung lại của 1 command (* = toàn bộ)"
-
-msgid "§eThe player is not currently online"
-msgstr "Người chơi đang không online"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Đã hủy thời gian dùng lại cho lệnh {0} của người chơi {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Không có thời gian dùng lại lệnh {0} cho {1} !"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Command sai, chỉ hỗ trợ  command làm mới hoặc biome!"
-
-msgid "restarts the cooldown on the command"
-msgstr "làm mới thời gian dung lại của 1 command (* = toàn bộ)"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eLàm mới thời gian của command {0}  từ {1} đến {2} giây"
-
-msgid "lists all the active cooldowns"
-msgstr "Liệt kê danh sách hồi"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCác lệnh có làm lại"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr ""
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eKhông có thời gian hồi cho §9{0}§e."
-
-msgid "control debugging"
-msgstr "Điều khiển sửa lỗi"
-
-msgid "set debug-level"
-msgstr "Đặt mức độ sửa lỗi"
-
-msgid "toggle debug-logging"
-msgstr "Bật, tắt lưu thông tin sửa lỗi"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4Tùy chọn lưu thông tin không được bật, nên bạn không thể tắt nó"
-
-msgid "flush current content of the logger to file."
-msgstr "Xả thông tin hiện tại vào file"
-
-msgid "§eLog-file has been flushed."
-msgstr "§eFile log đã được xả"
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4Chức năng lưu thông tin không được bật, gõ §d/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Sai cú pháp, hãy thử INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eĐã tắt logging"
-
-msgid "tries to fix the the area of flatland."
-msgstr "Đang thử sửa khu vực đất phẳng"
-
-msgid "§4No valid island found"
-msgstr "§4Không có đảo hợp lệ."
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4Không có đảo hợp lệ tại đảo của {0}"
-
-msgid "flushes all caches to files"
-msgstr "Xả toàn bộ cache vào files"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-"§eĐã xả đảo của §a{0} §e, §b{1} người chơi §6{2} và thông tin nhiệm vụ."
-
-msgid "manually update the top 10 list"
-msgstr "Cập nhật danh sách top 10 1 cách thủ công"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eĐang khởi tạo danh sách top 10"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eHoản thành khởi tạo"
-
-msgid "advanced command for getting island-data"
-msgstr "Command nâng cáo về thông tin đảo"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§eGiá trị hiện tải của {0} là \"{1}\""
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§cKhông thể lấy được state cho {0}"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§eCác nơi hợp lệ {0}"
-
-msgid "teleport to another players island"
-msgstr "Dịch chuyển đến đảo của người chơi khác"
-
-msgid "§4Only supported for players"
-msgstr "§4Chỉ hỗ trợ cho người chơi"
-
-msgid "§4That player does not have an island!"
-msgstr "§4Người chơi đó không có skyblock."
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr "§aĐang dịch chuyển đến đảo của {0}."
-
-msgid "imports players and islands from other formats"
-msgstr "Chuyển đổi thông tin người chơi và đảo từ dạng khác"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Thống kê công việc"
-
-msgid "§7----------------"
-msgstr ""
-
-msgid "#"
-msgstr ""
-
-msgid "ms/job"
-msgstr ""
-
-msgid "ms/tick"
-msgstr ""
-
-msgid "ticks"
-msgstr ""
-
-msgid "act"
-msgstr ""
-
-msgid "time"
-msgstr ""
-
-msgid "name"
-msgstr ""
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "chuyên ngôn ngữ, và reload"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aĐã chuyển ngon ngữ sang §e{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§aThất bại chuyển ngon ngữ sang §e{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Các ngôn ngữ được hỗ trợ:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 dịch bởi {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cKhông thể xác định ngôn ngữ"
-
-msgid "transfer leadership to another player"
-msgstr "Chuyển đổi thủ lĩnh cho người chơi"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§eNgười chơi {0} không có đảo!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§eNgười chơi §d{0}§e Đã có đảo.§eDùng lệnh §d/usb island remove <name>§e để "
-"xóa người chơi khỏi đảo."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bĐã chuyển quyền thủ lĩnh đảo của {0}§b cho {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr ""
-
-msgid "shows the NBTTag for the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr ""
-
-msgid "§cNo item in hand!"
-msgstr ""
-
-msgid "§eCan only be executed as a player"
-msgstr "§eChỉ có thể dung bời người chơi"
-
-msgid "sets the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "adds the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "manage orphans"
-msgstr ""
-
-msgid "count orphans"
-msgstr ""
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§e{0} Địa điểm cũ của các đảo sẽ được dung trước cái mới."
-
-msgid "clear orphans"
-msgstr ""
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eXóa những vị trí đảo cũ (trống)."
-
-msgid "list orphans"
-msgstr ""
-
-msgid "§eNo orphans currently registered."
-msgstr ""
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr ""
-
-msgid "protects all islands (time consuming)"
-msgstr "bảo vệ toàn bộ skyblock (Tốn thời gian)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr ""
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§eĐang tiến hành bảo vệ toàn bộ. Sẽ mất 1 chút thời gian."
-
-msgid "purges all abandoned islands"
-msgstr "Lọc toàn bộ đảo bị bỏ hoang"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4Bạn phải cung cấp số ngày để lọc!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr ""
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr ""
-
-msgid "region manipulations"
-msgstr ""
-
-msgid "shows the borders of the current island"
-msgstr "Hiện giới hạn xây của đảo hiện tại"
-
-msgid "§eNo island found at your current location"
-msgstr "§eKhông tìm thấy đảo ở vị trí của bạn"
-
-msgid "shows the borders of the current chunk"
-msgstr "Hiện giới hạn của chunk hiện tại"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "Hiện giới hạn của chunk bên trong"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr ""
-
-msgid "shows the borders of the outer-chunks"
-msgstr "Hiện giới hạn của chunk bên ngoài"
-
-msgid "hides the regions again"
-msgstr "Giấu khu vực "
-
-msgid "§eStopped displaying regions"
-msgstr "§eĐã dừng giấu khu vực "
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§eKhông có khu vực nào được xuất hiện cho người chơi này"
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr ""
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr ""
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "Đặt đảo của người chơi tại vị trí của bạn"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "reload lại config.yml"
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§e Đã reload lại config.yml"
-
-msgid "advanced command for setting island-data"
-msgstr "Command nâng cáo về chỉnh thông tin đảo"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§c{0} đã được chỉnh sang ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§cKhông thê chỉnh {0} sang ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr "§cKhông thê chỉnh {0} sang ''{1}'', cần 1 con số"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§cField {0} không hợp lệ"
-
-msgid "toggles maintenance mode"
-msgstr ""
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr ""
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr ""
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr ""
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr ""
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4PURGE:§9 Lọc hoàn tất"
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr ""
-
-msgid "displays version information"
-msgstr "Hiện thông tin phiên bản"
-
-msgid "various WorldGuard utilities"
-msgstr ""
-
-msgid "refreshes the chunks around the player"
-msgstr "refreshes chunks quanh người chơi"
-
-msgid "§eResending chunks to the client"
-msgstr "§eGửi lại chunk tới cilent"
-
-msgid "load the region chunks"
-msgstr ""
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr ""
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr ""
-
-msgid "update the WG regions"
-msgstr ""
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr ""
-
-msgid "§eNo island found at your location!"
-msgstr "§eKhông tìm thấy đảo tại vị trí của bạn"
-
-msgid "refreshes the chunk around the player"
-msgstr ""
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "xem thông tin người chơi"
-
-msgid "try to complete a challenge"
-msgstr ""
-
-msgid "§cCommand only available for players."
-msgstr ""
-
-msgid "show information about the challenge"
-msgstr ""
-
-msgid "§eRank: "
-msgstr "§eXếp hạng: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4Không thể làm lại nhiệm vụ!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr "§4Bạn sẽ mất những món đồ sau khi hoàn thành!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4Tất cả món đồ phải đươc đặt trong skyblock của bạn trong bán kính {0} "
-"blocks."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§eĐể hoàn thành nhiệm vụ, gõ lệnh §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4Tên nhiệm vụ không đúng! Gõ lệnh /c help để có thêm thông tin"
-
-msgid "complete and list challenges"
-msgstr ""
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eNhiệm vụ bị tắt.Gọi admin server để mở."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4Bạn chỉ có thể hoàn thành nhiệm vụ ở skyblock !"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4Bạn chỉ có thể hoàn thành nhiệm vụ khi bận đã tạo skyblock"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr "§4Đảo đã đầy, hoặc có quá nhiều lời mời đang chờ"
-
-msgid "§4That player is already leader on another island."
-msgstr "§4Người chơi đã là thủ lĩnh của đảo khác."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e đã mời bạn, nhưng bạn đã ở trong 1 đảo"
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e mời bạn vào đảo"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§f/island [accept/reject]§e để chấp nhận/ từ chối lời mời"
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4Cảnh báo: bạn sẽ mất đảo nếu đồng ý"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d Đã mời {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e đã từ chối lời mời."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr "§4Không dung được command, hãy rời đảo trước"
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr "§aBạn đã tham gia đảo! Gõ /island party để xem những thành viên khác."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§eLời mời {0} đã quá thời hạn hoặc bị huỷ bỏ."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§eLời mời đến dảo của {0} đã quá thời hạn hoặc bị huỷ bỏ."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§eBạn chấp nhận lời mời gia nhập đảo."
-
-msgid "§4You haven't been invited."
-msgstr "§4Bạn không được mời"
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eBạn từ chơi lời mời gia nhập đảo"
-
-msgid "accept/reject an invitation."
-msgstr "chấp nhận/từ chối lời mời."
-
-msgid "teleports you to your island (or create one)"
-msgstr ""
-
-msgid "ban/unban a player from your island."
-msgstr "(bỏ) cấm người chơi."
-
-msgid "exempts user from being banned"
-msgstr ""
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§eNhững người chơi cấm bạn đến đảo của họ:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr "§eĐể (bỏ) cấm, dùng /island ban <tên người chơi>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§Bạn không thế cấm người chơi. Hãy trục xuất họ trước!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4Bạn không có quyền trục xuất/cấm ngươi chơi"
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr ""
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4{0} cố gắng cấm bạn đến đảo của họ"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4{0} không thể bị cấm"
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eBạn cấm §4{0} dịch chuyển đến đảo của bạn"
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eBạn bị §cCấm§e tại đảo của {0}"
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr ""
-"§eBạn bỏ lệnh cấm §a{0}§e, người chơi có thể dịch chuyển đến đảo của bạn."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eBạn được §abỏ lệnh cấm§e tại đảo của {0}"
-
-msgid "change the biome of the island"
-msgstr "chuyển vùng"
-
-msgid "exempt player from biome-cooldown"
-msgstr ""
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr ""
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr "§cBạn không có quyền chuyển vùng đảo hiện tại."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4Bạn không có quyền chuyền vùng cho đảo này"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eBạn phải ở trên đảo của mình để chuyển vùng"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr "§cBạn chọn sai tên vùng. Phải là một trong {0}"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eBạn có thể chuyển vùng lần nữa trong {0,number,#} phút."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cBạn không có quyền chuyển đến vùng này."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr "§7Đang chuyển vùng thành §9{0}§7, hãy kiên nhẫn."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr ""
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aBạn chuyển vùng đến {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} chuyền vùng đến {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr ""
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr ""
-
-msgid "create an island"
-msgstr "tạo đảo mới"
-
-msgid "exempt player from create-cooldown"
-msgstr ""
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr "§4Tìm thấy đảo!§e Bạn đã có đảo. Để tạo mới, dùng /is restart."
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4Tìm thấy đảo!§e Bạn đã là thành viên của một đảo.\n"
-"Để tạo đảo, đầu tiên hãy dùng§b /is leave"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eBạn khởi tạo đảo mới tron {0,number,#} giây."
-
-msgid "teleport to the island home"
-msgstr "hồi chuyển về nhà"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr "§cĐảo của bạn đang khởi tạo, bạn không thể hồi chuyển về nhà."
-
-msgid "check your or another''s island info"
-msgstr "kiểm tra thông tin đảo của bạn hoặc người khác"
-
-msgid "allows user to see others island info"
-msgstr ""
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4Cấp đảo bị vô hiệu hoá, liên lạc với quản trị viên."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eBạn phải có đảo để dùng lệnh"
-
-msgid "§4You do not have an island!"
-msgstr "§4Bạn không có đảo"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4Không thể dùng lệnh"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4Người chơi không xác đính hoặc không có đảo"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eKhối trên đảo của {0} (trang {1,number} của {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Điểm theo khối"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aCấp đảo là {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "mời người chơi vào đảo của bạn"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr "§eDùng§f /island invite <tên người chơi>§e để mời người chơi vào đảo."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4Chỉ có quản lý mới có thể mời người chơi khác!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aBạn có thể mời thêm {0} người chơi."
-
-msgid "§4You can't invite any more players."
-msgstr "§4Bạn không thể mời thêm người chơi."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4Bạn không có quyền mời người chơi vào đảo!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4Người chơi ngoại tuyến hoặc không tồn tại."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4Bạn không thế tự mời!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4Người chơi đang quản lý đảo của bạn"
-
-msgid "remove a member from your island."
-msgstr "trục xuất thành viên ra khỏi đảo của bạn"
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4Bạn không có quyền trục xuất ngươi chơi khác!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4Bạn không thể trục xuất quản lý của đáo!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4Dừng việc tự trục xuất"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0} đã trục xuất bạn khỏi đảo của họ!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} đã bị trục xuất khỏi đảo"
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0} cố gắng trục xuất bạn khỏi đảo của họ"
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4{0} không thể bị trục xuất"
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4{0} đã trục xuất bạn khỏi đảo của họ"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0} đã bị trục xuất khỏi đảo."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr "§4Người chơi không phải thành viên của đảo!"
-
-msgid "leave your party"
-msgstr "rời khỏi nhóm"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4Bạn không thể rời đảo chỉ có 1 thành viên. Thử dùng /island restart\n"
-"§4để khởi tạo đảo mới"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr ""
-"§eBạn sở hữu đảo này, thay vào đó dùng /island remove <tên người chơi>."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eBạn đã rời khỏi đào và hồi chuyển về khu vực chung."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0} rời khỏi đảo của bạn"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4Bạn phải trong thể giới của uSkyblock để rời khỏi nhóm"
-
-msgid "check your or anothers island level"
-msgstr "kiểm tra cấp đảo của bạn hoặc người khác"
-
-msgid "allows user to query for others levels"
-msgstr ""
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§Thông tin đảo của {0}:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9Hạng {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "khoá đảo đối với người ngoài nhóm"
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4Bạn không có quyền khoá đảo"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4Bạn không có quyền dung lệnh này!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4Bạn không có quyền mở khoá đảo!"
-
-msgid "display log"
-msgstr "xem lịch sử đảo"
-
-msgid "transfer leadership to another member"
-msgstr "nhường quyền quản lý cho thành viên khác"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4Bạn chỉ có thể nhường quyền quản lý cho thành viên trong nhóm"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e đã là quản lý đảo của bạn"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4Quản lý có thể nhường quyền hạn!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} cố xâm nhập đảo của bạn"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "xem thông tin nhóm"
-
-msgid "shows information about your party"
-msgstr "xem thông tin nhóm"
-
-msgid "show pending invites"
-msgstr "xem lời mời đang có"
-
-msgid "§eNo pending invites"
-msgstr "§eKhông có lời mời"
-
-msgid "withdraw an invite"
-msgstr "huỷ lời mời"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4Bạn không có quyền huỷ lời mời."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4Lệnh chỉ có thể dùng bởi người chơi"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4Không có đảo. §eDùng §b/is create §e để khởi tạo"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "xoá đảo của bạn và khởi tạo đảo mới"
-
-msgid "exempt player from restart-cooldown"
-msgstr ""
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4Chỉ quản lý có thể khởi tạo lại đảo.\n"
-"§4Rời khỏi đảo để có thể tạo đảo riêng (/island leave)"
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eBạn phải trục xuất tất cả thành viên trước khi khởi tạo lại đảo(/island "
-"kick player)\n"
-"Xem danh sách thành viên bằng /is party"
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§cBạn có thể khởi tạo lại trong {0} giây"
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§cĐảo của bạn đang khởi tạo lại"
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eGhi chú: Mọi thử trên đảo và vật phẩm của bạn sẽ bị khởi tạo lại"
-
-msgid "set the island-home"
-msgstr "thiết đặt vị trí nhà"
-
-msgid "set your island''s warp location"
-msgstr "thiết đặt điểm dịch chuyển của đảo"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cBạn không có quyền thiết đặt điểm dịch chuyển của đảo"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§cBạn phải trên đảo của bản thân để thiết đặt điểm dịch chuyển"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d thay đổi điểm dịch chuyển của đảo"
-
-msgid "teleports you to the skyblock spawn"
-msgstr "hồi chuyển về khu vực chung"
-
-msgid "enable/disable warping to your island."
-msgstr "bật/tắt dịch chuyển tới đảo của bạn"
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr "§4Đảo của bạn đã khoá. Bạn phải mở khoá để kích hoạt điểm dịch chuyển"
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d kích hoạt điểm dịch chuyển của đảo"
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d vô hiệu hoá điểm dịch chuyển của đảo"
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr "§cBạn không có quyền bật/tắt điểm dịch chuyển"
-
-msgid "display the top10 of islands"
-msgstr "hiện 10 đảo thứ hạng cao nhất"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr ""
-
-msgid "trust/untrust a player to help on your island."
-msgstr "(không) tín nhiệm người chơi để giúp bạn xây dựng đảo"
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eNhưng người chơi đã tín nhiệm bạn trên đảo:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eNhững quản lý đã tín nhiệm bạn:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr "§eĐể (huỷ bỏ) tín nhiệm, dùng /island trust <tên người chơi>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4Người chơi đã được tín nhiệm"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Người chơi không xác định {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eBạn được tín nhiệm trên đảo của {0}"
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} tín nhiệm bạn{1}"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eBạn không còn được tin tưởng trên đảo của §4{0}"
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0} không còn tín nhiệm {1}"
-
-msgid "warp to another player''s island"
-msgstr "dịch chuyển đến đảo của người chơi khác"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr "§aĐiểm dịch chuyển đã hoạt động, người chơi có thể dịch chuyển đến"
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§4Điểm dịch chuyển không hoạt động, người chơi không thể dịch chuyển đến đảo "
-"của bạn"
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr "§fThiết đặt điểm dịch chuyển tại vị trí của bạn dùng §e/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§f Bật tắt điểm dịch chuyển dùng §e/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4Không có quyền tạo điểm dịch chuyển trên đảo"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§fDịch chuyển đén đảo khác dùng §e/island wảp <tên người chơi>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4Không có quyền dịch chuyển tới đảo khác"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr "§cĐảo của bạn đang khởi tạo, không thể dịch chuyển đến nơi khác"
-
-msgid "§4That player does not exist!"
-msgstr "§4Người chơi không tồn tại"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4Người chơi không kích hoạt điểm dịch chuyển"
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr "§cĐảo của người đang khởi tạo, dịch chuyển vô hiệu"
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cCảnh báoL §9{0}§e đang dịch chuyển tới đảo của bạn!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4Bạn bị người chơi này cấm dịch chuyển tơi đảo này"
-
-msgid "general island command"
-msgstr "lệnh thông thường"
-
-msgid "allows user to bypass cooldowns"
-msgstr ""
-
-msgid "allows user to bypass visitor-protections"
-msgstr ""
-
-msgid "allows user to bypass teleport-delay"
-msgstr ""
-
-msgid "allows user to use [usb] signs"
-msgstr ""
-
-msgid "allows user to place [usb] signs"
-msgstr ""
+msgid "{0}''s Wither"
+msgstr "Tử hồn khô héo của{0}"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr ""
@@ -1710,31 +97,6 @@ msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr "§cTử hồn khô héo tân biến§e do di chuyển quá xa khỏi đảo"
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "Tử hồn khô héo của{0}"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eKhông thể vứt vật phẩm!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Quản lý: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "Bạn không thể nhặt vật phẩm ở đảo khác"
-
-msgid "Config:"
-msgstr "Tuỳ chỉnh:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr "§cKhông thể dịch chuyển vượt giới hạn độ cao §cĐịa ngục"
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr "§4Bạn có thể chuyển đổi nham thạch mỗi 10 giấy"
@@ -1778,19 +140,82 @@ msgstr "§eBạn chỉ có thể dùng trứng tạo sinh vật ở đảo của
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§cBạn đã đạt đến điểm bảo vệ giới hạn"
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eKhông thể vứt vật phẩm!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Quản lý: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "Bạn không thể nhặt vật phẩm ở đảo khác"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cBạn bị cấm khỏi đảo"
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§eĐảo đã khoá! Không thể xâm nhập"
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eHãy chờ đến lược của bạn §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "Lỗi phát sinh khi lưu trữ thông tin đảo/nhóm"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr ""
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr ""
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Khởi tạo đảo ... §e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"buSkyBlock phụ thuộc vào §9{0}§e >= §av{1}§e nhưng chỉ có §cv{2}§e được tìm "
+"thấy!\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyblock phụ thuộc vào §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§eKhông thể dùng mẫu đảo"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4Đảo đã chuyển giao cho người chơi"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4Cần phải ở trên đảo của bạn để thiết đặt nhà chính!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aNhà chính đã được đặt tại vị trí hiện tại."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4Vị trí hiện tại không an toàn."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr "§7Đang chuyển vùng thành §9{0}§7, hãy kiên nhẫn."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr "§cĐảo đang trong quá trình khởi tạo, không thể tạo mới ngay bây giờ."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "Tạo đảo không thành công. Liên lạc với quản trị viên để giải quyết."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr "§eKhởi tạo đảo, xin vui lòng chờ trong giây lát."
+
+msgid "§cCommand is currently disabled!"
+msgstr ""
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eThiếu các block sau: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1801,9 +226,6 @@ msgid ""
 "§eDoing §9{0}§e is §cRISKY§e. Repeat the command within §a{1}§e seconds to "
 "accept!"
 msgstr "§eLặp lại lệnh trong §a{1}§e giây để chấp nhận! {0}"
-
-msgid "N/A"
-msgstr "Không xác định"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** Bạn đã vào vùng được bảo vệ nhưng bị bỏ hoang"
@@ -1836,208 +258,32 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4Bạn phải là quản lý đảo để mở khoá"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr ""
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eHãy chờ đến lược của bạn §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr ""
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Khởi tạo đảo ... §e{0,number,###}%"
 
-#, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr ""
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr ""
-
-msgid "SUCCESS"
-msgstr ""
-
-msgid "FAILED"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4Không tìm thấy tệp chuyển đổi §e{0}"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr ""
-
-msgid "The island has been created."
-msgstr "Đảo đã được tạo"
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d khoá đảo"
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§Khi đảo bị khoá, điểm dịnh chuyển bị vô hiệu hoá"
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d mở khoá đảo"
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cBầu trời §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d đã bị trục xuất khỏi đảo"
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7 -{0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§Khởi tạo đảo tại vị trí của bạn"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9Khởi tạo đảo §7{0} của bạn"
-
-msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
-msgstr ""
-"§cĐảo ảnh hướng đến khu vực này vừa bị xoá! Hồi chuyển về \n"
-"khu vực chung"
-
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§cĐảo vừa bị xoá! Hồi chuyển về khu vực chung."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eBức tường danh vọng (trang {0} trên {1}:"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr "§4Danh sách xếp hạng đang trống! Chỉ áp dụng cho đảo trên cấp {0}"
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eHạng hiện tại: §f{0}"
-
-msgid "UNKNOWN"
+msgid "N/A"
 msgstr "Không xác định"
 
-msgid "ANIMAL"
-msgstr "Động vật"
+msgid "§4§lLocked Challenge"
+msgstr "§4§lNhiệm vụ bị khóa"
 
-msgid "MONSTER"
-msgstr "Quái vật"
-
-msgid "VILLAGER"
-msgstr "Dân làng"
-
-msgid "GOLEM"
-msgstr "Người máy"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (tối đa. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "Không thể xác định mẫu {0}, liên hế với quản trị viên"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aChúc mừng! §eKhởi tạo đảo thành công."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cGhi chú: Cong trình có thể vẫn được tiếp tục"
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Dùng §9/is h§r hay §9/ís§r menu để tới đó"
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§cCẩn thận!§9 Không thể đặt rương với {0}."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7 Trang {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
+msgid "READY"
 msgstr ""
 
 #, java-format
-msgid "§a+{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr ""
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr ""
-
-msgid "Return"
-msgstr "Trở về"
-
-msgid "§9Integer Editor"
-msgstr "§9Soạn thảo số"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eĐã lưu và tải lại tuỳ chỉnh"
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cPhát sinh lỗi! §9Không thể lưu tập tin tuỳ chỉnh"
-
-msgid "§3First Page"
-msgstr "§3Trang đầu"
-
-msgid "§3Last Page"
-msgstr "§3Trang cuối"
-
-msgid "§cSave & Reload config"
-msgstr "§cLưu và tải lại tuỳ chỉnh"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§4Nhiệm vụ {0} chưa xuất hiện!"
 
 msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
-"§7Lưu trữ chỉnh sửa và tải lại.\n"
-"§cGhi chú: §7Sử dụng cẩn thận"
 
-msgid "§7 (readonly)"
-msgstr "§7 (chỉ đọc)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr ""
 
 msgid "true"
 msgstr "đúng"
@@ -2456,6 +702,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "§7Trang hiện tại"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7 Trang {0}"
+
 msgid "§7First Page"
 msgstr "§7Trang đầu"
 
@@ -2739,8 +989,8 @@ msgstr "§cNhấp đề trở về"
 msgid "Island Restart Menu"
 msgstr "Tái khởi tạo đảo"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§eKhông thể dùng mẫu đảo"
+msgid "Config:"
+msgstr "Tuỳ chỉnh:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2756,112 +1006,116 @@ msgstr "§cNhấp vào §9{0}§c để tái khởi tạo"
 msgid "§aClick to restart!"
 msgstr "§aNhấp vào để tái khởi tạo"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr ""
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr ""
+
+msgid "Return"
+msgstr "Trở về"
+
+msgid "§9Integer Editor"
+msgstr "§9Soạn thảo số"
+
 msgid "Caps On"
 msgstr "Bật Caps Lock"
 
 msgid "§9Text Editor"
 msgstr "§9Trình soạn thảo"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eĐã lưu và tải lại tuỳ chỉnh"
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cPhát sinh lỗi! §9Không thể lưu tập tin tuỳ chỉnh"
+
+msgid "§3First Page"
+msgstr "§3Trang đầu"
+
+msgid "§3Last Page"
+msgstr "§3Trang cuối"
+
+msgid "§cSave & Reload config"
+msgstr "§cLưu và tải lại tuỳ chỉnh"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Lưu trữ chỉnh sửa và tải lại.\n"
+"§cGhi chú: §7Sử dụng cẩn thận"
+
+msgid "§7 (readonly)"
+msgstr "§7 (chỉ đọc)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4Không tìm thấy tệp chuyển đổi §e{0}"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr ""
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr ""
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr ""
+
+msgid "SUCCESS"
+msgstr ""
+
+msgid "FAILED"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr ""
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
-msgstr ""
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§eHồi chuyển về khu vực chug"
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§eĐảo đã bị khoá"
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aBạn sẽ dịch chuyển trong {0} giây"
-
-msgid "§7Teleport cancelled"
-msgstr "§7Huỷ bỏ dịch chuyển"
-
-msgid "READY"
-msgstr ""
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr ""
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Lỗi phát sinh khi lưu trữ thông tin đảo/nhóm"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr ""
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr ""
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"buSkyBlock phụ thuộc vào §9{0}§e >= §av{1}§e nhưng chỉ có §cv{2}§e được tìm "
-"thấy!\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyblock phụ thuộc vào §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4Đảo đã chuyển giao cho người chơi"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4Không thể tìm thấy chỗ đáp an toàn ở đảo của bạn!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§cCẢNH BÁO: §eĐang dịch chuyển bạn lên không trung."
-
-msgid "§aTeleporting you to your island."
-msgstr "§aDịch chuyển về đảo."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Không thể dịch chuyển đến đảo của người chơi này!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aDịch chuyển đến đảo của {0}."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4Cần phải ở trên đảo của bạn để thiết đặt nhà chính!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aNhà chính đã được đặt tại vị trí hiện tại."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4Vị trí hiện tại không an toàn."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cĐảo đang trong quá trình khởi tạo, không thể tạo mới ngay bây giờ."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "Tạo đảo không thành công. Liên lạc với quản trị viên để giải quyết."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr "§eKhởi tạo đảo, xin vui lòng chờ trong giây lát."
-
-msgid "§cCommand is currently disabled!"
 msgstr ""
 
 msgid "North"
@@ -2887,3 +1141,1747 @@ msgstr "Tây"
 
 msgid "North-West"
 msgstr "Tây bắc"
+
+msgid "The island has been created."
+msgstr "Đảo đã được tạo"
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d khoá đảo"
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§Khi đảo bị khoá, điểm dịnh chuyển bị vô hiệu hoá"
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d vô hiệu hoá điểm dịch chuyển của đảo"
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d mở khoá đảo"
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cBầu trời §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d đã bị trục xuất khỏi đảo"
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7 -{0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§Khởi tạo đảo tại vị trí của bạn"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9Khởi tạo đảo §7{0} của bạn"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aChúc mừng! §eKhởi tạo đảo thành công."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cGhi chú: Cong trình có thể vẫn được tiếp tục"
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Dùng §9/is h§r hay §9/ís§r menu để tới đó"
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "Không thể xác định mẫu {0}, liên hế với quản trị viên"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§cCẩn thận!§9 Không thể đặt rương với {0}."
+
+msgid "UNKNOWN"
+msgstr "Không xác định"
+
+msgid "ANIMAL"
+msgstr "Động vật"
+
+msgid "MONSTER"
+msgstr "Quái vật"
+
+msgid "VILLAGER"
+msgstr "Dân làng"
+
+msgid "GOLEM"
+msgstr "Người máy"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (tối đa. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§cĐảo ảnh hướng đến khu vực này vừa bị xoá! Hồi chuyển về \n"
+"khu vực chung"
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§cĐảo vừa bị xoá! Hồi chuyển về khu vực chung."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eBức tường danh vọng (trang {0} trên {1}:"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr "§4Danh sách xếp hạng đang trống! Chỉ áp dụng cho đảo trên cấp {0}"
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4Cấp đảo bị vô hiệu hoá, liên lạc với quản trị viên."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eHạng hiện tại: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "Hoàn thành {0} hơn {1} lần"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Hoàn thành nhiệm vụ {0}"
+
+msgid "to unlock this rank"
+msgstr "Để mở mốc này"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr "§4Bạn có thể hoàn thành cái này {0} lần nữa."
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Điều kiện hoàn thành sẽ được thiếp lập lại trong {0} ngày."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Điều kiện hoàn thành sẽ được thiếp lập lại trong {0} giờ."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4Điều kiện hoàn thành sẽ được thiếp lập lại trong {0} phút."
+
+msgid "§4This challenge is currently unavailable."
+msgstr "§4Thử thách hiện thời không có sẵn."
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr "§4Bạn có thể hoàn thành cái này sau {0} ngày."
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr "§4Bạn có thể hoàn thành cái này sau {0} giờ."
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr "§4Bạn có thể hoàn thành cái này sau {0} phút"
+
+msgid "§eThis challenge requires:"
+msgstr "§eThử thách này cần:"
+
+msgid "§7and more..."
+msgstr "§7và còn nữa"
+
+msgid "§eItems will be traded for reward."
+msgstr "§eVật phẩm sẽ được trao đổi như phần thưởng."
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr "§ePhải trong phạm vi {0} mét."
+
+msgid "§6Item Reward: §a"
+msgstr "§6Phần thưởng: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Tiền thưởng: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Kinh nghiệm được thưởng: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dTổng số lần hoàn thành: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr "§7Cần {0}"
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4Không tìm thấy nhiệm vụ {0} "
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4Yêu cầu bạn phải ở trên skyblock của bạn để thao tác!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4Nhiệm vụ {0} không thể hoàn thành nhiều lần!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr "§4Bạn chưa thể hoàn thành nhiệm vụ {0} lần nữa!"
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§eĐang thử hoàn thành nhiệm vụ §a{0}"
+
+#, java-format
+msgid "§4{0}"
+msgstr ""
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr ""
+"§4Bạn phải đứng trong phạm vi {0} block đối với những nguyên liệu của nhiệm "
+"vụ."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4Skyblock phải được {0} level để hoàn thành nhiệm vụ!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Chưa mở nhiệm vụ: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§eThiếu những vật thể sau:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr ""
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eBanj thiếu những nguyên liệu sau:{0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aBạn đã hoàn thành nhiệm vụ {0} !"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9{0}§f đã hoàn thành nhiệm vụ §9{1}§f!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§ePhần thưởng: §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eThưởng kinh nghiệm: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eTiền thưởng: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eKho linh kiện đã §4đầy§e. Phần thưởng rơi xuông dưới chân."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lClick để hoàn thành nhiệm vụ."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lBạn không thể làm lại nhiệm vụ này."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Xếp hạng: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fHoàn thành nhiều nhiệm vụ nhất ở "
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fMốc này để mở mốc nhiệm vụ sau."
+
+msgid "§eClick here to show previous page"
+msgstr "§eClick để xem trang trước"
+
+msgid "§eClick here to show next page"
+msgstr "§eClick để xem trang sau"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "Bạn vẫn CÔÔÔÔÔÔÔÔ ĐƠNNNNNNNNNN"
+
+msgid "But you are Yelling in the wind!"
+msgstr "Gào thét trong cùng cuồng phong"
+
+msgid "But your fantasy friends are gone!"
+msgstr "Người bạn thú vị của bạn đã rời khỏi"
+
+msgid "But you are Talking to your self!"
+msgstr "Bạn đang độc thoại"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cXin lỗi! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr "Gửi tin nhắn trực tiếp đến nhóm của bạn, hoặc tùy chọn tắt/mở."
+
+msgid "party"
+msgstr ""
+
+msgid "island"
+msgstr ""
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§cTin nhắn đến {0} đã §aBẬT"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§cDùng §9{0}§c lần nữa để tắt nó"
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§aTin nhắn đã §cTẮT§a cho {0}"
+
+msgid "§cCommand only available to players"
+msgstr "§cLệnh chỉ có thể dùng bởi người chơi"
+
+msgid "talk to your island party"
+msgstr "trò chuyện với thành viên trong đảo"
+
+msgid "talk to players on your island"
+msgstr "trò chuyện với người chơi trên đảo"
+
+msgid "manually update the top 10 list"
+msgstr "Cập nhật danh sách top 10 1 cách thủ công"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eĐang khởi tạo danh sách top 10"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eHoản thành khởi tạo"
+
+msgid "purges all abandoned islands"
+msgstr "Lọc toàn bộ đảo bị bỏ hoang"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4Bạn phải cung cấp số ngày để lọc!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr ""
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr ""
+
+msgid "Controls player-cooldowns"
+msgstr "Điều khiển thời gian dung lại command của người chơi"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "bỏ thời gian dung lại của 1 command (* = toàn bộ)"
+
+msgid "§eThe player is not currently online"
+msgstr "Người chơi đang không online"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Đã hủy thời gian dùng lại cho lệnh {0} của người chơi {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Không có thời gian dùng lại lệnh {0} cho {1} !"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Command sai, chỉ hỗ trợ  command làm mới hoặc biome!"
+
+msgid "restarts the cooldown on the command"
+msgstr "làm mới thời gian dung lại của 1 command (* = toàn bộ)"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eLàm mới thời gian của command {0}  từ {1} đến {2} giây"
+
+msgid "lists all the active cooldowns"
+msgstr "Liệt kê danh sách hồi"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCác lệnh có làm lại"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr ""
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eKhông có thời gian hồi cho §9{0}§e."
+
+msgid "toggles maintenance mode"
+msgstr ""
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr ""
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Thống kê công việc"
+
+msgid "§7----------------"
+msgstr ""
+
+msgid "#"
+msgstr ""
+
+msgid "ms/job"
+msgstr ""
+
+msgid "ms/tick"
+msgstr ""
+
+msgid "ticks"
+msgstr ""
+
+msgid "act"
+msgstr ""
+
+msgid "time"
+msgstr ""
+
+msgid "name"
+msgstr ""
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§eNgười chơi {0} không có đảo!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eKhông có người chơi {0} ."
+
+msgid "flushes all caches to files"
+msgstr "Xả toàn bộ cache vào files"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+"§eĐã xả đảo của §a{0} §e, §b{1} người chơi §6{2} và thông tin nhiệm vụ."
+
+msgid "tries to fix the the area of flatland."
+msgstr "Đang thử sửa khu vực đất phẳng"
+
+msgid "§4No valid island found"
+msgstr "§4Không có đảo hợp lệ."
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4Không có đảo hợp lệ tại đảo của {0}"
+
+msgid "manage orphans"
+msgstr ""
+
+msgid "count orphans"
+msgstr ""
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§e{0} Địa điểm cũ của các đảo sẽ được dung trước cái mới."
+
+msgid "clear orphans"
+msgstr ""
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eXóa những vị trí đảo cũ (trống)."
+
+msgid "list orphans"
+msgstr ""
+
+msgid "§eNo orphans currently registered."
+msgstr ""
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "Chuyển đổi thủ lĩnh cho người chơi"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§eNgười chơi {0} không có đảo!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eNgười chơi §d{0}§e Đã có đảo.§eDùng lệnh §d/usb island remove <name>§e để "
+"xóa người chơi khỏi đảo."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bĐã chuyển quyền thủ lĩnh đảo của {0}§b cho {1}"
+
+msgid "open GUI for config"
+msgstr "Mở menu tùy chỉnh"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§eTùy chỉnh không hợp lệ"
+
+msgid "teleport to another players island"
+msgstr "Dịch chuyển đến đảo của người chơi khác"
+
+msgid "§4Only supported for players"
+msgstr "§4Chỉ hỗ trợ cho người chơi"
+
+msgid "§4That player does not have an island!"
+msgstr "§4Người chơi đó không có skyblock."
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr "§aĐang dịch chuyển đến đảo của {0}."
+
+msgid "various WorldGuard utilities"
+msgstr ""
+
+msgid "refreshes the chunks around the player"
+msgstr "refreshes chunks quanh người chơi"
+
+msgid "§eResending chunks to the client"
+msgstr "§eGửi lại chunk tới cilent"
+
+msgid "load the region chunks"
+msgstr ""
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr ""
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr ""
+
+msgid "update the WG regions"
+msgstr ""
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr ""
+
+msgid "§eNo island found at your location!"
+msgstr "§eKhông tìm thấy đảo tại vị trí của bạn"
+
+msgid "refreshes the chunk around the player"
+msgstr ""
+
+msgid "region manipulations"
+msgstr ""
+
+msgid "shows the borders of the current island"
+msgstr "Hiện giới hạn xây của đảo hiện tại"
+
+msgid "§eNo island found at your current location"
+msgstr "§eKhông tìm thấy đảo ở vị trí của bạn"
+
+msgid "§eCan only be executed as a player"
+msgstr "§eChỉ có thể dung bời người chơi"
+
+msgid "shows the borders of the current chunk"
+msgstr "Hiện giới hạn của chunk hiện tại"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "Hiện giới hạn của chunk bên trong"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr ""
+
+msgid "shows the borders of the outer-chunks"
+msgstr "Hiện giới hạn của chunk bên ngoài"
+
+msgid "hides the regions again"
+msgstr "Giấu khu vực "
+
+msgid "§eStopped displaying regions"
+msgstr "§eĐã dừng giấu khu vực "
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§eKhông có khu vực nào được xuất hiện cho người chơi này"
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr ""
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr ""
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4PURGE:§9 Lọc hoàn tất"
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr ""
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr ""
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr ""
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr ""
+
+msgid "control debugging"
+msgstr "Điều khiển sửa lỗi"
+
+msgid "set debug-level"
+msgstr "Đặt mức độ sửa lỗi"
+
+msgid "toggle debug-logging"
+msgstr "Bật, tắt lưu thông tin sửa lỗi"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4Tùy chọn lưu thông tin không được bật, nên bạn không thể tắt nó"
+
+msgid "flush current content of the logger to file."
+msgstr "Xả thông tin hiện tại vào file"
+
+msgid "§eLog-file has been flushed."
+msgstr "§eFile log đã được xả"
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4Chức năng lưu thông tin không được bật, gõ §d/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Sai cú pháp, hãy thử INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eĐã tắt logging"
+
+msgid "advanced command for setting island-data"
+msgstr "Command nâng cáo về chỉnh thông tin đảo"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§c{0} đã được chỉnh sang ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§cKhông thê chỉnh {0} sang ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr "§cKhông thê chỉnh {0} sang ''{1}'', cần 1 con số"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§cField {0} không hợp lệ"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§eGiá trị hiện tải của {0} là \"{1}\""
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§cKhông thể lấy được state cho {0}"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§eCác nơi hợp lệ {0}"
+
+msgid "set a player''s island to your location"
+msgstr "Đặt đảo của người chơi tại vị trí của bạn"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr ""
+
+msgid "shows the NBTTag for the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr ""
+
+msgid "§cNo item in hand!"
+msgstr ""
+
+msgid "sets the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "adds the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "Manage challenges for a player"
+msgstr "Chỉnh nhiệm vụ cho 1 người chơi"
+
+msgid "resets the challenge for the player"
+msgstr "làm mới nhiệm vụ cho người chơi"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4Nhiệm vụ chưa bao giờ được hoàn thành"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§eNhiệm vụ: {0} đã được làm mới cho {1}"
+
+msgid "resets all challenges for the player"
+msgstr "làm mới toàn bộ nhiệm vụ cho người chơi"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§eNhiệm vụ của {0} đã được làm mới toàn bộ "
+
+msgid "complete all challenges in the rank"
+msgstr "làm mới toàn bộ nhiệm vụ trong xêp hạng"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4Không tìm thấy người chơi tên {0} !"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4Nhiệm vụ {0} đã được hoàn thành"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§enhiệm vụ: {0} đã được hoàn thành bởi {1}"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4Không có nhiệm vụ tên {0} !"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4Nhiệm vụ cấp {0} không được tìm thấy!"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "bảo vệ toàn bộ skyblock (Tốn thời gian)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr ""
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§eĐang tiến hành bảo vệ toàn bộ. Sẽ mất 1 chút thời gian."
+
+msgid "reload configuration from file."
+msgstr "reload lại config.yml"
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§e Đã reload lại config.yml"
+
+msgid "manage islands"
+msgstr "tùy chỉnh skyblock"
+
+msgid "protects the island"
+msgstr "bảo vệ skyblock"
+
+msgid "delete the island (removes the blocks)"
+msgstr "xóa đảo skyblock "
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Xóa skyblock đang bị bỏ hoang ở vị trí của bạn"
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4Skyblock này đang có người chơi\n"
+"§eGõ lệnh §9/usb island delete <tên>§e để xóa."
+
+msgid "removes the player from the island"
+msgstr "loại bỏ người chơi ra khỏi skyblock"
+
+msgid "adds the player to the island"
+msgstr "Thêm người chơi vào skyblock"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d đã tham gia skyblock của bạn"
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4Không tìm thấy người chơi tên {0} !"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+"§4Không tìm thấy skyblock hợp lê, hay đứng trên 1 cái, hoắc đưa ra tên gọi "
+"của skyblock"
+
+msgid "print out info about the island"
+msgstr "xem thông tin về skyblock đó"
+
+msgid "sets the biome of the island"
+msgstr "chuyển môi trường (biome) cua skyblock"
+
+msgid "§4That player has no island."
+msgstr "§4Người chơi đó không có skyblock."
+
+msgid "§4No valid island at your location"
+msgstr "§4Không có đảo hợp lệ ở vị trí của bạn"
+
+msgid "purges the island"
+msgstr "lọc skyblock"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4Lỗi! §9Không có dảo hợp lệ để lọc."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cBỘ LỌC: §9Đã lọc skyblock tại {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "chuyển đổi trạng thái phớt lờ cho skyblock"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cĐưa skyblock của {0} được phớt lờ bởi bộ lọc và danh sách top 10."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cBỏ trạng thái phơt lờ cho đảo của {0} nó sẽ được liệt vào danh sách top 10 "
+"và bộ lọc."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Tên người chơi không đúng."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Loại bỏ {0} khỏi skyblock"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eĐã chuyển môi trường đảo của {0}s thành {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eĐã chuyển môi trường đảo của {0} sang OCEAN."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr ""
+"§aBạn có thể phải ra spawn server hoặc vào lại server để thấy sự thay đổi."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} đã chuyển môi trường đảo sang {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} đã chuyển môi trường đảo sang OCEAN"
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eĐang xóa skyblock của {0}."
+
+msgid "Error: That player does not have an island!"
+msgstr "Lỗi: Người chơi đó không có skyblock!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§eĐảo của {0} ở {1} đã được bảo vệ"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4Đảo của {0} ở {1} đã được bảo vệ"
+
+msgid "displays version information"
+msgstr "Hiện thông tin phiên bản"
+
+msgid "imports players and islands from other formats"
+msgstr "Chuyển đổi thông tin người chơi và đảo từ dạng khác"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr ""
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "chuyên ngôn ngữ, và reload"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aĐã chuyển ngon ngữ sang §e{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§aThất bại chuyển ngon ngữ sang §e{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Các ngôn ngữ được hỗ trợ:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 dịch bởi {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cKhông thể xác định ngôn ngữ"
+
+msgid "advanced command for getting island-data"
+msgstr "Command nâng cáo về thông tin đảo"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "xem thông tin người chơi"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr "§4Đảo đã đầy, hoặc có quá nhiều lời mời đang chờ"
+
+msgid "§4That player is already leader on another island."
+msgstr "§4Người chơi đã là thủ lĩnh của đảo khác."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e đã mời bạn, nhưng bạn đã ở trong 1 đảo"
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e mời bạn vào đảo"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§f/island [accept/reject]§e để chấp nhận/ từ chối lời mời"
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4Cảnh báo: bạn sẽ mất đảo nếu đồng ý"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d Đã mời {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e đã từ chối lời mời."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr "§4Không dung được command, hãy rời đảo trước"
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr "§aBạn đã tham gia đảo! Gõ /island party để xem những thành viên khác."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§eLời mời {0} đã quá thời hạn hoặc bị huỷ bỏ."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§eLời mời đến dảo của {0} đã quá thời hạn hoặc bị huỷ bỏ."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§eBạn chấp nhận lời mời gia nhập đảo."
+
+msgid "§4You haven't been invited."
+msgstr "§4Bạn không được mời"
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eBạn từ chơi lời mời gia nhập đảo"
+
+msgid "general island command"
+msgstr "lệnh thông thường"
+
+msgid "allows user to bypass cooldowns"
+msgstr ""
+
+msgid "allows user to bypass visitor-protections"
+msgstr ""
+
+msgid "allows user to bypass teleport-delay"
+msgstr ""
+
+msgid "allows user to use [usb] signs"
+msgstr ""
+
+msgid "allows user to place [usb] signs"
+msgstr ""
+
+msgid "complete and list challenges"
+msgstr ""
+
+msgid "§cCommand only available for players."
+msgstr ""
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eNhiệm vụ bị tắt.Gọi admin server để mở."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4Bạn chỉ có thể hoàn thành nhiệm vụ ở skyblock !"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4Bạn chỉ có thể hoàn thành nhiệm vụ khi bận đã tạo skyblock"
+
+msgid "warp to another player''s island"
+msgstr "dịch chuyển đến đảo của người chơi khác"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr "§aĐiểm dịch chuyển đã hoạt động, người chơi có thể dịch chuyển đến"
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§4Điểm dịch chuyển không hoạt động, người chơi không thể dịch chuyển đến đảo "
+"của bạn"
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr "§fThiết đặt điểm dịch chuyển tại vị trí của bạn dùng §e/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§f Bật tắt điểm dịch chuyển dùng §e/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4Không có quyền tạo điểm dịch chuyển trên đảo"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§fDịch chuyển đén đảo khác dùng §e/island wảp <tên người chơi>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4Không có quyền dịch chuyển tới đảo khác"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr "§cĐảo của bạn đang khởi tạo, không thể dịch chuyển đến nơi khác"
+
+msgid "§4That player does not exist!"
+msgstr "§4Người chơi không tồn tại"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4Người chơi không kích hoạt điểm dịch chuyển"
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr "§cĐảo của người đang khởi tạo, dịch chuyển vô hiệu"
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cCảnh báoL §9{0}§e đang dịch chuyển tới đảo của bạn!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4Bạn bị người chơi này cấm dịch chuyển tơi đảo này"
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4Không có đảo. §eDùng §b/is create §e để khởi tạo"
+
+msgid "accept/reject an invitation."
+msgstr "chấp nhận/từ chối lời mời."
+
+msgid "leave your party"
+msgstr "rời khỏi nhóm"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4Bạn không thể rời đảo chỉ có 1 thành viên. Thử dùng /island restart\n"
+"§4để khởi tạo đảo mới"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr ""
+"§eBạn sở hữu đảo này, thay vào đó dùng /island remove <tên người chơi>."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eBạn đã rời khỏi đào và hồi chuyển về khu vực chung."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0} rời khỏi đảo của bạn"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4Bạn phải trong thể giới của uSkyblock để rời khỏi nhóm"
+
+msgid "check your or anothers island level"
+msgstr "kiểm tra cấp đảo của bạn hoặc người khác"
+
+msgid "allows user to query for others levels"
+msgstr ""
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eBạn phải có đảo để dùng lệnh"
+
+msgid "§4You do not have an island!"
+msgstr "§4Bạn không có đảo"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4Không thể dùng lệnh"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4Người chơi không xác đính hoặc không có đảo"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§Thông tin đảo của {0}:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aCấp đảo là {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9Hạng {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "tạo đảo mới"
+
+msgid "exempt player from create-cooldown"
+msgstr ""
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr "§4Tìm thấy đảo!§e Bạn đã có đảo. Để tạo mới, dùng /is restart."
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4Tìm thấy đảo!§e Bạn đã là thành viên của một đảo.\n"
+"Để tạo đảo, đầu tiên hãy dùng§b /is leave"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eBạn khởi tạo đảo mới tron {0,number,#} giây."
+
+msgid "invite a player to your island"
+msgstr "mời người chơi vào đảo của bạn"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr "§eDùng§f /island invite <tên người chơi>§e để mời người chơi vào đảo."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4Chỉ có quản lý mới có thể mời người chơi khác!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aBạn có thể mời thêm {0} người chơi."
+
+msgid "§4You can't invite any more players."
+msgstr "§4Bạn không thể mời thêm người chơi."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4Bạn không có quyền mời người chơi vào đảo!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4Người chơi ngoại tuyến hoặc không tồn tại."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4Bạn không thế tự mời!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4Người chơi đang quản lý đảo của bạn"
+
+msgid "lock your island to non-party members."
+msgstr "khoá đảo đối với người ngoài nhóm"
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4Bạn không có quyền khoá đảo"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4Bạn không có quyền dung lệnh này!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4Bạn không có quyền mở khoá đảo!"
+
+msgid "display the top10 of islands"
+msgstr "hiện 10 đảo thứ hạng cao nhất"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr ""
+
+msgid "remove a member from your island."
+msgstr "trục xuất thành viên ra khỏi đảo của bạn"
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4Bạn không có quyền trục xuất ngươi chơi khác!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4Bạn không thể trục xuất quản lý của đáo!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4Dừng việc tự trục xuất"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0} đã trục xuất bạn khỏi đảo của họ!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} đã bị trục xuất khỏi đảo"
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4{0} cố gắng trục xuất bạn khỏi đảo của họ"
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4{0} không thể bị trục xuất"
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4{0} đã trục xuất bạn khỏi đảo của họ"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0} đã bị trục xuất khỏi đảo."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr "§4Người chơi không phải thành viên của đảo!"
+
+msgid "teleport to the island home"
+msgstr "hồi chuyển về nhà"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr "§cĐảo của bạn đang khởi tạo, bạn không thể hồi chuyển về nhà."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4Lệnh chỉ có thể dùng bởi người chơi"
+
+msgid "transfer leadership to another member"
+msgstr "nhường quyền quản lý cho thành viên khác"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4Bạn chỉ có thể nhường quyền quản lý cho thành viên trong nhóm"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e đã là quản lý đảo của bạn"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4Quản lý có thể nhường quyền hạn!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} cố xâm nhập đảo của bạn"
+
+msgid "show party information"
+msgstr "xem thông tin nhóm"
+
+msgid "shows information about your party"
+msgstr "xem thông tin nhóm"
+
+msgid "show pending invites"
+msgstr "xem lời mời đang có"
+
+msgid "§eNo pending invites"
+msgstr "§eKhông có lời mời"
+
+msgid "withdraw an invite"
+msgstr "huỷ lời mời"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4Bạn không có quyền huỷ lời mời."
+
+msgid "check your or another''s island info"
+msgstr "kiểm tra thông tin đảo của bạn hoặc người khác"
+
+msgid "allows user to see others island info"
+msgstr ""
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eKhối trên đảo của {0} (trang {1,number} của {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Điểm theo khối"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "(không) tín nhiệm người chơi để giúp bạn xây dựng đảo"
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eNhưng người chơi đã tín nhiệm bạn trên đảo:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eNhững quản lý đã tín nhiệm bạn:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr "§eĐể (huỷ bỏ) tín nhiệm, dùng /island trust <tên người chơi>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4Người chơi đã được tín nhiệm"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Người chơi không xác định {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eBạn được tín nhiệm trên đảo của {0}"
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} tín nhiệm bạn{1}"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eBạn không còn được tin tưởng trên đảo của §4{0}"
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0} không còn tín nhiệm {1}"
+
+msgid "delete your island and start a new one."
+msgstr "xoá đảo của bạn và khởi tạo đảo mới"
+
+msgid "exempt player from restart-cooldown"
+msgstr ""
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4Chỉ quản lý có thể khởi tạo lại đảo.\n"
+"§4Rời khỏi đảo để có thể tạo đảo riêng (/island leave)"
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eBạn phải trục xuất tất cả thành viên trước khi khởi tạo lại đảo(/island "
+"kick player)\n"
+"Xem danh sách thành viên bằng /is party"
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§cBạn có thể khởi tạo lại trong {0} giây"
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr "§cĐảo của bạn đang khởi tạo lại"
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§eGhi chú: Mọi thử trên đảo và vật phẩm của bạn sẽ bị khởi tạo lại"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "hồi chuyển về khu vực chung"
+
+msgid "change the biome of the island"
+msgstr "chuyển vùng"
+
+msgid "exempt player from biome-cooldown"
+msgstr ""
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr ""
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr "§cBạn không có quyền chuyển vùng đảo hiện tại."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4Bạn không có quyền chuyền vùng cho đảo này"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eBạn phải ở trên đảo của mình để chuyển vùng"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr "§cBạn chọn sai tên vùng. Phải là một trong {0}"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eBạn có thể chuyển vùng lần nữa trong {0,number,#} phút."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§cBạn không có quyền chuyển đến vùng này."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr ""
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aBạn chuyển vùng đến {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} chuyền vùng đến {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr ""
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr ""
+
+msgid "set your island''s warp location"
+msgstr "thiết đặt điểm dịch chuyển của đảo"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cBạn không có quyền thiết đặt điểm dịch chuyển của đảo"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§cBạn phải trên đảo của bản thân để thiết đặt điểm dịch chuyển"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d thay đổi điểm dịch chuyển của đảo"
+
+msgid "teleports you to your island (or create one)"
+msgstr ""
+
+msgid "ban/unban a player from your island."
+msgstr "(bỏ) cấm người chơi."
+
+msgid "exempts user from being banned"
+msgstr ""
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§eNhững người chơi cấm bạn đến đảo của họ:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr "§eĐể (bỏ) cấm, dùng /island ban <tên người chơi>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§Bạn không thế cấm người chơi. Hãy trục xuất họ trước!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4Bạn không có quyền trục xuất/cấm ngươi chơi"
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr ""
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4{0} cố gắng cấm bạn đến đảo của họ"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4{0} không thể bị cấm"
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eBạn cấm §4{0} dịch chuyển đến đảo của bạn"
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eBạn bị §cCấm§e tại đảo của {0}"
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr ""
+"§eBạn bỏ lệnh cấm §a{0}§e, người chơi có thể dịch chuyển đến đảo của bạn."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eBạn được §abỏ lệnh cấm§e tại đảo của {0}"
+
+msgid "display log"
+msgstr "xem lịch sử đảo"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "thiết đặt vị trí nhà"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "bật/tắt dịch chuyển tới đảo của bạn"
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr "§4Đảo của bạn đã khoá. Bạn phải mở khoá để kích hoạt điểm dịch chuyển"
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d kích hoạt điểm dịch chuyển của đảo"
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr "§cBạn không có quyền bật/tắt điểm dịch chuyển"
+
+msgid "try to complete a challenge"
+msgstr ""
+
+msgid "show information about the challenge"
+msgstr ""
+
+msgid "§eRank: "
+msgstr "§eXếp hạng: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4Không thể làm lại nhiệm vụ!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr "§4Bạn sẽ mất những món đồ sau khi hoàn thành!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4Tất cả món đồ phải đươc đặt trong skyblock của bạn trong bán kính {0} "
+"blocks."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§eĐể hoàn thành nhiệm vụ, gõ lệnh §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4Tên nhiệm vụ không đúng! Gõ lệnh /c help để có thêm thông tin"
+
+msgid "§eSending you to spawn."
+msgstr "§eHồi chuyển về khu vực chug"
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§eĐảo đã bị khoá"
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4Không thể tìm thấy chỗ đáp an toàn ở đảo của bạn!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§cCẢNH BÁO: §eĐang dịch chuyển bạn lên không trung."
+
+msgid "§aTeleporting you to your island."
+msgstr "§aDịch chuyển về đảo."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aBạn sẽ dịch chuyển trong {0} giây"
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Không thể dịch chuyển đến đảo của người chơi này!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aDịch chuyển đến đảo của {0}."
+
+msgid "§7Teleport cancelled"
+msgstr "§7Huỷ bỏ dịch chuyển"

--- a/uSkyBlock-Core/src/main/po/xx_PIRATE.po
+++ b/uSkyBlock-Core/src/main/po/xx_PIRATE.po
@@ -10,6 +10,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+msgid "d"
+msgstr "d"
+
+msgid "h"
+msgstr "h"
+
+msgid "m"
+msgstr "m"
+
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§eYe do not have access (§4{0}§e)"
@@ -17,6 +41,15 @@ msgstr "§eYe do not have access (§4{0}§e)"
 #, java-format
 msgid "§eInvalid command: {0}"
 msgstr "§eInvalid command: {0}"
+
+msgid "Command"
+msgstr "Command"
+
+msgid "Permission"
+msgstr "Permission"
+
+msgid "Description"
+msgstr "Description"
 
 #, java-format
 msgid "§7Usage: {0}"
@@ -41,1672 +74,12 @@ msgstr "Wrote documentation to {0}"
 msgid "§4Error writing documentation: {0}"
 msgstr "§4Blimey writin'' documentation: {0}"
 
-msgid "Command"
-msgstr "Command"
+msgid "§cWither Despawned!§e It wandered too far from your island."
+msgstr "§cWither Despawned!§e It wandered too far from yer hideout."
 
-msgid "Permission"
-msgstr "Permission"
-
-msgid "Description"
-msgstr "Description"
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-msgid "d"
-msgstr "d"
-
-msgid "h"
-msgstr "h"
-
-msgid "m"
-msgstr "m"
-
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eStill the followin'' blocks short: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4Requirements will reset in {0} days."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4Requirements will reset in {0} hours."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4Requirements will reset in {0} minutes."
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr "§eThis challenge requires:"
-
-msgid "§7and more..."
-msgstr "§7an' more..."
-
-msgid "§eItems will be traded for reward."
-msgstr "§eItems will be traded for bounty."
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr "§eMust be within {0} meters."
-
-msgid "§6Item Reward: §a"
-msgstr "§6Item Bounty: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Currency Bounty: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Exp Bounty: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dTotal times completed: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr "§7Requires {0}"
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4Nay challenge named {0} found"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4Ye must be in yer hideout to do that!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§4The {0} challenge be not available yet!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4The {0} challenge be not repeatable!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§eTryin'' to complete challenge §a{0}"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr "§4Ye must be standin'' within {0} blocks of all required items."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4Yer hideout must be level {0} to complete this challenge!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Unknown type of challenge: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§eStill the followin'' entities short:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eYe be the followin'' items short:{0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aYe have completed the {0} challenge!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9{0}§f has completed the §9{1}§f challenge!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§eItem bounty(s): §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eExp bounty: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eCurrency bounty: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eYer inventory be §4full§e. Items dropped on the ground."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lClick to complete this challenge."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lYe can't repeat this challenge."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Rank: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fComplete most challenges in"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fthis rank to unlock the next rank."
-
-msgid "§eClick here to show previous page"
-msgstr "§eClick here to show previous page"
-
-msgid "§eClick here to show next page"
-msgstr "§eClick here to show next page"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lLocked Challenge"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "§7Complete {0} more {1} §7challenges"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Complete {0}"
-
-msgid "to unlock this rank"
-msgstr "to unlock this rank"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "But ye be ALLLLLLL ALOOOOONE!"
-
-msgid "But you are Yelling in the wind!"
-msgstr "But ye be Yellin' in the wind!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "But yer fantasy friends be gone!"
-
-msgid "But you are Talking to your self!"
-msgstr "But ye be Talkin' to yer self!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cSorry! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr "Either send a message directly to yer group, or toggle it on/off."
-
-msgid "party"
-msgstr "party"
-
-msgid "island"
-msgstr "island"
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§cToggled chat to {0} §aON"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§cRepeat §9{0}§c to toggle it off"
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§aToggled chat §cOFF§a for {0}"
-
-msgid "§cCommand only available to players"
-msgstr "§cCommand only available to pirates"
-
-msgid "talk to players on your island"
-msgstr "talk to pirates in yer hideout"
-
-msgid "talk to your island party"
-msgstr "talk to yer hideout party"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§ePirate {0} has nay hideout!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eInvalid pirate {0} supplied."
-
-msgid "Manage challenges for a player"
-msgstr "Manage challenges for a pirate"
-
-msgid "resets the challenge for the player"
-msgstr "resets the challenge for the pirate"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4Challenge has never been completed"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§echallenge: {0} has been reset for {1}"
-
-msgid "resets all challenges for the player"
-msgstr "resets all challenges for the pirate"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0} has had all challenges reset."
-
-msgid "complete all challenges in the rank"
-msgstr "complete all challenges in the rank"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4Nay pirate named {0} was found!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4Challenge {0} has already been completed"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§eChallenge {0} has been completed for {1}"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4Nay challenge named {0} was found!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4Nay rank named {0} was found!"
-
-msgid "manage islands"
-msgstr "manage islands"
-
-msgid "protects the island"
-msgstr "protects the hideout"
-
-msgid "delete the island (removes the blocks)"
-msgstr "delete the hideout (removes the blocks)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Deleted abandoned hideout at yer current location."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb hideout delete <name>§e to delete it."
-
-msgid "removes the player from the island"
-msgstr "removes the pirate from the hideout"
-
-msgid "adds the player to the island"
-msgstr "adds the pirate to the hideout"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d has joined yer hideout group."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4Nay pirate named {0} found!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-"§4Nay valid hideout provided, either stand within one, or provide a hideout "
-"name"
-
-msgid "print out info about the island"
-msgstr "print out info about the hideout"
-
-msgid "sets the biome of the island"
-msgstr "sets the biome of the hideout"
-
-msgid "§4That player has no island."
-msgstr "§4That pirate has nay hideout."
-
-msgid "§4No valid island at your location"
-msgstr "§4Nay valid hideout at yer location"
-
-msgid "purges the island"
-msgstr "purges the hideout"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Blimey! §9Nay valid hideout found for purgin'."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cPURGE: §9Purged hideout at {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "toggles the islands ignore status"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cSet {0}s hideout to be ignored on top-ten an'' purge."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§cRemoved ignore-flag of {0}s hideout, it will now show up on top-ten an'' "
-"purge."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Nay valid pirate-name supplied."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Removin'' {0} from hideout"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eChanged biome of {0}s hideout to {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eChanged biome of {0}s hideout to OCEAN."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr "§aYe may need to go to spawn, or relog, to see the changes."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} has had their biome changed to {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} has had their biome changed to OCEAN."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eRemovin'' {0}''s hideout."
-
-msgid "Error: That player does not have an island!"
-msgstr "Blimey: That pirate does not have a hideout!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§e{0}s hideout at {1} has been protected"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4{0}s hideout at {1} was already protected"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "open GUI for config"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§eInvalid configuration name"
-
-msgid "Controls player-cooldowns"
-msgstr "Controls pirate-cooldowns"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "clears the cooldown on a command (* = all)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eThe pirate be not currently online"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Cleared cooldown on {0} for {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Nay active cooldown on {0} for {1} detected!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Invalid command supplied, only restart an' biome supported!"
-
-msgid "restarts the cooldown on the command"
-msgstr "restarts the cooldown on the command"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eReset cooldown on {0} for {1}§e to {2} seconds"
-
-msgid "lists all the active cooldowns"
-msgstr "lists all the active cooldowns"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCmd Cooldown"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eNay active cooldowns for §9{0}§e found."
-
-msgid "control debugging"
-msgstr "control debuggin'"
-
-msgid "set debug-level"
-msgstr "set debug-level"
-
-msgid "toggle debug-logging"
-msgstr "toggle debug-loggin'"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4Loggin' wasn't active, so ye can't disable it!"
-
-msgid "flush current content of the logger to file."
-msgstr "flush current content of the logger to file."
-
-msgid "§eLog-file has been flushed."
-msgstr "§eLog-file has been flushed."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4Loggin' be not enabled, use §d/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eLoggin' disabled!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "tries to fix the the area of flatland."
-
-msgid "§4No valid island found"
-msgstr "§4Nay valid hideout found"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4Nay flatland detected at {0}''s hideout!"
-
-msgid "flushes all caches to files"
-msgstr "flushes all caches to files"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-"§eFlushed §a{0} islands§e, §b{1} pirates an'' §6{2} challenge-completions."
-
-msgid "manually update the top 10 list"
-msgstr "manually update the top 10 list"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eGeneratin' the Top Ten list"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eFinished generation of the Top Ten list"
-
-msgid "advanced command for getting island-data"
-msgstr "advanced command for gettin' hideout-data"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§eCurrent value for {0} is ''{1}''"
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§cUnable to get state for {0}"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§eValid fields be {0}"
-
-msgid "teleport to another players island"
-msgstr "teleport to another pirates hideout"
-
-msgid "§4Only supported for players"
-msgstr "§4Only supported for pirates"
-
-msgid "§4That player does not have an island!"
-msgstr "§4That pirate does not have a hideout!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr "§aTeleportin'' to {0}''s hideout."
-
-msgid "imports players and islands from other formats"
-msgstr "imports pirates an' islands from other formats"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Job Statistics"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/job"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "act"
-
-msgid "time"
-msgstr "time"
-
-msgid "name"
-msgstr "name"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "changes the language of the plugin, an' reloads"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aSuccessfully changed language to §e{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cFailed to change language to §e{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Supported Languages:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cUnable to locate any languages."
-
-msgid "transfer leadership to another player"
-msgstr "transfer leadership to another pirate"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4Pirate {0} has nay hideout to transfer!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§ePirate §d{0}§e already has a hideout.§eUse §d/usb hideout remove <name>§e "
-"to remove him first."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bLeadership transferred by {0}§b to {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr "advanced info about NBT stuff"
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "shows the NBTTag for the currently held item"
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§eInfo for §9{0}"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - name: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - nbttag: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§cNay item in hand!"
-
-msgid "§eCan only be executed as a player"
-msgstr "§eCan only be executed as a pirate"
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "sets the NBTTag on the currently held item"
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "§eSet §9{0}§e to §c{1}"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "adds the NBTTag on the currently held item"
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§eAdded §9{0}§e to §c{1}"
-
-msgid "manage orphans"
-msgstr "manage orphans"
-
-msgid "count orphans"
-msgstr "count orphans"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§e{0} old hideout locations will be used before new ones."
-
-msgid "clear orphans"
-msgstr "clear orphans"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eClearin' all old (empty) island locations."
-
-msgid "list orphans"
-msgstr "list orphans"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eNay orphans currently registered."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr "additional perks {0}"
-
-msgid "protects all islands (time consuming)"
-msgstr "protects all islands (time consumin')"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§cTryin' to abort protect-all task."
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-"§4Sorry!§e A protect-all be already runnin'. Let it complete first, or use "
-"§9usb protectall §cstop"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§eStartin' a protect-all task. It will take a while."
-
-msgid "purges all abandoned islands"
-msgstr "purges all abandoned islands"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4Ye must provide the age in days to purge!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr "§4Tryin' to abort purge"
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr "§4Startin' purge..."
-
-msgid "region manipulations"
-msgstr "region manipulations"
-
-msgid "shows the borders of the current island"
-msgstr "shows the borders of the current hideout"
-
-msgid "§eNo island found at your current location"
-msgstr "§eNay hideout found at yer current location"
-
-msgid "shows the borders of the current chunk"
-msgstr "shows the borders of the current chunk"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "shows the borders of the inner-chunks"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "shows the non-chunk-aligned borders"
-
-msgid "shows the borders of the outer-chunks"
-msgstr "shows the borders of the outer-chunks"
-
-msgid "hides the regions again"
-msgstr "hides the regions again"
-
-msgid "§eStopped displaying regions"
-msgstr "§eStopped displayin' regions"
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§eNay currently shown regions for this pirate"
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§eAnimation-tick changed to {0}."
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§eAnimation-tick must be a valid integer."
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "set a pirate''s hideout to yer location"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "reload configuration from file."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eConfiguration reloaded from file."
-
-msgid "advanced command for setting island-data"
-msgstr "advanced command for settin' hideout-data"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§c{0} was set to ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§cUnable to set field {0} to ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr "§cUnable to set field {0} to ''{1}'', a number was expected"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§cInvalid field {0}"
-
-msgid "toggles maintenance mode"
-msgstr "toggles maintenance mode"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-"§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr "§cMaintenance mode can only be changed from console!"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§cABORTED:§e Protect-All was aborted!"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr "§eCompleted protect-all in {0}, {1} new regions were created!"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4PURGE:§9 Scannin' aborted."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4PURGE:§9 Finished purgin' abandoned islands."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4PURGE:§9 Aborted purgin' abandoned islands."
-
-msgid "displays version information"
-msgstr "displays version information"
-
-msgid "various WorldGuard utilities"
-msgstr "various WorldGuard utilities"
-
-msgid "refreshes the chunks around the player"
-msgstr "refreshes the chunks around the pirate"
-
-msgid "§eResending chunks to the client"
-msgstr "§eResendin' chunks to the client"
-
-msgid "load the region chunks"
-msgstr "load the region chunks"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eLoadin'' chunks at {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eUnloadin'' chunks at {0}"
-
-msgid "update the WG regions"
-msgstr "update the WG regions"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§eIsland world-guard regions updated for {0}"
-
-msgid "§eNo island found at your location!"
-msgstr "§eNay hideout found at yer location!"
-
-msgid "refreshes the chunk around the player"
-msgstr "refreshes the chunk around the pirate"
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "show pirate-information"
-
-msgid "try to complete a challenge"
-msgstr "try to complete a challenge"
-
-msgid "§cCommand only available for players."
-msgstr "§cCommand only available for pirates."
-
-msgid "show information about the challenge"
-msgstr "show information about the challenge"
-
-msgid "§eRank: "
-msgstr "§eRank: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4This Challenge be not repeatable!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr "§4Ye will lose all required items when ye complete this challenge!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4All required items must be placed in yer hideout, within {0} blocks of ye."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§eTo complete this challenge, use §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4Invalid challenge name! Use /c help for more information"
-
-msgid "complete and list challenges"
-msgstr "complete an' list challenges"
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eChallenges has been disabled. Contact an administrator."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4Ye can only submit challenges in the skyblock world!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4Ye can only submit challenges when ye have a hideout!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4Yer hideout be full, or ye have too many pendin' invites. Ye can't invite "
-"anyone else."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4That pirate be already captain on another hideout."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e tried to invite ye, but ye be already in a party."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr "§aInvite sent to {0}"
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e has invited ye to join their hideout!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§f/island [accept/reject]§e to accept or reject the invite."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4WARNING: Ye will lose yer current hideout if ye accept!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d invited {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e has rejected the invitation."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr "§4Ye can't use that command right now. Leave yer current party first."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§aYe have joined a hideout! Use /island party to see the other members."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§eInvitation for {0}§e has timedout or been cancelled."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§eInvitation for {0}''s hideout has timedout or been cancelled."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§eYe have accepted the invitation to join a hideout."
-
-msgid "§4You haven't been invited."
-msgstr "§4Ye haven't been invited."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eYe have rejected the invitation to join a hideout."
-
-msgid "accept/reject an invitation."
-msgstr "accept/reject an invitation."
-
-msgid "teleports you to your island (or create one)"
-msgstr "teleports ye to yer hideout (or create one)"
-
-msgid "ban/unban a player from your island."
-msgstr "ban/unban a pirate from yer hideout."
-
-msgid "exempts user from being banned"
-msgstr "exempts user from bein' banned"
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§eThe followin' pirates be banned from warpin' to yer hideout:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr "§eTo ban/unban from yer hideout, use /island ban <pirate>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4Ye can't ban members. Remove 'em first!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4Ye do not have permission to kick/ban pirates."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§eUnable to ban unknown pirate {0}"
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4{0} tried to ban ye from their hideout!"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4{0} is exempt from bein'' banned."
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eYe have banned §4{0}§e from warpin'' to yer hideout."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eYe have been §cBANNED§e from {0}§e''s hideout."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§eYe have unbanned §a{0}§e from warpin'' to yer hideout."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eYe have been §aUNBANNED§e from {0}§e''s hideout."
-
-msgid "change the biome of the island"
-msgstr "change the biome of the hideout"
-
-msgid "exempt player from biome-cooldown"
-msgstr "exempt pirate from biome-cooldown"
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr "Let the pirate change their islands biome to {0}"
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr ""
-"§cYe do not have permission to change the biome of yer current hideout."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4Ye do not have permission to change the biome of this hideout!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eYe must be in yer hideout to change the biome!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr "§cYe have misspelled the biome name. Must be one of {0}"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eYe can change yer biome again in {0,number,#} minutes."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cYe do not have permission to change yer biome to that type."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-"§7The pixies be busy changin'' the biome near ye to §9{0}§7, be patient."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-"§7The pixies be busy changin'' the biome of yer hideout to §9{0}§7, be "
-"patient."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr "§eInvalid biome {0} supplied!"
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aYe have changed yer hideout''s biome to {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} changed the hideout biome to {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr "§aYe have changed {0} blocks around ye to the {1} biome"
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr "{0} created an area with {1} biome"
-
-msgid "create an island"
-msgstr "create a hideout"
-
-msgid "exempt player from create-cooldown"
-msgstr "exempt pirate from create-cooldown"
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4Island found!§e Ye already have a hideout. If ye want a fresh hideout, "
-"type§b /is restart§e to get one"
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4Island found!§e Ye be already a mates of a hideout. To start yer own, "
-"first§b /is leave"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eYe can create a new hideout in {0,number,#} seconds."
-
-msgid "teleport to the island home"
-msgstr "teleport to the hideout home"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§cYer hideout be in the process of generatin', ye cannot teleport home right "
-"now."
-
-msgid "check your or another''s island info"
-msgstr "check yer or anothers hideout info"
-
-msgid "allows user to see others island info"
-msgstr "allows user to see others hideout info"
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4Island level has been disabled, contact an administrator."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eYe must be in yer hideout to use this command."
-
-msgid "§4You do not have an island!"
-msgstr "§4Ye do not have a hideout!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4Ye do not have access to that command!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4That pirate be invalid or does not have a hideout!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Score Count Block"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aIsland level be {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "invite a pirate to yer hideout"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§eUse§f /island invite <playername>§e to invite a pirate to yer hideout."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4Only the hideout''s owner can invite!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aYe can invite {0} more pirates."
-
-msgid "§4You can't invite any more players."
-msgstr "§4Ye can't invite any more pirates."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4Ye do not have permission to invite others to this hideout!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4That pirate be offline or doesn't exist."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4Ye can't invite yourself!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4That pirate be the captain of yer hideout!"
-
-msgid "remove a member from your island."
-msgstr "remove a mates from yer hideout."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4Ye do not have permission to kick others from this hideout!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4Ye can't remove the captain from the Island!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4Stop kickin' yourself!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0} has removed ye from their hideout!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} has been removed from the hideout."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0} tried to kick ye from their hideout!"
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4{0} is exempt from bein'' kicked."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4{0} has kicked ye from their hideout!"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0} has been kicked from the hideout."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr ""
-"§4That pirate be not part of yer hideout group, an' not in yer hideout!"
-
-msgid "leave your party"
-msgstr "leave yer party"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4Ye can't leave yer hideout if ye be the only person. Try usin' /island "
-"restart if ye want a new one!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§eYe own this hideout, use /island remove <pirate> instead."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eYe have left the hideout an' returned to the pirate spawn."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0} has left yer hideout!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4Ye must be in the skyblock world to leave yer party!"
-
-msgid "check your or anothers island level"
-msgstr "check yer or anothers hideout level"
-
-msgid "allows user to query for others levels"
-msgstr "allows user to query for others levels"
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eInformation about {0}''s Island:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9Rank be {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "lock yer hideout to non-party members."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4Ye do not have permission to lock yer hideout!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4Ye don't have access to this command!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4Ye do not have permission to unlock yer hideout!"
-
-msgid "display log"
-msgstr "display log"
-
-msgid "transfer leadership to another member"
-msgstr "transfer leadership to another mates"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4Ye can only transfer ownership to party-members!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e be already captain of yer hideout!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4Only captain can transfer leadership!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} tried to take over the hideout!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "show party information"
-
-msgid "shows information about your party"
-msgstr "shows information about yer party"
-
-msgid "show pending invites"
-msgstr "show pendin' invites"
-
-msgid "§eNo pending invites"
-msgstr "§eNay pendin' invites"
-
-msgid "withdraw an invite"
-msgstr "withdraw an invite"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4Ye don't have permissions to uninvite pirates."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4This command can only be executed by a pirate"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4Nay Island. §eUse §b/is create§e to get one"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "delete yer hideout an' start a new one."
-
-msgid "exempt player from restart-cooldown"
-msgstr "exempt pirate from restart-cooldown"
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4Only the owner may restart this hideout. Leave this hideout in order to "
-"start yer own (/island leave)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eYe must remove all pirates from yer hideout before ye can restart it (/"
-"island kick <pirate>). See a list of pirates currently part of yer hideout "
-"usin' /island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§cYe can restart yer hideout in {0} seconds."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr "§cYer hideout be in the process of generatin', ye cannot restart now."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eNOTE: Yer entire hideout an' all yer belongin''s will be RESET!"
-
-msgid "set the island-home"
-msgstr "set the hideout-home"
-
-msgid "set your island''s warp location"
-msgstr "set yer hideout''s warp location"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cYe do not have permission to set yer hideout''s warp point!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§cYe need to be on yer own hideout to set the warp!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d changed the hideout warp location."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "teleports ye to the skyblock spawn"
-
-msgid "enable/disable warping to your island."
-msgstr "enable/disable warpin' to yer hideout."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr "§4Yer hideout be locked. Ye must unlock it before enablin' yer warp."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d activated the hideout warp."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d deactivated the hideout warp."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr "§cYe do not have permission to enable/disable yer hideout''s warp!"
-
-msgid "display the top10 of islands"
-msgstr "display the top10 of islands"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr "enables user to all-ways generate top-ten (nay cachin')"
-
-msgid "trust/untrust a player to help on your island."
-msgstr "trust/untrust a pirate to help in yer hideout."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eThe followin' pirates be trusted in yer hideout:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eThe followin' leaders trusts ye:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr "§eTo trust/untrust from yer hideout, use /island trust <pirate>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4Members be already trusted!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Unknown pirate {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eYe be now trusted on §4{0}''s §eisland."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} trusted {1} on the hideout"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eYe be nay longer trusted on §4{0}''s §eisland."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0} revoked trust in {1} on the hideout"
-
-msgid "warp to another player''s island"
-msgstr "warp to another pirate''s hideout"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr "§aYer incomin' warp be active, pirates may warp to yer hideout."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr "§4Yer incomin' warp be inactive, pirates may not warp to yer hideout."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr "§fSet incomin' warp to yer current location usin' §e/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§fToggle yer warp on/off usin' §e/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4Ye do not have permission to create a warp in yer hideout!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§fWarp to another hideout usin' §e/island warp <pirate>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4Ye do not have permission to warp to other islands!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§cYer hideout be in the process of generatin', ye cannot warp to other "
-"pirates islands right now."
-
-msgid "§4That player does not exist!"
-msgstr "§4That pirate does not exist!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4That pirate does not have an active warp."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§cThat pirates hideout be in the process of generatin', ye cannot warp to it "
-"right now."
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cWARNING: §9{0}§e be warpin'' to yer hideout!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4That pirate has forbidden ye from warpin' to their hideout."
-
-msgid "general island command"
-msgstr "general hideout command"
-
-msgid "allows user to bypass cooldowns"
-msgstr "allows user to bypass cooldowns"
-
-msgid "allows user to bypass visitor-protections"
-msgstr "allows user to bypass visitor-protections"
-
-msgid "allows user to bypass teleport-delay"
-msgstr "allows user to bypass teleport-delay"
-
-msgid "allows user to use [usb] signs"
-msgstr "allows user to use [usb] signs"
-
-msgid "allows user to place [usb] signs"
-msgstr "allows user to place [usb] signs"
+msgid "{0}''s Wither"
+msgstr "{0}''s Wither"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr ""
@@ -1722,33 +95,6 @@ msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr "§cWither Despawned!§e It wandered too far from yer hideout."
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "{0}''s Wither"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eVisitors can't drop items!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Owner: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "Ye cannot pick up other pirates' loot when ye be a visitor!"
-
-msgid "Config:"
-msgstr "Config:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§cNay Access! §eYe be tryin' to teleport to the roof of the §cNETHER§e, that "
-"be not allowed."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr "§4Ye can only convert obsidian once every 10 seconds"
@@ -1792,19 +138,83 @@ msgstr "§eYe can only use spawn-eggs on yer own hideout."
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§cYe have reached yer spawn-limit for yer hideout."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eVisitors can't drop items!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Owner: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "Ye cannot pick up other pirates' loot when ye be a visitor!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cBanned:§e Ye be banned from this hideout."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cLocked:§e That hideout be locked! Nay entry allowed."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eWaitin'' for our turn §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "Somethin' went awry storin' the hideout an'/or party data!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr "Convertin' data to UUID, this make take a while!"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§cMAINTENANCE:§e uSkyBlock be currently in maintenance mode"
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Creatin'' hideout...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§eYe do not have access to that hideout-schematic!"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4Pirate be already assigned to this hideout!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4Ye must be closer to yer hideout to set yer skyblock home!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aYer skyblock home has been set to yer current location."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4Yer current location be not a safe home-location."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+"§7The pixies be busy changin'' the biome of yer hideout to §9{0}§7, be "
+"patient."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr "§cYer hideout be in the process of generatin', ye cannot create now."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "Could not create yer Island. Please contact a server moderator."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr "§eGettin' yer hideout ready, please be patient, it can take a while."
+
+msgid "§cCommand is currently disabled!"
+msgstr "§cCommand be currently disabled!"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eStill the followin'' blocks short: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1817,9 +227,6 @@ msgid ""
 msgstr ""
 "§eDoin'' §9{0}§e be §cRISKY§e. Repeat the command within §a{1}§e seconds to "
 "accept!"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** Ye be enterin' a protected - but abandoned - island area."
@@ -1852,213 +259,33 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4Ye must be the party captain to unlock yer hideout!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§7PlayerDB: Filterin'' {0} pirates from uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eWaitin'' for our turn §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Creatin'' hideout...§e{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lLocked Challenge"
+
+msgid "READY"
+msgstr "READY"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§7PlayerDB: Filtered {0} names"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§7MojangAPI: Tryin'' to fetch {0} pirates from Mojang"
-
-msgid "SUCCESS"
-msgstr "SUCCESS"
-
-msgid "FAILED"
-msgstr "FAILED"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§7 - MojangAPI:§aCOMPLETED: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§7 - MojangAPI:§cERROR: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4Nay importer named §e{0}§4 found"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§eConverted {0}/{1} files in {2}"
-
-msgid "The island has been created."
-msgstr "The hideout has been created."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d locked the hideout."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§4Since yer hideout be locked, yer incomin' warp has been deactivated."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d unlocked the hideout."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cSKY §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d has been removed from the hideout group."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9Creatin' a hideout at yer location"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9Creatin'' a hideout §7{0}§9 of ye"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§4The {0} challenge be not available yet!"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
-"§cThe hideout ownin' this piece of nether be bein' deleted! Sendin' ye to "
-"spawn."
+"§cWARNING:§e Could not transfer all the required items to yer inventory!"
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§cThe hideout ye be on be bein' deleted! Sendin' ye to spawn."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eWALL OF FAME (page {0} of {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr "§4Top ten list be empty! Only islands above level {0} is considered."
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eYer rank be: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "UNKNOWN"
-
-msgid "ANIMAL"
-msgstr "ANIMAL"
-
-msgid "MONSTER"
-msgstr "MONSTER"
-
-msgid "VILLAGER"
-msgstr "VILLAGER"
-
-msgid "GOLEM"
-msgstr "GOLEM"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (max. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "Unable to locate schematic {0}, contact a server-admin"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aCongratulations! §eYer hideout has appeared."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cNote:§e Construction might still be ongoin'."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Use §9/is h§r or the §9/is§r menu to go there."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§cWatchdog!§9 Unable to locate a chest within {0}, bailin'' out."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7Page {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr "§c{0,number,#}"
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr "§a+{0,number,#}"
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr "§a{0,number,#}"
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr "&aLeft:&7 Increment with {0}"
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr "&cRight-Click:&7 Set to {0}"
-
-msgid "Return"
-msgstr "Return"
-
-msgid "§9Integer Editor"
-msgstr "§9Integer Editor"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eConfiguration saved an' reloaded."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cBlimey! §9Unable to save config file!"
-
-msgid "§3First Page"
-msgstr "§3First Page"
-
-msgid "§3Last Page"
-msgstr "§3Last Page"
-
-msgid "§cSave & Reload config"
-msgstr "§cSave & Reload config"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Saves the settin''s to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (readonly)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr "§cNot enough items in chest to complete challenge!"
 
 msgid "true"
 msgstr "true"
@@ -2514,6 +741,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "§7Current page"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7Page {0}"
+
 msgid "§7First Page"
 msgstr "§7First Page"
 
@@ -2828,8 +1059,8 @@ msgstr "§cClick to leave"
 msgid "Island Restart Menu"
 msgstr "Island Restart Menu"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§eYe do not have access to that hideout-schematic!"
+msgid "Config:"
+msgstr "Config:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2845,113 +1076,122 @@ msgstr "§cClick within §9{0}§c to restart!"
 msgid "§aClick to restart!"
 msgstr "§aClick to restart!"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr "§c{0,number,#}"
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr "§a+{0,number,#}"
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr "§a{0,number,#}"
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr "&aLeft:&7 Increment with {0}"
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr "&cRight-Click:&7 Set to {0}"
+
+msgid "Return"
+msgstr "Return"
+
+msgid "§9Integer Editor"
+msgstr "§9Integer Editor"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9Text Editor"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eConfiguration saved an' reloaded."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cBlimey! §9Unable to save config file!"
+
+msgid "§3First Page"
+msgstr "§3First Page"
+
+msgid "§3Last Page"
+msgstr "§3Last Page"
+
+msgid "§cSave & Reload config"
+msgstr "§cSave & Reload config"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Saves the settin''s to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (readonly)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4Nay importer named §e{0}§4 found"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§eConverted {0}/{1} files in {2}"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§7PlayerDB: Filterin'' {0} pirates from uuid2name.yml"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§7PlayerDB: Filtered {0} names"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§7MojangAPI: Tryin'' to fetch {0} pirates from Mojang"
+
+msgid "SUCCESS"
+msgstr "SUCCESS"
+
+msgid "FAILED"
+msgstr "FAILED"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§7 - MojangAPI:§aCOMPLETED: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§7 - MojangAPI:§cERROR: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "Too many requests for Mojangs API ({0} within {1}), sleepin'' {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§eSendin' ye to spawn."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§eThe hideout has been §cLOCKED§e."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aYe will be teleported in {0} seconds."
-
-msgid "§7Teleport cancelled"
-msgstr "§7Teleport cancelled"
-
-msgid "READY"
-msgstr "READY"
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-"§cWARNING:§e Could not transfer all the required items to yer inventory!"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr "§cNot enough items in chest to complete challenge!"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Somethin' went awry storin' the hideout an'/or party data!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr "Convertin' data to UUID, this make take a while!"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§cMAINTENANCE:§e uSkyBlock be currently in maintenance mode"
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4Pirate be already assigned to this hideout!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4Unable to find a safe home-location in yer hideout!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§cWARNING: §eTeleportin' ye to mid-air."
-
-msgid "§aTeleporting you to your island."
-msgstr "§aTeleportin' ye to yer hideout."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Unable to warp ye to that pirate''s hideout!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aTeleportin'' ye to {0}''s hideout."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4Ye must be closer to yer hideout to set yer skyblock home!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aYer skyblock home has been set to yer current location."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4Yer current location be not a safe home-location."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr "§cYer hideout be in the process of generatin', ye cannot create now."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "Could not create yer Island. Please contact a server moderator."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr "§eGettin' yer hideout ready, please be patient, it can take a while."
-
-msgid "§cCommand is currently disabled!"
-msgstr "§cCommand be currently disabled!"
 
 msgid "North"
 msgstr "North"
@@ -2976,6 +1216,1769 @@ msgstr "West"
 
 msgid "North-West"
 msgstr "North-West"
+
+msgid "The island has been created."
+msgstr "The hideout has been created."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d locked the hideout."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§4Since yer hideout be locked, yer incomin' warp has been deactivated."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d deactivated the hideout warp."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d unlocked the hideout."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cSKY §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d has been removed from the hideout group."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9Creatin' a hideout at yer location"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9Creatin'' a hideout §7{0}§9 of ye"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aCongratulations! §eYer hideout has appeared."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cNote:§e Construction might still be ongoin'."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Use §9/is h§r or the §9/is§r menu to go there."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "Unable to locate schematic {0}, contact a server-admin"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§cWatchdog!§9 Unable to locate a chest within {0}, bailin'' out."
+
+msgid "UNKNOWN"
+msgstr "UNKNOWN"
+
+msgid "ANIMAL"
+msgstr "ANIMAL"
+
+msgid "MONSTER"
+msgstr "MONSTER"
+
+msgid "VILLAGER"
+msgstr "VILLAGER"
+
+msgid "GOLEM"
+msgstr "GOLEM"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (max. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§cThe hideout ownin' this piece of nether be bein' deleted! Sendin' ye to "
+"spawn."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§cThe hideout ye be on be bein' deleted! Sendin' ye to spawn."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eWALL OF FAME (page {0} of {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr "§4Top ten list be empty! Only islands above level {0} is considered."
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4Island level has been disabled, contact an administrator."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eYer rank be: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "§7Complete {0} more {1} §7challenges"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Complete {0}"
+
+msgid "to unlock this rank"
+msgstr "to unlock this rank"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Requirements will reset in {0} days."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Requirements will reset in {0} hours."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4Requirements will reset in {0} minutes."
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr "§eThis challenge requires:"
+
+msgid "§7and more..."
+msgstr "§7an' more..."
+
+msgid "§eItems will be traded for reward."
+msgstr "§eItems will be traded for bounty."
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr "§eMust be within {0} meters."
+
+msgid "§6Item Reward: §a"
+msgstr "§6Item Bounty: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Currency Bounty: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Exp Bounty: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dTotal times completed: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr "§7Requires {0}"
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4Nay challenge named {0} found"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4Ye must be in yer hideout to do that!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4The {0} challenge be not repeatable!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§eTryin'' to complete challenge §a{0}"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr "§4Ye must be standin'' within {0} blocks of all required items."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4Yer hideout must be level {0} to complete this challenge!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Unknown type of challenge: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§eStill the followin'' entities short:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eYe be the followin'' items short:{0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aYe have completed the {0} challenge!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9{0}§f has completed the §9{1}§f challenge!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§eItem bounty(s): §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eExp bounty: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eCurrency bounty: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eYer inventory be §4full§e. Items dropped on the ground."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lClick to complete this challenge."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lYe can't repeat this challenge."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Rank: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fComplete most challenges in"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fthis rank to unlock the next rank."
+
+msgid "§eClick here to show previous page"
+msgstr "§eClick here to show previous page"
+
+msgid "§eClick here to show next page"
+msgstr "§eClick here to show next page"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "But ye be ALLLLLLL ALOOOOONE!"
+
+msgid "But you are Yelling in the wind!"
+msgstr "But ye be Yellin' in the wind!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "But yer fantasy friends be gone!"
+
+msgid "But you are Talking to your self!"
+msgstr "But ye be Talkin' to yer self!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cSorry! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr "Either send a message directly to yer group, or toggle it on/off."
+
+msgid "party"
+msgstr "party"
+
+msgid "island"
+msgstr "island"
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§cToggled chat to {0} §aON"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§cRepeat §9{0}§c to toggle it off"
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§aToggled chat §cOFF§a for {0}"
+
+msgid "§cCommand only available to players"
+msgstr "§cCommand only available to pirates"
+
+msgid "talk to your island party"
+msgstr "talk to yer hideout party"
+
+msgid "talk to players on your island"
+msgstr "talk to pirates in yer hideout"
+
+msgid "manually update the top 10 list"
+msgstr "manually update the top 10 list"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eGeneratin' the Top Ten list"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eFinished generation of the Top Ten list"
+
+msgid "purges all abandoned islands"
+msgstr "purges all abandoned islands"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4Ye must provide the age in days to purge!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr "§4Tryin' to abort purge"
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr "§4Startin' purge..."
+
+msgid "Controls player-cooldowns"
+msgstr "Controls pirate-cooldowns"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "clears the cooldown on a command (* = all)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eThe pirate be not currently online"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Cleared cooldown on {0} for {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Nay active cooldown on {0} for {1} detected!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Invalid command supplied, only restart an' biome supported!"
+
+msgid "restarts the cooldown on the command"
+msgstr "restarts the cooldown on the command"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eReset cooldown on {0} for {1}§e to {2} seconds"
+
+msgid "lists all the active cooldowns"
+msgstr "lists all the active cooldowns"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCmd Cooldown"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eNay active cooldowns for §9{0}§e found."
+
+msgid "toggles maintenance mode"
+msgstr "toggles maintenance mode"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+"§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr "§cMaintenance mode can only be changed from console!"
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Job Statistics"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/job"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "act"
+
+msgid "time"
+msgstr "time"
+
+msgid "name"
+msgstr "name"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§ePirate {0} has nay hideout!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eInvalid pirate {0} supplied."
+
+msgid "flushes all caches to files"
+msgstr "flushes all caches to files"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+"§eFlushed §a{0} islands§e, §b{1} pirates an'' §6{2} challenge-completions."
+
+msgid "tries to fix the the area of flatland."
+msgstr "tries to fix the the area of flatland."
+
+msgid "§4No valid island found"
+msgstr "§4Nay valid hideout found"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4Nay flatland detected at {0}''s hideout!"
+
+msgid "manage orphans"
+msgstr "manage orphans"
+
+msgid "count orphans"
+msgstr "count orphans"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§e{0} old hideout locations will be used before new ones."
+
+msgid "clear orphans"
+msgstr "clear orphans"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eClearin' all old (empty) island locations."
+
+msgid "list orphans"
+msgstr "list orphans"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eNay orphans currently registered."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "transfer leadership to another pirate"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4Pirate {0} has nay hideout to transfer!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§ePirate §d{0}§e already has a hideout.§eUse §d/usb hideout remove <name>§e "
+"to remove him first."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bLeadership transferred by {0}§b to {1}"
+
+msgid "open GUI for config"
+msgstr "open GUI for config"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§eInvalid configuration name"
+
+msgid "teleport to another players island"
+msgstr "teleport to another pirates hideout"
+
+msgid "§4Only supported for players"
+msgstr "§4Only supported for pirates"
+
+msgid "§4That player does not have an island!"
+msgstr "§4That pirate does not have a hideout!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr "§aTeleportin'' to {0}''s hideout."
+
+msgid "various WorldGuard utilities"
+msgstr "various WorldGuard utilities"
+
+msgid "refreshes the chunks around the player"
+msgstr "refreshes the chunks around the pirate"
+
+msgid "§eResending chunks to the client"
+msgstr "§eResendin' chunks to the client"
+
+msgid "load the region chunks"
+msgstr "load the region chunks"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eLoadin'' chunks at {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eUnloadin'' chunks at {0}"
+
+msgid "update the WG regions"
+msgstr "update the WG regions"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§eIsland world-guard regions updated for {0}"
+
+msgid "§eNo island found at your location!"
+msgstr "§eNay hideout found at yer location!"
+
+msgid "refreshes the chunk around the player"
+msgstr "refreshes the chunk around the pirate"
+
+msgid "region manipulations"
+msgstr "region manipulations"
+
+msgid "shows the borders of the current island"
+msgstr "shows the borders of the current hideout"
+
+msgid "§eNo island found at your current location"
+msgstr "§eNay hideout found at yer current location"
+
+msgid "§eCan only be executed as a player"
+msgstr "§eCan only be executed as a pirate"
+
+msgid "shows the borders of the current chunk"
+msgstr "shows the borders of the current chunk"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "shows the borders of the inner-chunks"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "shows the non-chunk-aligned borders"
+
+msgid "shows the borders of the outer-chunks"
+msgstr "shows the borders of the outer-chunks"
+
+msgid "hides the regions again"
+msgstr "hides the regions again"
+
+msgid "§eStopped displaying regions"
+msgstr "§eStopped displayin' regions"
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§eNay currently shown regions for this pirate"
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§eAnimation-tick changed to {0}."
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§eAnimation-tick must be a valid integer."
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4PURGE:§9 Finished purgin' abandoned islands."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4PURGE:§9 Aborted purgin' abandoned islands."
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4PURGE:§9 Scannin' aborted."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§cABORTED:§e Protect-All was aborted!"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr "§eCompleted protect-all in {0}, {1} new regions were created!"
+
+msgid "control debugging"
+msgstr "control debuggin'"
+
+msgid "set debug-level"
+msgstr "set debug-level"
+
+msgid "toggle debug-logging"
+msgstr "toggle debug-loggin'"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4Loggin' wasn't active, so ye can't disable it!"
+
+msgid "flush current content of the logger to file."
+msgstr "flush current content of the logger to file."
+
+msgid "§eLog-file has been flushed."
+msgstr "§eLog-file has been flushed."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4Loggin' be not enabled, use §d/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eLoggin' disabled!"
+
+msgid "advanced command for setting island-data"
+msgstr "advanced command for settin' hideout-data"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§c{0} was set to ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§cUnable to set field {0} to ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr "§cUnable to set field {0} to ''{1}'', a number was expected"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§cInvalid field {0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§eCurrent value for {0} is ''{1}''"
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§cUnable to get state for {0}"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§eValid fields be {0}"
+
+msgid "set a player''s island to your location"
+msgstr "set a pirate''s hideout to yer location"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr "advanced info about NBT stuff"
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "shows the NBTTag for the currently held item"
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§eInfo for §9{0}"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - name: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - nbttag: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§cNay item in hand!"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "sets the NBTTag on the currently held item"
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "§eSet §9{0}§e to §c{1}"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "adds the NBTTag on the currently held item"
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§eAdded §9{0}§e to §c{1}"
+
+msgid "Manage challenges for a player"
+msgstr "Manage challenges for a pirate"
+
+msgid "resets the challenge for the player"
+msgstr "resets the challenge for the pirate"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4Challenge has never been completed"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§echallenge: {0} has been reset for {1}"
+
+msgid "resets all challenges for the player"
+msgstr "resets all challenges for the pirate"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0} has had all challenges reset."
+
+msgid "complete all challenges in the rank"
+msgstr "complete all challenges in the rank"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4Nay pirate named {0} was found!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4Challenge {0} has already been completed"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§eChallenge {0} has been completed for {1}"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4Nay challenge named {0} was found!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4Nay rank named {0} was found!"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "protects all islands (time consumin')"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§cTryin' to abort protect-all task."
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4Sorry!§e A protect-all be already runnin'. Let it complete first, or use "
+"§9usb protectall §cstop"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§eStartin' a protect-all task. It will take a while."
+
+msgid "reload configuration from file."
+msgstr "reload configuration from file."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eConfiguration reloaded from file."
+
+msgid "manage islands"
+msgstr "manage islands"
+
+msgid "protects the island"
+msgstr "protects the hideout"
+
+msgid "delete the island (removes the blocks)"
+msgstr "delete the hideout (removes the blocks)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Deleted abandoned hideout at yer current location."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb hideout delete <name>§e to delete it."
+
+msgid "removes the player from the island"
+msgstr "removes the pirate from the hideout"
+
+msgid "adds the player to the island"
+msgstr "adds the pirate to the hideout"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d has joined yer hideout group."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4Nay pirate named {0} found!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+"§4Nay valid hideout provided, either stand within one, or provide a hideout "
+"name"
+
+msgid "print out info about the island"
+msgstr "print out info about the hideout"
+
+msgid "sets the biome of the island"
+msgstr "sets the biome of the hideout"
+
+msgid "§4That player has no island."
+msgstr "§4That pirate has nay hideout."
+
+msgid "§4No valid island at your location"
+msgstr "§4Nay valid hideout at yer location"
+
+msgid "purges the island"
+msgstr "purges the hideout"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4Blimey! §9Nay valid hideout found for purgin'."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cPURGE: §9Purged hideout at {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "toggles the islands ignore status"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cSet {0}s hideout to be ignored on top-ten an'' purge."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cRemoved ignore-flag of {0}s hideout, it will now show up on top-ten an'' "
+"purge."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Nay valid pirate-name supplied."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Removin'' {0} from hideout"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eChanged biome of {0}s hideout to {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eChanged biome of {0}s hideout to OCEAN."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr "§aYe may need to go to spawn, or relog, to see the changes."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} has had their biome changed to {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} has had their biome changed to OCEAN."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eRemovin'' {0}''s hideout."
+
+msgid "Error: That player does not have an island!"
+msgstr "Blimey: That pirate does not have a hideout!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§e{0}s hideout at {1} has been protected"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4{0}s hideout at {1} was already protected"
+
+msgid "displays version information"
+msgstr "displays version information"
+
+msgid "imports players and islands from other formats"
+msgstr "imports pirates an' islands from other formats"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr "additional perks {0}"
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "changes the language of the plugin, an' reloads"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aSuccessfully changed language to §e{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cFailed to change language to §e{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Supported Languages:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cUnable to locate any languages."
+
+msgid "advanced command for getting island-data"
+msgstr "advanced command for gettin' hideout-data"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "show pirate-information"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4Yer hideout be full, or ye have too many pendin' invites. Ye can't invite "
+"anyone else."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4That pirate be already captain on another hideout."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e tried to invite ye, but ye be already in a party."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr "§aInvite sent to {0}"
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e has invited ye to join their hideout!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§f/island [accept/reject]§e to accept or reject the invite."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4WARNING: Ye will lose yer current hideout if ye accept!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d invited {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e has rejected the invitation."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr "§4Ye can't use that command right now. Leave yer current party first."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§aYe have joined a hideout! Use /island party to see the other members."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§eInvitation for {0}§e has timedout or been cancelled."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§eInvitation for {0}''s hideout has timedout or been cancelled."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§eYe have accepted the invitation to join a hideout."
+
+msgid "§4You haven't been invited."
+msgstr "§4Ye haven't been invited."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eYe have rejected the invitation to join a hideout."
+
+msgid "general island command"
+msgstr "general hideout command"
+
+msgid "allows user to bypass cooldowns"
+msgstr "allows user to bypass cooldowns"
+
+msgid "allows user to bypass visitor-protections"
+msgstr "allows user to bypass visitor-protections"
+
+msgid "allows user to bypass teleport-delay"
+msgstr "allows user to bypass teleport-delay"
+
+msgid "allows user to use [usb] signs"
+msgstr "allows user to use [usb] signs"
+
+msgid "allows user to place [usb] signs"
+msgstr "allows user to place [usb] signs"
+
+msgid "complete and list challenges"
+msgstr "complete an' list challenges"
+
+msgid "§cCommand only available for players."
+msgstr "§cCommand only available for pirates."
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eChallenges has been disabled. Contact an administrator."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4Ye can only submit challenges in the skyblock world!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4Ye can only submit challenges when ye have a hideout!"
+
+msgid "warp to another player''s island"
+msgstr "warp to another pirate''s hideout"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr "§aYer incomin' warp be active, pirates may warp to yer hideout."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr "§4Yer incomin' warp be inactive, pirates may not warp to yer hideout."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr "§fSet incomin' warp to yer current location usin' §e/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§fToggle yer warp on/off usin' §e/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4Ye do not have permission to create a warp in yer hideout!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§fWarp to another hideout usin' §e/island warp <pirate>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4Ye do not have permission to warp to other islands!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cYer hideout be in the process of generatin', ye cannot warp to other "
+"pirates islands right now."
+
+msgid "§4That player does not exist!"
+msgstr "§4That pirate does not exist!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4That pirate does not have an active warp."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§cThat pirates hideout be in the process of generatin', ye cannot warp to it "
+"right now."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cWARNING: §9{0}§e be warpin'' to yer hideout!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4That pirate has forbidden ye from warpin' to their hideout."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4Nay Island. §eUse §b/is create§e to get one"
+
+msgid "accept/reject an invitation."
+msgstr "accept/reject an invitation."
+
+msgid "leave your party"
+msgstr "leave yer party"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4Ye can't leave yer hideout if ye be the only person. Try usin' /island "
+"restart if ye want a new one!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§eYe own this hideout, use /island remove <pirate> instead."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eYe have left the hideout an' returned to the pirate spawn."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0} has left yer hideout!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4Ye must be in the skyblock world to leave yer party!"
+
+msgid "check your or anothers island level"
+msgstr "check yer or anothers hideout level"
+
+msgid "allows user to query for others levels"
+msgstr "allows user to query for others levels"
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eYe must be in yer hideout to use this command."
+
+msgid "§4You do not have an island!"
+msgstr "§4Ye do not have a hideout!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4Ye do not have access to that command!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4That pirate be invalid or does not have a hideout!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eInformation about {0}''s Island:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aIsland level be {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9Rank be {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "create a hideout"
+
+msgid "exempt player from create-cooldown"
+msgstr "exempt pirate from create-cooldown"
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4Island found!§e Ye already have a hideout. If ye want a fresh hideout, "
+"type§b /is restart§e to get one"
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4Island found!§e Ye be already a mates of a hideout. To start yer own, "
+"first§b /is leave"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eYe can create a new hideout in {0,number,#} seconds."
+
+msgid "invite a player to your island"
+msgstr "invite a pirate to yer hideout"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§eUse§f /island invite <playername>§e to invite a pirate to yer hideout."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4Only the hideout''s owner can invite!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aYe can invite {0} more pirates."
+
+msgid "§4You can't invite any more players."
+msgstr "§4Ye can't invite any more pirates."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4Ye do not have permission to invite others to this hideout!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4That pirate be offline or doesn't exist."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4Ye can't invite yourself!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4That pirate be the captain of yer hideout!"
+
+msgid "lock your island to non-party members."
+msgstr "lock yer hideout to non-party members."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4Ye do not have permission to lock yer hideout!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4Ye don't have access to this command!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4Ye do not have permission to unlock yer hideout!"
+
+msgid "display the top10 of islands"
+msgstr "display the top10 of islands"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr "enables user to all-ways generate top-ten (nay cachin')"
+
+msgid "remove a member from your island."
+msgstr "remove a mates from yer hideout."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4Ye do not have permission to kick others from this hideout!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4Ye can't remove the captain from the Island!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4Stop kickin' yourself!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0} has removed ye from their hideout!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} has been removed from the hideout."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4{0} tried to kick ye from their hideout!"
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4{0} is exempt from bein'' kicked."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4{0} has kicked ye from their hideout!"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0} has been kicked from the hideout."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr ""
+"§4That pirate be not part of yer hideout group, an' not in yer hideout!"
+
+msgid "teleport to the island home"
+msgstr "teleport to the hideout home"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§cYer hideout be in the process of generatin', ye cannot teleport home right "
+"now."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4This command can only be executed by a pirate"
+
+msgid "transfer leadership to another member"
+msgstr "transfer leadership to another mates"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4Ye can only transfer ownership to party-members!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e be already captain of yer hideout!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4Only captain can transfer leadership!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} tried to take over the hideout!"
+
+msgid "show party information"
+msgstr "show party information"
+
+msgid "shows information about your party"
+msgstr "shows information about yer party"
+
+msgid "show pending invites"
+msgstr "show pendin' invites"
+
+msgid "§eNo pending invites"
+msgstr "§eNay pendin' invites"
+
+msgid "withdraw an invite"
+msgstr "withdraw an invite"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4Ye don't have permissions to uninvite pirates."
+
+msgid "check your or another''s island info"
+msgstr "check yer or anothers hideout info"
+
+msgid "allows user to see others island info"
+msgstr "allows user to see others hideout info"
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Score Count Block"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "trust/untrust a pirate to help in yer hideout."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eThe followin' pirates be trusted in yer hideout:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eThe followin' leaders trusts ye:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr "§eTo trust/untrust from yer hideout, use /island trust <pirate>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4Members be already trusted!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Unknown pirate {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eYe be now trusted on §4{0}''s §eisland."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} trusted {1} on the hideout"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eYe be nay longer trusted on §4{0}''s §eisland."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0} revoked trust in {1} on the hideout"
+
+msgid "delete your island and start a new one."
+msgstr "delete yer hideout an' start a new one."
+
+msgid "exempt player from restart-cooldown"
+msgstr "exempt pirate from restart-cooldown"
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4Only the owner may restart this hideout. Leave this hideout in order to "
+"start yer own (/island leave)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eYe must remove all pirates from yer hideout before ye can restart it (/"
+"island kick <pirate>). See a list of pirates currently part of yer hideout "
+"usin' /island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§cYe can restart yer hideout in {0} seconds."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr "§cYer hideout be in the process of generatin', ye cannot restart now."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§eNOTE: Yer entire hideout an' all yer belongin''s will be RESET!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "teleports ye to the skyblock spawn"
+
+msgid "change the biome of the island"
+msgstr "change the biome of the hideout"
+
+msgid "exempt player from biome-cooldown"
+msgstr "exempt pirate from biome-cooldown"
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr "Let the pirate change their islands biome to {0}"
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr ""
+"§cYe do not have permission to change the biome of yer current hideout."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4Ye do not have permission to change the biome of this hideout!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eYe must be in yer hideout to change the biome!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr "§cYe have misspelled the biome name. Must be one of {0}"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eYe can change yer biome again in {0,number,#} minutes."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§cYe do not have permission to change yer biome to that type."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+"§7The pixies be busy changin'' the biome near ye to §9{0}§7, be patient."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr "§eInvalid biome {0} supplied!"
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aYe have changed yer hideout''s biome to {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} changed the hideout biome to {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr "§aYe have changed {0} blocks around ye to the {1} biome"
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr "{0} created an area with {1} biome"
+
+msgid "set your island''s warp location"
+msgstr "set yer hideout''s warp location"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cYe do not have permission to set yer hideout''s warp point!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§cYe need to be on yer own hideout to set the warp!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d changed the hideout warp location."
+
+msgid "teleports you to your island (or create one)"
+msgstr "teleports ye to yer hideout (or create one)"
+
+msgid "ban/unban a player from your island."
+msgstr "ban/unban a pirate from yer hideout."
+
+msgid "exempts user from being banned"
+msgstr "exempts user from bein' banned"
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§eThe followin' pirates be banned from warpin' to yer hideout:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr "§eTo ban/unban from yer hideout, use /island ban <pirate>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4Ye can't ban members. Remove 'em first!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4Ye do not have permission to kick/ban pirates."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§eUnable to ban unknown pirate {0}"
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4{0} tried to ban ye from their hideout!"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4{0} is exempt from bein'' banned."
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eYe have banned §4{0}§e from warpin'' to yer hideout."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eYe have been §cBANNED§e from {0}§e''s hideout."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§eYe have unbanned §a{0}§e from warpin'' to yer hideout."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eYe have been §aUNBANNED§e from {0}§e''s hideout."
+
+msgid "display log"
+msgstr "display log"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "set the hideout-home"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "enable/disable warpin' to yer hideout."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr "§4Yer hideout be locked. Ye must unlock it before enablin' yer warp."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d activated the hideout warp."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr "§cYe do not have permission to enable/disable yer hideout''s warp!"
+
+msgid "try to complete a challenge"
+msgstr "try to complete a challenge"
+
+msgid "show information about the challenge"
+msgstr "show information about the challenge"
+
+msgid "§eRank: "
+msgstr "§eRank: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4This Challenge be not repeatable!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr "§4Ye will lose all required items when ye complete this challenge!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4All required items must be placed in yer hideout, within {0} blocks of ye."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§eTo complete this challenge, use §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4Invalid challenge name! Use /c help for more information"
+
+msgid "§eSending you to spawn."
+msgstr "§eSendin' ye to spawn."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§eThe hideout has been §cLOCKED§e."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4Unable to find a safe home-location in yer hideout!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§cWARNING: §eTeleportin' ye to mid-air."
+
+msgid "§aTeleporting you to your island."
+msgstr "§aTeleportin' ye to yer hideout."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aYe will be teleported in {0} seconds."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Unable to warp ye to that pirate''s hideout!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aTeleportin'' ye to {0}''s hideout."
+
+msgid "§7Teleport cancelled"
+msgstr "§7Teleport cancelled"
+
+#~ msgid ""
+#~ "§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
+#~ "that is not allowed."
+#~ msgstr ""
+#~ "§cNay Access! §eYe be tryin' to teleport to the roof of the §cNETHER§e, "
+#~ "that be not allowed."
 
 #~ msgid "§9Item List Editor"
 #~ msgstr "§9Item List Editor"

--- a/uSkyBlock-Core/src/main/po/xx_lol_US.po
+++ b/uSkyBlock-Core/src/main/po/xx_lol_US.po
@@ -10,6 +10,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+msgid "d"
+msgstr "d"
+
+msgid "h"
+msgstr "h"
+
+msgid "m"
+msgstr "m"
+
+msgid "s"
+msgstr "s"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr "§f{0}x §7{1}"
+
+#, java-format
+msgid "§7{0}"
+msgstr "§7{0}"
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr "§eYou do not have access (§4{0}§e)"
@@ -17,6 +41,15 @@ msgstr "§eYou do not have access (§4{0}§e)"
 #, java-format
 msgid "§eInvalid command: {0}"
 msgstr "§eInvalid command: {0}"
+
+msgid "Command"
+msgstr "Command"
+
+msgid "Permission"
+msgstr "Permission"
+
+msgid "Description"
+msgstr "Description"
 
 #, java-format
 msgid "§7Usage: {0}"
@@ -41,1676 +74,12 @@ msgstr "Wrote documentation to {0}"
 msgid "§4Error writing documentation: {0}"
 msgstr "§4Yikes writing documentation: {0}"
 
-msgid "Command"
-msgstr "Command"
+msgid "§cWither Despawned!§e It wandered too far from your island."
+msgstr "§cWither Despawned!§e It wandered too far from yoor cathouz."
 
-msgid "Permission"
-msgstr "Permission"
-
-msgid "Description"
-msgstr "Description"
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr "§f{0}x §7{1}"
-
-#, java-format
-msgid "§7{0}"
-msgstr "§7{0}"
-
-msgid "d"
-msgstr "d"
-
-msgid "h"
-msgstr "h"
-
-msgid "m"
-msgstr "m"
-
-msgid "s"
-msgstr "s"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr "{0,number,0}:{1,number,00}.{2,number,000}"
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§eStill no haz dese bloks: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4Stuffs needed will reset in {0} dais."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4Stuffs needed will reset in {0} hours."
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4Stuffs needed will reset in {0} minutes."
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr "§eThis challenge rekwirz:"
-
-msgid "§7and more..."
-msgstr "§7an' moar..."
-
-msgid "§eItems will be traded for reward."
-msgstr "§eItems will be traded for kitteh treet."
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr "§eMust be wiffin {0} meters."
-
-msgid "§6Item Reward: §a"
-msgstr "§6stuffs Kitteh treet: §a"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6Moniez Kitteh treet: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6Exp Kitteh treet: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§dTotal times completed: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr "§7Rekwirz {0}"
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr "§4Noe challenge named {0} found"
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4You must be on yoor cathouz to do that!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr "§4Teh {0} challenge  kitteh no can haz yet!"
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4Teh {0} challenge  can haz onlie wunce!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr "§eTrying to complete challenge §a{0}"
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr "§4You must be standing wiffin {0} bloks of all required items."
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4Yoor cathouz must be level {0} to complete this challenge!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4Unknown type of challenge: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§eStill teh following entities short:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr " §4{0} §b{1}"
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§eYou be teh following items short:{0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§aYou have completed teh {0} challenge!"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr "§9{0}§f haz completed teh §9{1}§f challenge!"
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§estuffs kitteh treet(s): §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§eExp kitteh treet: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§eMoniez kitteh treet: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§eYoor inventory  iz §4full§e. Items dropped on teh ground."
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§lClick to complete this challenge."
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§lYou can't repeat this challenge."
-
-#, java-format
-msgid "Rank: {0}"
-msgstr "Rank: {0}"
-
-msgid "§fComplete most challenges in"
-msgstr "§fComplete most challenges in"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§fthis rank to unlock teh next rank."
-
-msgid "§eClick here to show previous page"
-msgstr "§eClick here to show previous page"
-
-msgid "§eClick here to show next page"
-msgstr "§eClick here to show next page"
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§lLocked Challenge"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr "§7Complete {0} moar {1} §7challenges"
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr "§7Complete {0}"
-
-msgid "to unlock this rank"
-msgstr "to unlock this rank"
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr "But you be ALLLLLLL ALOOOOONE!"
-
-msgid "But you are Yelling in the wind!"
-msgstr "But you be Yelling in teh wind!"
-
-msgid "But your fantasy friends are gone!"
-msgstr "But yoor fantasy friends be gone!"
-
-msgid "But you are Talking to your self!"
-msgstr "But you be Talking to yoor self!"
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr "§cSorry! {0}"
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr "Either send a message directly to yoor group, or toggle it on/off."
-
-msgid "party"
-msgstr "party"
-
-msgid "island"
-msgstr "island"
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr "§cToggled chat to {0} §aON"
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr "§cRepeat §9{0}§c to toggle it off"
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr "§aToggled chat §cOFF§a for {0}"
-
-msgid "§cCommand only available to players"
-msgstr "§cCommand only available to kittehs"
-
-msgid "talk to players on your island"
-msgstr "talk to kittehs on yoor cathouz"
-
-msgid "talk to your island party"
-msgstr "talk to yoor cathouz party"
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§eKitteh {0} haz noe cathouz!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§eInvalid kitteh {0} supplied."
-
-msgid "Manage challenges for a player"
-msgstr "Manage challenges for a kitteh"
-
-msgid "resets the challenge for the player"
-msgstr "resets teh challenge for teh kitteh"
-
-msgid "§4Challenge has never been completed"
-msgstr "§4Challenge haz never been completed"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§echallenge: {0} haz been reset for {1}"
-
-msgid "resets all challenges for the player"
-msgstr "resets all challenges for teh kitteh"
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0} haz had all challenges reset."
-
-msgid "complete all challenges in the rank"
-msgstr "complete all challenges in teh rank"
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4Noe kitteh named {0} wuz found!"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr "§4Challenge {0} haz already been completed"
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr "§eChallenge {0} haz been completed for {1}"
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4Noe challenge named {0} wuz found!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr "§4Noe rank named {0} wuz found!"
-
-msgid "manage islands"
-msgstr "manage islands"
-
-msgid "protects the island"
-msgstr "proteks teh cathouz"
-
-msgid "delete the island (removes the blocks)"
-msgstr "delete teh cathouz (removes teh bloks)"
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9Deleted abandoned cathouz at yoor current location."
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4Island at this location haz members!\n"
-"§eUse §9/usb cathouz delete <name>§e to delete it."
-
-msgid "removes the player from the island"
-msgstr "removes teh kitteh from teh cathouz"
-
-msgid "adds the player to the island"
-msgstr "adds teh kitteh to teh cathouz"
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d haz joined yoor cathouz group."
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr "§4Noe kitteh named {0} found!"
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-"§4Noe valid cathouz provided, either stand wiffin one, or provide a cathouz "
-"name"
-
-msgid "print out info about the island"
-msgstr "print out info about teh cathouz"
-
-msgid "sets the biome of the island"
-msgstr "sets teh baium of teh cathouz"
-
-msgid "§4That player has no island."
-msgstr "§4That kitteh haz noe cathouz."
-
-msgid "§4No valid island at your location"
-msgstr "§4Noe valid cathouz at yoor location"
-
-msgid "purges the island"
-msgstr "purges teh cathouz"
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr "§4Yikes! §9Noe valid cathouz found for purging."
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr "§cPURGE: §9Purged cathouz at {0}"
-
-msgid "toggles the islands ignore status"
-msgstr "toggles teh islands ignore status"
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr "§cSet {0}s cathouz to be ignored on top-ten an'' purrrge."
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-"§cRemoved ignore-flag of {0}s cathouz, it will now show up on top-ten an'' "
-"purrrge."
-
-msgid "§4No valid player-name supplied."
-msgstr "§4Noe valid kitteh-name supplied."
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "Removing {0} from cathouz"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§eChanged baium of {0}s cathouz to {1}."
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr "§eChanged baium of {0}s cathouz to OCEAN."
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr "§aYou may need to go to spawn, or relog, to see teh changes."
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} haz had their baium changed to {1}."
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} haz had their baium changed to OCEAN."
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§eRemoving {0}''s cathouz."
-
-msgid "Error: That player does not have an island!"
-msgstr "Yikes: That kitteh does not have a cathouz!"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§e{0}s cathouz at {1} haz been protected"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr "§4{0}s cathouz at {1} wuz already protected"
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr "open GUI for config"
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr "§eInvalid configuration name"
-
-msgid "Controls player-cooldowns"
-msgstr "Controls kitteh-cooldowns"
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr "clears teh cooldown on a command (* = all)"
-
-msgid "§eThe player is not currently online"
-msgstr "§eTeh kitteh  iz not currently online"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "Cleared cooldown on {0} for {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "Noe active cooldown on {0} for {1} detected!"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "Invalid command supplied, only restart an' baium supported!"
-
-msgid "restarts the cooldown on the command"
-msgstr "restarts teh cooldown on teh command"
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§eReset cooldown on {0} for {1}§e to {2} seconds"
-
-msgid "lists all the active cooldowns"
-msgstr "lists all teh active cooldowns"
-
-msgid "§eCmd Cooldown"
-msgstr "§eCmd Cooldown"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§eNoe active cooldowns for §9{0}§e found."
-
-msgid "control debugging"
-msgstr "control debugging"
-
-msgid "set debug-level"
-msgstr "set debug-level"
-
-msgid "toggle debug-logging"
-msgstr "toggle debug-logging"
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4Logging wasn't active, so you can't disable it!"
-
-msgid "flush current content of the logger to file."
-msgstr "flush current content of teh logger to file."
-
-msgid "§eLog-file has been flushed."
-msgstr "§eLog-file haz been flushed."
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4Logging  iz not enabled, use §d/usb debug enable"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§eLogging disabled!"
-
-msgid "tries to fix the the area of flatland."
-msgstr "tries to fix teh teh area of flatland."
-
-msgid "§4No valid island found"
-msgstr "§4Noe valid cathouz found"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4Noe flatland detected at {0}''s cathouz!"
-
-msgid "flushes all caches to files"
-msgstr "flushes all caches to files"
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-"§eFlushed §a{0} islands§e, §b{1} kittehs an'' §6{2} challenge-completions."
-
-msgid "manually update the top 10 list"
-msgstr "manually update teh top 10 list"
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§eGenerating teh Top Ten list"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§eFinished generation of teh Top Ten list"
-
-msgid "advanced command for getting island-data"
-msgstr "advanced command for getting cathouz-data"
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr "§eCurrent value for {0}  iz ''{1}''"
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr "§cUnable to get state for {0}"
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr "§eValid fields be {0}"
-
-msgid "teleport to another players island"
-msgstr "teleport to another kittehs cathouz"
-
-msgid "§4Only supported for players"
-msgstr "§4Only supported for kittehs"
-
-msgid "§4That player does not have an island!"
-msgstr "§4That kitteh does not have a cathouz!"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr "§aTeleporting to {0}''s cathouz."
-
-msgid "imports players and islands from other formats"
-msgstr "imports kittehs an' islands from other formats"
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr "§9Job Statistics"
-
-msgid "§7----------------"
-msgstr "§7----------------"
-
-msgid "#"
-msgstr "#"
-
-msgid "ms/job"
-msgstr "ms/job"
-
-msgid "ms/tick"
-msgstr "ms/tick"
-
-msgid "ticks"
-msgstr "ticks"
-
-msgid "act"
-msgstr "act"
-
-msgid "time"
-msgstr "time"
-
-msgid "name"
-msgstr "name"
-
-msgid "changes the language of the plugin, and reloads"
-msgstr "changes teh language of teh plugin, an' reloads"
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr "§aSuccessfully changed language to §e{0}"
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr "§cFailed to change language to §e{0}"
-
-msgid "§9Supported Languages:\n"
-msgstr "§9Supported Languages:\n"
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
-
-msgid "§cUnable to locate any languages."
-msgstr "§cUnable to locate any languages."
-
-msgid "transfer leadership to another player"
-msgstr "transfer leadership to another kitteh"
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4Kitteh {0} haz noe cathouz to transfer!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§eKitteh §d{0}§e already haz a cathouz.§eUse §d/usb cathouz remove <name>§e "
-"to remove him first."
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§bLeadership transferred by {0}§b to {1}"
-
-msgid "advanced info about NBT stuff"
-msgstr "advanced info about NBT stuff"
-
-msgid "shows the NBTTag for the currently held item"
-msgstr "shows teh NBTTag for teh currently held item"
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr "§eInfo for §9{0}"
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr "§7 - name: §9{0}"
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr "§7 - nbttag: §9{0}"
-
-msgid "§cNo item in hand!"
-msgstr "§cNoe item in hand!"
-
-msgid "§eCan only be executed as a player"
-msgstr "§eCan only be executed as a kitteh"
-
-msgid "sets the NBTTag on the currently held item"
-msgstr "sets teh NBTTag on teh currently held item"
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr "§eSet §9{0}§e to §c{1}"
-
-msgid "adds the NBTTag on the currently held item"
-msgstr "adds teh NBTTag on teh currently held item"
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr "§eAdded §9{0}§e to §c{1}"
-
-msgid "manage orphans"
-msgstr "manage orfanz"
-
-msgid "count orphans"
-msgstr "count orfanz"
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§e{0} old cathouz locations will be used before new ones."
-
-msgid "clear orphans"
-msgstr "clear orfanz"
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§eClearing all old (empty) island locations."
-
-msgid "list orphans"
-msgstr "list orfanz"
-
-msgid "§eNo orphans currently registered."
-msgstr "§eNoe orfanz currently registered."
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr "additional perks {0}"
-
-msgid "protects all islands (time consuming)"
-msgstr "proteks all islands (time consuming)"
-
-msgid "§cTrying to abort protect-all task."
-msgstr "§cTrying to abort protect-all task."
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-"§4Sorry!§e A protect-all  iz already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§eStarting a protect-all task. It will take a while."
-
-msgid "purges all abandoned islands"
-msgstr "purges all abandoned islands"
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4You must provide teh age in dais to purrrge!"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr "§4Trying to abort purrrge"
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr "§4Starting purrrge..."
-
-msgid "region manipulations"
-msgstr "region manipulations"
-
-msgid "shows the borders of the current island"
-msgstr "shows teh borders of teh current cathouz"
-
-msgid "§eNo island found at your current location"
-msgstr "§eNoe cathouz found at yoor current location"
-
-msgid "shows the borders of the current chunk"
-msgstr "shows teh borders of teh current chunk"
-
-msgid "shows the borders of the inner-chunks"
-msgstr "shows teh borders of teh inner-chunks"
-
-msgid "shows the non-chunk-aligned borders"
-msgstr "shows teh non-chunk-aligned borders"
-
-msgid "shows the borders of the outer-chunks"
-msgstr "shows teh borders of teh outer-chunks"
-
-msgid "hides the regions again"
-msgstr "hides teh regions again"
-
-msgid "§eStopped displaying regions"
-msgstr "§eStopped displaying regions"
-
-msgid "§eNo currently shown regions for this player"
-msgstr "§eNoe currently shown regions for this kitteh"
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr "§eAnimation-tick changed to {0}."
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr "§eAnimation-tick must be a valid integer."
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr "set a kitteh''s cathouz to yoor location"
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr "reload configuration from file."
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§eConfiguration reloaded from file."
-
-msgid "advanced command for setting island-data"
-msgstr "advanced command for setting cathouz-data"
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr "§c{0} wuz set to ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr "§cUnable to set field {0} to ''{1}''"
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr "§cUnable to set field {0} to ''{1}'', a number wuz expected"
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr "§cInvalid field {0}"
-
-msgid "toggles maintenance mode"
-msgstr "toggles maintenance mode"
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-"§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr "§cMaintenance mode can only be changed from console!"
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr "§cABORTED:§e Protect-All wuz aborted!"
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr "§eCompleted protect-all in {0}, {1} new regions were created!"
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr "§4PURGE:§9 Scanning aborted."
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr "§4PURGE:§9 Finished purging abandoned islands."
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr "§4PURGE:§9 Aborted purging abandoned islands."
-
-msgid "displays version information"
-msgstr "displays version information"
-
-msgid "various WorldGuard utilities"
-msgstr "various WorldGuard utilities"
-
-msgid "refreshes the chunks around the player"
-msgstr "refreshes teh chunks around teh kitteh"
-
-msgid "§eResending chunks to the client"
-msgstr "§eResending chunks to teh client"
-
-msgid "load the region chunks"
-msgstr "load teh region chunks"
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§eLoading chunks at {0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§eUnloading chunks at {0}"
-
-msgid "update the WG regions"
-msgstr "update teh WG regions"
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr "§eIsland world-guard regions updated for {0}"
-
-msgid "§eNo island found at your location!"
-msgstr "§eNoe cathouz found at yoor location!"
-
-msgid "refreshes the chunk around the player"
-msgstr "refreshes teh chunk around teh kitteh"
-
-msgid "Ultimate SkyBlock Admin"
-msgstr "Ultimate SkyBlock Admin"
-
-msgid "show player-information"
-msgstr "show kitteh-information"
-
-msgid "try to complete a challenge"
-msgstr "try to complete a challenge"
-
-msgid "§cCommand only available for players."
-msgstr "§cCommand only available for kittehs."
-
-msgid "show information about the challenge"
-msgstr "show information about teh challenge"
-
-msgid "§eRank: "
-msgstr "§eRank: "
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4This Challenge  can haz onlie wunce!"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr "§4You will lose all required items when you complete this challenge!"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-"§4All required items must be placed on yoor cathouz, wiffin {0} bloks of you."
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr "§eTo complete this challenge, use §f/c c {0}"
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4Invalid challenge name! Use /c help for moar information"
-
-msgid "complete and list challenges"
-msgstr "complete an' list challenges"
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§eChallenges haz been disabled. Contact an administrator."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4You can only submit challenges in teh skyblock world!"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4You can only submit challenges when you have a cathouz!"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr ""
-"§4Yoor cathouz  iz full, or you have too many pending invites. You can't "
-"invite anyone else."
-
-msgid "§4That player is already leader on another island."
-msgstr "§4That kitteh  iz already top cat on another cathouz."
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e tried to invite you, but you be already in a party."
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr "§aInvite sent to {0}"
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e haz invited you to join their cathouz!"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§f/island [accept/reject]§e to accept or reject teh invite."
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4WARNING: You will lose yoor current cathouz if you accept!"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d invited {1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e haz rejected teh invitashun."
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr ""
-"§4You can't use that command right now. Leave yoor current party first."
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr ""
-"§aYou have joined a cathouz! Use /island party to see teh other members."
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§eInvitashun for {0}§e haz timedout or been cancelled."
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§eInvitashun for {0}''s cathouz haz timedout or been cancelled."
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§eYou have accepted teh invitashun to join a cathouz."
-
-msgid "§4You haven't been invited."
-msgstr "§4You haven't been invited."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§eYou have rejected teh invitashun to join a cathouz."
-
-msgid "accept/reject an invitation."
-msgstr "accept/reject an invitashun."
-
-msgid "teleports you to your island (or create one)"
-msgstr "teleports you to yoor cathouz (or create one)"
-
-msgid "ban/unban a player from your island."
-msgstr "ban/unban a kitteh from yoor cathouz."
-
-msgid "exempts user from being banned"
-msgstr "exempts user from being banned"
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§eTeh following kittehs be banned from warping to yoor cathouz:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr "§eTo ban/unban from yoor cathouz, use /island ban <kitteh>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4You can't ban members. Remove 'dem first!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4You do not have permission to kick/ban kittehs."
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr "§eUnable to ban unknown kitteh {0}"
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr "§4{0} tried to ban you from their cathouz!"
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr "§4{0}  iz exempt from being banned."
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§eYou have banned §4{0}§e from warping to yoor cathouz."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr "§eYou have been §cBANNED§e from {0}§e''s cathouz."
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§eYou have unbanned §a{0}§e from warping to yoor cathouz."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr "§eYou have been §aUNBANNED§e from {0}§e''s cathouz."
-
-msgid "change the biome of the island"
-msgstr "change teh baium of teh cathouz"
-
-msgid "exempt player from biome-cooldown"
-msgstr "exempt kitteh from baium-cooldown"
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr "Let teh kitteh change their islands baium to {0}"
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr ""
-"§cYou do not have permission to change teh baium of yoor current cathouz."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4You do not have permission to change teh baium of this cathouz!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§eYou must be on yoor cathouz to change teh baium!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr "§cYou have misspelled teh baium name. Must be one of {0}"
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§eYou can change yoor baium again in {0,number,#} minutes."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr "§cYou do not have permission to change yoor baium to that type."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-"§7Teh pixies be busy changing teh baium near you to §9{0}§7, be patient."
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-"§7Teh pixies be busy changing teh baium of yoor cathouz to §9{0}§7, be "
-"patient."
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr "§eInvalid baium {0} supplied!"
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr "§aYou have changed yoor cathouz''s baium to {0}"
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0} changed teh cathouz baium to {1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr "§aYou have changed {0} bloks around you to teh {1} baium"
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr "{0} created an area with {1} baium"
-
-msgid "create an island"
-msgstr "create a cathouz"
-
-msgid "exempt player from create-cooldown"
-msgstr "exempt kitteh from create-cooldown"
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4Island found!§e You already have a cathouz. If you want a fresh cathouz, "
-"type§b / iz restart§e to get one"
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4Island found!§e You be already a cats of a cathouz. To start yoor own, "
-"first§b / iz leave"
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§eYou can create a new cathouz in {0,number,#} seconds."
-
-msgid "teleport to the island home"
-msgstr "teleport to teh cathouz home"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-"§cYoor cathouz  iz in teh process of generating, you cannot teleport home "
-"right now."
-
-msgid "check your or another''s island info"
-msgstr "check yoor or anothers cathouz info"
-
-msgid "allows user to see others island info"
-msgstr "allows user to see others cathouz info"
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4Island level haz been disabled, contact an administrator."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§eYou must be on yoor cathouz to use this command."
-
-msgid "§4You do not have an island!"
-msgstr "§4You do not have a cathouz!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4You do not have access to that command!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4That kitteh  iz invalid or does not have a cathouz!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "§eBloks on {0}s Island (page {1,number} of {2,number}):"
-
-msgid "Score Count Block"
-msgstr "Score Count Blok"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§aIsland level  iz {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr "invite a kitteh to yoor cathouz"
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr ""
-"§eUse§f /island invite <playername>§e to invite a kitteh to yoor cathouz."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4Only teh cathouz''s owner can invite!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§aYou can invite {0} moar kittehs."
-
-msgid "§4You can't invite any more players."
-msgstr "§4You can't invite any moar kittehs."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4You do not have permission to invite others to this cathouz!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4That kitteh  iz offline or doesn't exist."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4You can't invite yourself!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4That kitteh  iz teh top cat of yoor cathouz!"
-
-msgid "remove a member from your island."
-msgstr "remove a cats from yoor cathouz."
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4You do not have permission to kick others from this cathouz!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4You can't remove teh top cat from teh Island!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4Stop kickin' yourself!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr "§4{0} haz removed you from their cathouz!"
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0} haz been removed from teh cathouz."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr "§4{0} tried to kick you from their cathouz!"
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr "§4{0}  iz exempt from being kicked."
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr "§4{0} haz kicked you from their cathouz!"
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0} haz been kicked from teh cathouz."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr ""
-"§4That kitteh  iz not part of yoor cathouz group, an' not on yoor cathouz!"
-
-msgid "leave your party"
-msgstr "leave yoor party"
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4You can't leave yoor cathouz if you be teh only person. Try using /island "
-"restart if you want a new one!"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§eYou own this cathouz, use /island remove <kitteh> instead."
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§eYou have left teh cathouz an' returned to teh kitteh spawn."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0} haz left yoor cathouz!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4You must be in teh skyblock world to leave yoor party!"
-
-msgid "check your or anothers island level"
-msgstr "check yoor or anothers cathouz level"
-
-msgid "allows user to query for others levels"
-msgstr "allows user to query for others levels"
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr "§eInformation about {0}''s Island:"
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9Rank  iz {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr "lock yoor cathouz to non-party members."
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4You do not have permission to lock yoor cathouz!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4You don't have access to this command!"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4You do not have permission to unlock yoor cathouz!"
-
-msgid "display log"
-msgstr "display log"
-
-msgid "transfer leadership to another member"
-msgstr "transfer leadership to another cats"
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4You can only transfer ownership to party-members!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e  iz already top cat of yoor cathouz!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4Only top cat can transfer leadership!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0} tried to take over teh cathouz!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr "show party information"
-
-msgid "shows information about your party"
-msgstr "shows information about yoor party"
-
-msgid "show pending invites"
-msgstr "show pending invites"
-
-msgid "§eNo pending invites"
-msgstr "§eNoe pending invites"
-
-msgid "withdraw an invite"
-msgstr "withdraw an invite"
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr "§4You don't have permissions to uninvite kittehs."
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4This command can only be executed by a kitteh"
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4Noe Island. §eUse §b/ iz create§e to get one"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr "delete yoor cathouz an' start a new one."
-
-msgid "exempt player from restart-cooldown"
-msgstr "exempt kitteh from restart-cooldown"
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4Only teh owner may restart this cathouz. Leave this cathouz in order to "
-"start yoor own (/island leave)."
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§eYou must remove all kittehs from yoor cathouz before you can restart it (/"
-"island kick <kitteh>). See a list of kittehs currently part of yoor cathouz "
-"using /island party."
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr "§cYou can restart yoor cathouz in {0} seconds."
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr ""
-"§cYoor cathouz  iz in teh process of generating, you cannot restart now."
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§eNOTE: Yoor entire cathouz an' all yoor belongings will be RESET!"
-
-msgid "set the island-home"
-msgstr "set teh cathouz-home"
-
-msgid "set your island''s warp location"
-msgstr "set yoor cathouz''s warp location"
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§cYou do not have permission to set yoor cathouz''s warp point!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§cYou need to be on yoor own cathouz to set teh warp!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d changed teh cathouz warp location."
-
-msgid "teleports you to the skyblock spawn"
-msgstr "teleports you to teh skyblock spawn"
-
-msgid "enable/disable warping to your island."
-msgstr "enable/disable warping to yoor cathouz."
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr ""
-"§4Yoor cathouz  iz locked. You must unlock it before enabling yoor warp."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr "§b{0}§d activated teh cathouz warp."
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d deactivated teh cathouz warp."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr "§cYou do not have permission to enable/disable yoor cathouz''s warp!"
-
-msgid "display the top10 of islands"
-msgstr "display teh top10 of islands"
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr "enables user to all-ways generate top-ten (noe caching)"
-
-msgid "trust/untrust a player to help on your island."
-msgstr "trust/untrust a kitteh to help on yoor cathouz."
-
-msgid "§eThe following players are trusted on your island:"
-msgstr "§eTeh following kittehs be trusted on yoor cathouz:"
-
-msgid "§eThe following leaders trusts you:"
-msgstr "§eTeh following leaders trusts you:"
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr "§eTo trust/untrust from yoor cathouz, use /island trust <kitteh>"
-
-msgid "§4Members are already trusted!"
-msgstr "§4Members be already trusted!"
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr "§4Unknown kitteh {0}"
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr "§eYou be now trusted on §4{0}''s §eisland."
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr "§a{0} trusted {1} on teh cathouz"
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr "§eYou be noe longer trusted on §4{0}''s §eisland."
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr "§c{0} revoked trust in {1} on teh cathouz"
-
-msgid "warp to another player''s island"
-msgstr "warp to another kitteh''s cathouz"
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr "§aYoor incoming warp  iz active, kittehs may warp to yoor cathouz."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr ""
-"§4Yoor incoming warp  iz inactive, kittehs may not warp to yoor cathouz."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr "§fSet incoming warp to yoor current location using §e/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§fToggle yoor warp on/off using §e/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4You do not have permission to create a warp on yoor cathouz!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§fWarp to another cathouz using §e/island warp <kitteh>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4You do not have permission to warp to other islands!"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-"§cYoor cathouz  iz in teh process of generating, you cannot warp to other "
-"kittehs islands right now."
-
-msgid "§4That player does not exist!"
-msgstr "§4That kitteh does not exist!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4That kitteh does not have an active warp."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-"§cThat kittehs cathouz  iz in teh process of generating, you cannot warp to "
-"it right now."
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr "§cWARNING: §9{0}§e  iz warping to yoor cathouz!"
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4That kitteh haz forbidden you from warping to their cathouz."
-
-msgid "general island command"
-msgstr "general cathouz command"
-
-msgid "allows user to bypass cooldowns"
-msgstr "allows user to bypass cooldowns"
-
-msgid "allows user to bypass visitor-protections"
-msgstr "allows user to bypass visitor-protections"
-
-msgid "allows user to bypass teleport-delay"
-msgstr "allows user to bypass teleport-delay"
-
-msgid "allows user to use [usb] signs"
-msgstr "allows user to use [usb] signs"
-
-msgid "allows user to place [usb] signs"
-msgstr "allows user to place [usb] signs"
+msgid "{0}''s Wither"
+msgstr "{0}''s Wither"
 
 msgid "§eYou can not use another island''s portals!"
 msgstr ""
@@ -1726,33 +95,6 @@ msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
 msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr "§cWither Despawned!§e It wandered too far from yoor cathouz."
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr "{0}''s Wither"
-
-msgid "§eVisitors can't drop items!"
-msgstr "§eVisitors can't drop items!"
-
-#, java-format
-msgid "Owner: {0}"
-msgstr "Owner: {0}"
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr "You cannot pick up other kittehs' loot when you be a visitor!"
-
-msgid "Config:"
-msgstr "Config:"
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
-msgstr ""
-"§cNoe Access! §eYou be trying to teleport to teh roof of teh §cNETHER§e, "
-"that  iz not allowed."
 
 msgid "§4You can only convert obsidian once every 10 seconds"
 msgstr "§4You can only convert obsidian once every 10 seconds"
@@ -1796,19 +138,84 @@ msgstr "§eYou can only use spawn-eggs on yoor own cathouz."
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr "§cYou have reached yoor spawn-limit for yoor cathouz."
 
+msgid "§eVisitors can't drop items!"
+msgstr "§eVisitors can't drop items!"
+
+#, java-format
+msgid "Owner: {0}"
+msgstr "Owner: {0}"
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr "You cannot pick up other kittehs' loot when you be a visitor!"
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr "§cBanned:§e You be banned from this cathouz."
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr "§cLocked:§e That cathouz  iz locked! Noe entry allowed."
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
-msgstr "§eWaiting for our turn §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "Something went awry storin' teh cathouz an'/or party data!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr "Converting data to UUID, this make take a while!"
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
+msgstr "§cMAINTENANCE:§e uSkyBlock  iz currently in maintenance mode"
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
-msgstr "§9Creating cathouz...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
+msgstr ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e wuz found!\n"
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr "§eYou do not have access to that cathouz-schematic!"
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4Kitteh  iz already assigned to this cathouz!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4You must be closer to yoor cathouz to set yoor skyblock home!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§aYoor skyblock home haz been set to yoor current location."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr "§4Yoor current location  iz not a safe home-location."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+"§7Teh pixies be busy changing teh baium of yoor cathouz to §9{0}§7, be "
+"patient."
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr ""
+"§cYoor cathouz  iz in teh process of generating, you cannot create now."
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "Could not create yoor Island. Please contact a server moderator."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr "§eGetting yoor cathouz ready, please be patient, it can take a while."
+
+msgid "§cCommand is currently disabled!"
+msgstr "§cCommand  iz currently disabled!"
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§eStill no haz dese bloks: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1821,9 +228,6 @@ msgid ""
 msgstr ""
 "§eDoing §9{0}§e  iz §cRISKY§e. Repeat teh command wiffin §a{1}§e seconds to "
 "accept!"
-
-msgid "N/A"
-msgstr "N/A"
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr "§4** You be entering a protected - but abandoned - island area."
@@ -1856,214 +260,33 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4You must be teh party top cat to unlock yoor cathouz!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
-msgstr "§7PlayerDB: Filtering {0} kittehs from uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
+msgstr "§eWaiting for our turn §c{0,number,###}%"
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
-msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr "§9Creating cathouz...§e{0,number,###}%"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§lLocked Challenge"
+
+msgid "READY"
+msgstr "READY"
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr "§7PlayerDB: Filtered {0} names"
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr "§7MojangAPI: Trying to fetch {0} kittehs from Mojang"
-
-msgid "SUCCESS"
-msgstr "SUCCESS"
-
-msgid "FAILED"
-msgstr "FAILED"
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr "§7 - MojangAPI:§aCOMPLETED: {0}"
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr "§7 - MojangAPI:§cERROR: {0}"
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4Noe importer named §e{0}§4 found"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr "§eConverted {0}/{1} files in {2}"
-
-msgid "The island has been created."
-msgstr "Teh cathouz haz been created."
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr "§b{0}§d locked teh cathouz."
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr ""
-"§4Since yoor cathouz  iz locked, yoor incoming warp haz been deactivated."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr "§b{0}§d unlocked teh cathouz."
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr "§cSKY §f> §7 {0}"
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr "§b{0}§d haz been removed from teh cathouz group."
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr "§9{1} §7- {0}"
-
-msgid "§9Creating an island at your location"
-msgstr "§9Creating a cathouz at yoor location"
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
-msgstr "§9Creating a cathouz §7{0}§9 of you"
+msgid "§4The {0} challenge is not available yet!"
+msgstr "§4Teh {0} challenge  kitteh no can haz yet!"
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
-"§cTeh cathouz owning this piece of nether  iz being deleted! Sending you to "
-"spawn."
+"§cWARNING:§e Could not transfer all teh required items to yoor inventory!"
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§cTeh cathouz you be on  iz being deleted! Sending you to spawn."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§eWALL OF FAME (page {0} of {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr "§4Top ten list  iz empty! Only islands above level {0}  iz considered."
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§eYoor rank  iz: §f{0}"
-
-msgid "UNKNOWN"
-msgstr "UNKNOWN"
-
-msgid "ANIMAL"
-msgstr "ANIMAL"
-
-msgid "MONSTER"
-msgstr "MONSTER"
-
-msgid "VILLAGER"
-msgstr "VILLAGER"
-
-msgid "GOLEM"
-msgstr "GOLEM"
-
-#, java-format
-msgid "§c{0}"
-msgstr "§c{0}"
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr "§7{0}: §a{1}§7 (max. {2})"
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr "Unable to locate schematic {0}, contact a server-admin"
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr "§aCongratulations! §eYoor cathouz haz appeared."
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr "§cNote:§e Construction might still be ongoing."
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr "Use §9/ iz h§r or teh §9/is§r menu to go there."
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr "§cWatchdog!§9 Unable to locate a chest wiffin {0}, bailing out."
-
-#, java-format
-msgid "§7Page {0}"
-msgstr "§7Page {0}"
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr "§c{0,number,#}"
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr "§a+{0,number,#}"
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr "§a{0,number,#}"
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr "&aLeft:&7 Increment with {0}"
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr "&cRight-Click:&7 Set to {0}"
-
-msgid "Return"
-msgstr "Return"
-
-msgid "§9Integer Editor"
-msgstr "§9Integer Editor"
-
-msgid "§eConfiguration saved and reloaded."
-msgstr "§eConfiguration saved an' reloaded."
-
-msgid "§cError! §9Unable to save config file!"
-msgstr "§cYikes! §9Unable to save config file!"
-
-msgid "§3First Page"
-msgstr "§3First Page"
-
-msgid "§3Last Page"
-msgstr "§3Last Page"
-
-msgid "§cSave & Reload config"
-msgstr "§cSave & Reload config"
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-"§7Saves teh settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-
-msgid "§7 (readonly)"
-msgstr "§7 (readonly)"
+msgid "§cNot enough items in chest to complete challenge!"
+msgstr "§cNot enough items in chest to complete challenge!"
 
 msgid "true"
 msgstr "true"
@@ -2519,6 +742,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr "§7Current page"
 
+#, java-format
+msgid "§7Page {0}"
+msgstr "§7Page {0}"
+
 msgid "§7First Page"
 msgstr "§7First Page"
 
@@ -2833,8 +1060,8 @@ msgstr "§cClick to leave"
 msgid "Island Restart Menu"
 msgstr "Island Restart Menu"
 
-msgid "§eYou do not have access to that island-schematic!"
-msgstr "§eYou do not have access to that cathouz-schematic!"
+msgid "Config:"
+msgstr "Config:"
 
 #, java-format
 msgid "§cClick within §9{0}§c to leave!"
@@ -2850,114 +1077,122 @@ msgstr "§cClick wiffin §9{0}§c to restart!"
 msgid "§aClick to restart!"
 msgstr "§aClick to restart!"
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr "§c{0,number,#}"
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr "§a+{0,number,#}"
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr "§a{0,number,#}"
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr "&aLeft:&7 Increment with {0}"
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr "&cRight-Click:&7 Set to {0}"
+
+msgid "Return"
+msgstr "Return"
+
+msgid "§9Integer Editor"
+msgstr "§9Integer Editor"
+
 msgid "Caps On"
 msgstr "Caps On"
 
 msgid "§9Text Editor"
 msgstr "§9Text Editor"
 
+msgid "§eConfiguration saved and reloaded."
+msgstr "§eConfiguration saved an' reloaded."
+
+msgid "§cError! §9Unable to save config file!"
+msgstr "§cYikes! §9Unable to save config file!"
+
+msgid "§3First Page"
+msgstr "§3First Page"
+
+msgid "§3Last Page"
+msgstr "§3Last Page"
+
+msgid "§cSave & Reload config"
+msgstr "§cSave & Reload config"
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+"§7Saves teh settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+
+msgid "§7 (readonly)"
+msgstr "§7 (readonly)"
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4Noe importer named §e{0}§4 found"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr "§eConverted {0}/{1} files in {2}"
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr "§7PlayerDB: Filtering {0} kittehs from uuid2name.yml"
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr "§7PlayerDB: Filtered {0} names"
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr "§7MojangAPI: Trying to fetch {0} kittehs from Mojang"
+
+msgid "SUCCESS"
+msgstr "SUCCESS"
+
+msgid "FAILED"
+msgstr "FAILED"
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr "§7 - MojangAPI:§aCOMPLETED: {0}"
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr "§7 - MojangAPI:§cERROR: {0}"
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
 msgstr "Too many requests for Mojangs API ({0} wiffin {1}), sleeping {2}"
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr "§eSending you to spawn."
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr "§eTeh cathouz haz been §cLOCKED§e."
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§aYou will be teleported in {0} seconds."
-
-msgid "§7Teleport cancelled"
-msgstr "§7Teleport cancelled"
-
-msgid "READY"
-msgstr "READY"
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-"§cWARNING:§e Could not transfer all teh required items to yoor inventory!"
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr "§cNot enough items in chest to complete challenge!"
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "Something went awry storin' teh cathouz an'/or party data!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr "Converting data to UUID, this make take a while!"
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr "§cMAINTENANCE:§e uSkyBlock  iz currently in maintenance mode"
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e wuz found!\n"
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4Kitteh  iz already assigned to this cathouz!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr "§4Unable to find a safe home-location on yoor cathouz!"
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr "§cWARNING: §eTeleporting you to mid-air."
-
-msgid "§aTeleporting you to your island."
-msgstr "§aTeleporting you to yoor cathouz."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4Unable to warp you to that kitteh''s cathouz!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr "§aTeleporting you to {0}''s cathouz."
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4You must be closer to yoor cathouz to set yoor skyblock home!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§aYoor skyblock home haz been set to yoor current location."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr "§4Yoor current location  iz not a safe home-location."
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr ""
-"§cYoor cathouz  iz in teh process of generating, you cannot create now."
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "Could not create yoor Island. Please contact a server moderator."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr "§eGetting yoor cathouz ready, please be patient, it can take a while."
-
-msgid "§cCommand is currently disabled!"
-msgstr "§cCommand  iz currently disabled!"
 
 msgid "North"
 msgstr "North"
@@ -2982,6 +1217,1774 @@ msgstr "West"
 
 msgid "North-West"
 msgstr "North-West"
+
+msgid "The island has been created."
+msgstr "Teh cathouz haz been created."
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr "§b{0}§d locked teh cathouz."
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr ""
+"§4Since yoor cathouz  iz locked, yoor incoming warp haz been deactivated."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d deactivated teh cathouz warp."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr "§b{0}§d unlocked teh cathouz."
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr "§cSKY §f> §7 {0}"
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr "§b{0}§d haz been removed from teh cathouz group."
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr "§9{1} §7- {0}"
+
+msgid "§9Creating an island at your location"
+msgstr "§9Creating a cathouz at yoor location"
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr "§9Creating a cathouz §7{0}§9 of you"
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr "§aCongratulations! §eYoor cathouz haz appeared."
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr "§cNote:§e Construction might still be ongoing."
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr "Use §9/ iz h§r or teh §9/is§r menu to go there."
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr "Unable to locate schematic {0}, contact a server-admin"
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr "§cWatchdog!§9 Unable to locate a chest wiffin {0}, bailing out."
+
+msgid "UNKNOWN"
+msgstr "UNKNOWN"
+
+msgid "ANIMAL"
+msgstr "ANIMAL"
+
+msgid "MONSTER"
+msgstr "MONSTER"
+
+msgid "VILLAGER"
+msgstr "VILLAGER"
+
+msgid "GOLEM"
+msgstr "GOLEM"
+
+#, java-format
+msgid "§c{0}"
+msgstr "§c{0}"
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr "§7{0}: §a{1}§7 (max. {2})"
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+"§cTeh cathouz owning this piece of nether  iz being deleted! Sending you to "
+"spawn."
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§cTeh cathouz you be on  iz being deleted! Sending you to spawn."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§eWALL OF FAME (page {0} of {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr "§4Top ten list  iz empty! Only islands above level {0}  iz considered."
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4Island level haz been disabled, contact an administrator."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§eYoor rank  iz: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr "§7Complete {0} moar {1} §7challenges"
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr "§7Complete {0}"
+
+msgid "to unlock this rank"
+msgstr "to unlock this rank"
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4Stuffs needed will reset in {0} dais."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4Stuffs needed will reset in {0} hours."
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4Stuffs needed will reset in {0} minutes."
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr "§eThis challenge rekwirz:"
+
+msgid "§7and more..."
+msgstr "§7an' moar..."
+
+msgid "§eItems will be traded for reward."
+msgstr "§eItems will be traded for kitteh treet."
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr "§eMust be wiffin {0} meters."
+
+msgid "§6Item Reward: §a"
+msgstr "§6stuffs Kitteh treet: §a"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6Moniez Kitteh treet: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6Exp Kitteh treet: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§dTotal times completed: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr "§7Rekwirz {0}"
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr "§4Noe challenge named {0} found"
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4You must be on yoor cathouz to do that!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4Teh {0} challenge  can haz onlie wunce!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr "§eTrying to complete challenge §a{0}"
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr "§4You must be standing wiffin {0} bloks of all required items."
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4Yoor cathouz must be level {0} to complete this challenge!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4Unknown type of challenge: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§eStill teh following entities short:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr " §4{0} §b{1}"
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§eYou be teh following items short:{0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§aYou have completed teh {0} challenge!"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr "§9{0}§f haz completed teh §9{1}§f challenge!"
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§estuffs kitteh treet(s): §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§eExp kitteh treet: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§eMoniez kitteh treet: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§eYoor inventory  iz §4full§e. Items dropped on teh ground."
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§lClick to complete this challenge."
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§lYou can't repeat this challenge."
+
+#, java-format
+msgid "Rank: {0}"
+msgstr "Rank: {0}"
+
+msgid "§fComplete most challenges in"
+msgstr "§fComplete most challenges in"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§fthis rank to unlock teh next rank."
+
+msgid "§eClick here to show previous page"
+msgstr "§eClick here to show previous page"
+
+msgid "§eClick here to show next page"
+msgstr "§eClick here to show next page"
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr "But you be ALLLLLLL ALOOOOONE!"
+
+msgid "But you are Yelling in the wind!"
+msgstr "But you be Yelling in teh wind!"
+
+msgid "But your fantasy friends are gone!"
+msgstr "But yoor fantasy friends be gone!"
+
+msgid "But you are Talking to your self!"
+msgstr "But you be Talking to yoor self!"
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr "§cSorry! {0}"
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr "Either send a message directly to yoor group, or toggle it on/off."
+
+msgid "party"
+msgstr "party"
+
+msgid "island"
+msgstr "island"
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr "§cToggled chat to {0} §aON"
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr "§cRepeat §9{0}§c to toggle it off"
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr "§aToggled chat §cOFF§a for {0}"
+
+msgid "§cCommand only available to players"
+msgstr "§cCommand only available to kittehs"
+
+msgid "talk to your island party"
+msgstr "talk to yoor cathouz party"
+
+msgid "talk to players on your island"
+msgstr "talk to kittehs on yoor cathouz"
+
+msgid "manually update the top 10 list"
+msgstr "manually update teh top 10 list"
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§eGenerating teh Top Ten list"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§eFinished generation of teh Top Ten list"
+
+msgid "purges all abandoned islands"
+msgstr "purges all abandoned islands"
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4You must provide teh age in dais to purrrge!"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr "§4Trying to abort purrrge"
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr "§4Starting purrrge..."
+
+msgid "Controls player-cooldowns"
+msgstr "Controls kitteh-cooldowns"
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr "clears teh cooldown on a command (* = all)"
+
+msgid "§eThe player is not currently online"
+msgstr "§eTeh kitteh  iz not currently online"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "Cleared cooldown on {0} for {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "Noe active cooldown on {0} for {1} detected!"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "Invalid command supplied, only restart an' baium supported!"
+
+msgid "restarts the cooldown on the command"
+msgstr "restarts teh cooldown on teh command"
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§eReset cooldown on {0} for {1}§e to {2} seconds"
+
+msgid "lists all the active cooldowns"
+msgstr "lists all teh active cooldowns"
+
+msgid "§eCmd Cooldown"
+msgstr "§eCmd Cooldown"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§eNoe active cooldowns for §9{0}§e found."
+
+msgid "toggles maintenance mode"
+msgstr "toggles maintenance mode"
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+"§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr "§cMaintenance mode can only be changed from console!"
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr "§9Job Statistics"
+
+msgid "§7----------------"
+msgstr "§7----------------"
+
+msgid "#"
+msgstr "#"
+
+msgid "ms/job"
+msgstr "ms/job"
+
+msgid "ms/tick"
+msgstr "ms/tick"
+
+msgid "ticks"
+msgstr "ticks"
+
+msgid "act"
+msgstr "act"
+
+msgid "time"
+msgstr "time"
+
+msgid "name"
+msgstr "name"
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§eKitteh {0} haz noe cathouz!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§eInvalid kitteh {0} supplied."
+
+msgid "flushes all caches to files"
+msgstr "flushes all caches to files"
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+"§eFlushed §a{0} islands§e, §b{1} kittehs an'' §6{2} challenge-completions."
+
+msgid "tries to fix the the area of flatland."
+msgstr "tries to fix teh teh area of flatland."
+
+msgid "§4No valid island found"
+msgstr "§4Noe valid cathouz found"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4Noe flatland detected at {0}''s cathouz!"
+
+msgid "manage orphans"
+msgstr "manage orfanz"
+
+msgid "count orphans"
+msgstr "count orfanz"
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§e{0} old cathouz locations will be used before new ones."
+
+msgid "clear orphans"
+msgstr "clear orfanz"
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§eClearing all old (empty) island locations."
+
+msgid "list orphans"
+msgstr "list orfanz"
+
+msgid "§eNo orphans currently registered."
+msgstr "§eNoe orfanz currently registered."
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr "transfer leadership to another kitteh"
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4Kitteh {0} haz noe cathouz to transfer!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§eKitteh §d{0}§e already haz a cathouz.§eUse §d/usb cathouz remove <name>§e "
+"to remove him first."
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§bLeadership transferred by {0}§b to {1}"
+
+msgid "open GUI for config"
+msgstr "open GUI for config"
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr "§eInvalid configuration name"
+
+msgid "teleport to another players island"
+msgstr "teleport to another kittehs cathouz"
+
+msgid "§4Only supported for players"
+msgstr "§4Only supported for kittehs"
+
+msgid "§4That player does not have an island!"
+msgstr "§4That kitteh does not have a cathouz!"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr "§aTeleporting to {0}''s cathouz."
+
+msgid "various WorldGuard utilities"
+msgstr "various WorldGuard utilities"
+
+msgid "refreshes the chunks around the player"
+msgstr "refreshes teh chunks around teh kitteh"
+
+msgid "§eResending chunks to the client"
+msgstr "§eResending chunks to teh client"
+
+msgid "load the region chunks"
+msgstr "load teh region chunks"
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§eLoading chunks at {0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§eUnloading chunks at {0}"
+
+msgid "update the WG regions"
+msgstr "update teh WG regions"
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr "§eIsland world-guard regions updated for {0}"
+
+msgid "§eNo island found at your location!"
+msgstr "§eNoe cathouz found at yoor location!"
+
+msgid "refreshes the chunk around the player"
+msgstr "refreshes teh chunk around teh kitteh"
+
+msgid "region manipulations"
+msgstr "region manipulations"
+
+msgid "shows the borders of the current island"
+msgstr "shows teh borders of teh current cathouz"
+
+msgid "§eNo island found at your current location"
+msgstr "§eNoe cathouz found at yoor current location"
+
+msgid "§eCan only be executed as a player"
+msgstr "§eCan only be executed as a kitteh"
+
+msgid "shows the borders of the current chunk"
+msgstr "shows teh borders of teh current chunk"
+
+msgid "shows the borders of the inner-chunks"
+msgstr "shows teh borders of teh inner-chunks"
+
+msgid "shows the non-chunk-aligned borders"
+msgstr "shows teh non-chunk-aligned borders"
+
+msgid "shows the borders of the outer-chunks"
+msgstr "shows teh borders of teh outer-chunks"
+
+msgid "hides the regions again"
+msgstr "hides teh regions again"
+
+msgid "§eStopped displaying regions"
+msgstr "§eStopped displaying regions"
+
+msgid "§eNo currently shown regions for this player"
+msgstr "§eNoe currently shown regions for this kitteh"
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr "§eAnimation-tick changed to {0}."
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr "§eAnimation-tick must be a valid integer."
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr "§4PURGE:§9 Finished purging abandoned islands."
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr "§4PURGE:§9 Aborted purging abandoned islands."
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr "§4PURGE:§9 Scanning aborted."
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr "§cABORTED:§e Protect-All wuz aborted!"
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr "§eCompleted protect-all in {0}, {1} new regions were created!"
+
+msgid "control debugging"
+msgstr "control debugging"
+
+msgid "set debug-level"
+msgstr "set debug-level"
+
+msgid "toggle debug-logging"
+msgstr "toggle debug-logging"
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4Logging wasn't active, so you can't disable it!"
+
+msgid "flush current content of the logger to file."
+msgstr "flush current content of teh logger to file."
+
+msgid "§eLog-file has been flushed."
+msgstr "§eLog-file haz been flushed."
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4Logging  iz not enabled, use §d/usb debug enable"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§eLogging disabled!"
+
+msgid "advanced command for setting island-data"
+msgstr "advanced command for setting cathouz-data"
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr "§c{0} wuz set to ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr "§cUnable to set field {0} to ''{1}''"
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr "§cUnable to set field {0} to ''{1}'', a number wuz expected"
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr "§cInvalid field {0}"
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr "§eCurrent value for {0}  iz ''{1}''"
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr "§cUnable to get state for {0}"
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr "§eValid fields be {0}"
+
+msgid "set a player''s island to your location"
+msgstr "set a kitteh''s cathouz to yoor location"
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr "advanced info about NBT stuff"
+
+msgid "shows the NBTTag for the currently held item"
+msgstr "shows teh NBTTag for teh currently held item"
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr "§eInfo for §9{0}"
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr "§7 - name: §9{0}"
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr "§7 - nbttag: §9{0}"
+
+msgid "§cNo item in hand!"
+msgstr "§cNoe item in hand!"
+
+msgid "sets the NBTTag on the currently held item"
+msgstr "sets teh NBTTag on teh currently held item"
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr "§eSet §9{0}§e to §c{1}"
+
+msgid "adds the NBTTag on the currently held item"
+msgstr "adds teh NBTTag on teh currently held item"
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr "§eAdded §9{0}§e to §c{1}"
+
+msgid "Manage challenges for a player"
+msgstr "Manage challenges for a kitteh"
+
+msgid "resets the challenge for the player"
+msgstr "resets teh challenge for teh kitteh"
+
+msgid "§4Challenge has never been completed"
+msgstr "§4Challenge haz never been completed"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§echallenge: {0} haz been reset for {1}"
+
+msgid "resets all challenges for the player"
+msgstr "resets all challenges for teh kitteh"
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0} haz had all challenges reset."
+
+msgid "complete all challenges in the rank"
+msgstr "complete all challenges in teh rank"
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4Noe kitteh named {0} wuz found!"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr "§4Challenge {0} haz already been completed"
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr "§eChallenge {0} haz been completed for {1}"
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4Noe challenge named {0} wuz found!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr "§4Noe rank named {0} wuz found!"
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr "proteks all islands (time consuming)"
+
+msgid "§cTrying to abort protect-all task."
+msgstr "§cTrying to abort protect-all task."
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+"§4Sorry!§e A protect-all  iz already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§eStarting a protect-all task. It will take a while."
+
+msgid "reload configuration from file."
+msgstr "reload configuration from file."
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§eConfiguration reloaded from file."
+
+msgid "manage islands"
+msgstr "manage islands"
+
+msgid "protects the island"
+msgstr "proteks teh cathouz"
+
+msgid "delete the island (removes the blocks)"
+msgstr "delete teh cathouz (removes teh bloks)"
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9Deleted abandoned cathouz at yoor current location."
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4Island at this location haz members!\n"
+"§eUse §9/usb cathouz delete <name>§e to delete it."
+
+msgid "removes the player from the island"
+msgstr "removes teh kitteh from teh cathouz"
+
+msgid "adds the player to the island"
+msgstr "adds teh kitteh to teh cathouz"
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d haz joined yoor cathouz group."
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr "§4Noe kitteh named {0} found!"
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+"§4Noe valid cathouz provided, either stand wiffin one, or provide a cathouz "
+"name"
+
+msgid "print out info about the island"
+msgstr "print out info about teh cathouz"
+
+msgid "sets the biome of the island"
+msgstr "sets teh baium of teh cathouz"
+
+msgid "§4That player has no island."
+msgstr "§4That kitteh haz noe cathouz."
+
+msgid "§4No valid island at your location"
+msgstr "§4Noe valid cathouz at yoor location"
+
+msgid "purges the island"
+msgstr "purges teh cathouz"
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr "§4Yikes! §9Noe valid cathouz found for purging."
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr "§cPURGE: §9Purged cathouz at {0}"
+
+msgid "toggles the islands ignore status"
+msgstr "toggles teh islands ignore status"
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr "§cSet {0}s cathouz to be ignored on top-ten an'' purrrge."
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+"§cRemoved ignore-flag of {0}s cathouz, it will now show up on top-ten an'' "
+"purrrge."
+
+msgid "§4No valid player-name supplied."
+msgstr "§4Noe valid kitteh-name supplied."
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "Removing {0} from cathouz"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§eChanged baium of {0}s cathouz to {1}."
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr "§eChanged baium of {0}s cathouz to OCEAN."
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr "§aYou may need to go to spawn, or relog, to see teh changes."
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} haz had their baium changed to {1}."
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} haz had their baium changed to OCEAN."
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§eRemoving {0}''s cathouz."
+
+msgid "Error: That player does not have an island!"
+msgstr "Yikes: That kitteh does not have a cathouz!"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§e{0}s cathouz at {1} haz been protected"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr "§4{0}s cathouz at {1} wuz already protected"
+
+msgid "displays version information"
+msgstr "displays version information"
+
+msgid "imports players and islands from other formats"
+msgstr "imports kittehs an' islands from other formats"
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr "additional perks {0}"
+
+msgid "changes the language of the plugin, and reloads"
+msgstr "changes teh language of teh plugin, an' reloads"
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr "§aSuccessfully changed language to §e{0}"
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr "§cFailed to change language to §e{0}"
+
+msgid "§9Supported Languages:\n"
+msgstr "§9Supported Languages:\n"
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr "§f{0} §7{1} §9 by {2} §7{3}\n"
+
+msgid "§cUnable to locate any languages."
+msgstr "§cUnable to locate any languages."
+
+msgid "advanced command for getting island-data"
+msgstr "advanced command for getting cathouz-data"
+
+msgid "Ultimate SkyBlock Admin"
+msgstr "Ultimate SkyBlock Admin"
+
+msgid "show player-information"
+msgstr "show kitteh-information"
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr ""
+"§4Yoor cathouz  iz full, or you have too many pending invites. You can't "
+"invite anyone else."
+
+msgid "§4That player is already leader on another island."
+msgstr "§4That kitteh  iz already top cat on another cathouz."
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e tried to invite you, but you be already in a party."
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr "§aInvite sent to {0}"
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e haz invited you to join their cathouz!"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§f/island [accept/reject]§e to accept or reject teh invite."
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4WARNING: You will lose yoor current cathouz if you accept!"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d invited {1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e haz rejected teh invitashun."
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr ""
+"§4You can't use that command right now. Leave yoor current party first."
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr ""
+"§aYou have joined a cathouz! Use /island party to see teh other members."
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§eInvitashun for {0}§e haz timedout or been cancelled."
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§eInvitashun for {0}''s cathouz haz timedout or been cancelled."
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§eYou have accepted teh invitashun to join a cathouz."
+
+msgid "§4You haven't been invited."
+msgstr "§4You haven't been invited."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§eYou have rejected teh invitashun to join a cathouz."
+
+msgid "general island command"
+msgstr "general cathouz command"
+
+msgid "allows user to bypass cooldowns"
+msgstr "allows user to bypass cooldowns"
+
+msgid "allows user to bypass visitor-protections"
+msgstr "allows user to bypass visitor-protections"
+
+msgid "allows user to bypass teleport-delay"
+msgstr "allows user to bypass teleport-delay"
+
+msgid "allows user to use [usb] signs"
+msgstr "allows user to use [usb] signs"
+
+msgid "allows user to place [usb] signs"
+msgstr "allows user to place [usb] signs"
+
+msgid "complete and list challenges"
+msgstr "complete an' list challenges"
+
+msgid "§cCommand only available for players."
+msgstr "§cCommand only available for kittehs."
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§eChallenges haz been disabled. Contact an administrator."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4You can only submit challenges in teh skyblock world!"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4You can only submit challenges when you have a cathouz!"
+
+msgid "warp to another player''s island"
+msgstr "warp to another kitteh''s cathouz"
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr "§aYoor incoming warp  iz active, kittehs may warp to yoor cathouz."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr ""
+"§4Yoor incoming warp  iz inactive, kittehs may not warp to yoor cathouz."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr "§fSet incoming warp to yoor current location using §e/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§fToggle yoor warp on/off using §e/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4You do not have permission to create a warp on yoor cathouz!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§fWarp to another cathouz using §e/island warp <kitteh>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4You do not have permission to warp to other islands!"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+"§cYoor cathouz  iz in teh process of generating, you cannot warp to other "
+"kittehs islands right now."
+
+msgid "§4That player does not exist!"
+msgstr "§4That kitteh does not exist!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4That kitteh does not have an active warp."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+"§cThat kittehs cathouz  iz in teh process of generating, you cannot warp to "
+"it right now."
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr "§cWARNING: §9{0}§e  iz warping to yoor cathouz!"
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4That kitteh haz forbidden you from warping to their cathouz."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4Noe Island. §eUse §b/ iz create§e to get one"
+
+msgid "accept/reject an invitation."
+msgstr "accept/reject an invitashun."
+
+msgid "leave your party"
+msgstr "leave yoor party"
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4You can't leave yoor cathouz if you be teh only person. Try using /island "
+"restart if you want a new one!"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§eYou own this cathouz, use /island remove <kitteh> instead."
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§eYou have left teh cathouz an' returned to teh kitteh spawn."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0} haz left yoor cathouz!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4You must be in teh skyblock world to leave yoor party!"
+
+msgid "check your or anothers island level"
+msgstr "check yoor or anothers cathouz level"
+
+msgid "allows user to query for others levels"
+msgstr "allows user to query for others levels"
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§eYou must be on yoor cathouz to use this command."
+
+msgid "§4You do not have an island!"
+msgstr "§4You do not have a cathouz!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4You do not have access to that command!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4That kitteh  iz invalid or does not have a cathouz!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr "§eInformation about {0}''s Island:"
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§aIsland level  iz {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9Rank  iz {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr "create a cathouz"
+
+msgid "exempt player from create-cooldown"
+msgstr "exempt kitteh from create-cooldown"
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4Island found!§e You already have a cathouz. If you want a fresh cathouz, "
+"type§b / iz restart§e to get one"
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4Island found!§e You be already a cats of a cathouz. To start yoor own, "
+"first§b / iz leave"
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§eYou can create a new cathouz in {0,number,#} seconds."
+
+msgid "invite a player to your island"
+msgstr "invite a kitteh to yoor cathouz"
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr ""
+"§eUse§f /island invite <playername>§e to invite a kitteh to yoor cathouz."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4Only teh cathouz''s owner can invite!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§aYou can invite {0} moar kittehs."
+
+msgid "§4You can't invite any more players."
+msgstr "§4You can't invite any moar kittehs."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4You do not have permission to invite others to this cathouz!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4That kitteh  iz offline or doesn't exist."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4You can't invite yourself!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4That kitteh  iz teh top cat of yoor cathouz!"
+
+msgid "lock your island to non-party members."
+msgstr "lock yoor cathouz to non-party members."
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4You do not have permission to lock yoor cathouz!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4You don't have access to this command!"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4You do not have permission to unlock yoor cathouz!"
+
+msgid "display the top10 of islands"
+msgstr "display teh top10 of islands"
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr "enables user to all-ways generate top-ten (noe caching)"
+
+msgid "remove a member from your island."
+msgstr "remove a cats from yoor cathouz."
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4You do not have permission to kick others from this cathouz!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4You can't remove teh top cat from teh Island!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4Stop kickin' yourself!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr "§4{0} haz removed you from their cathouz!"
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0} haz been removed from teh cathouz."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr "§4{0} tried to kick you from their cathouz!"
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr "§4{0}  iz exempt from being kicked."
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr "§4{0} haz kicked you from their cathouz!"
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0} haz been kicked from teh cathouz."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr ""
+"§4That kitteh  iz not part of yoor cathouz group, an' not on yoor cathouz!"
+
+msgid "teleport to the island home"
+msgstr "teleport to teh cathouz home"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+"§cYoor cathouz  iz in teh process of generating, you cannot teleport home "
+"right now."
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4This command can only be executed by a kitteh"
+
+msgid "transfer leadership to another member"
+msgstr "transfer leadership to another cats"
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4You can only transfer ownership to party-members!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e  iz already top cat of yoor cathouz!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4Only top cat can transfer leadership!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0} tried to take over teh cathouz!"
+
+msgid "show party information"
+msgstr "show party information"
+
+msgid "shows information about your party"
+msgstr "shows information about yoor party"
+
+msgid "show pending invites"
+msgstr "show pending invites"
+
+msgid "§eNo pending invites"
+msgstr "§eNoe pending invites"
+
+msgid "withdraw an invite"
+msgstr "withdraw an invite"
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr "§4You don't have permissions to uninvite kittehs."
+
+msgid "check your or another''s island info"
+msgstr "check yoor or anothers cathouz info"
+
+msgid "allows user to see others island info"
+msgstr "allows user to see others cathouz info"
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "§eBloks on {0}s Island (page {1,number} of {2,number}):"
+
+msgid "Score Count Block"
+msgstr "Score Count Blok"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr "trust/untrust a kitteh to help on yoor cathouz."
+
+msgid "§eThe following players are trusted on your island:"
+msgstr "§eTeh following kittehs be trusted on yoor cathouz:"
+
+msgid "§eThe following leaders trusts you:"
+msgstr "§eTeh following leaders trusts you:"
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr "§eTo trust/untrust from yoor cathouz, use /island trust <kitteh>"
+
+msgid "§4Members are already trusted!"
+msgstr "§4Members be already trusted!"
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr "§4Unknown kitteh {0}"
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr "§eYou be now trusted on §4{0}''s §eisland."
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr "§a{0} trusted {1} on teh cathouz"
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr "§eYou be noe longer trusted on §4{0}''s §eisland."
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr "§c{0} revoked trust in {1} on teh cathouz"
+
+msgid "delete your island and start a new one."
+msgstr "delete yoor cathouz an' start a new one."
+
+msgid "exempt player from restart-cooldown"
+msgstr "exempt kitteh from restart-cooldown"
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4Only teh owner may restart this cathouz. Leave this cathouz in order to "
+"start yoor own (/island leave)."
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§eYou must remove all kittehs from yoor cathouz before you can restart it (/"
+"island kick <kitteh>). See a list of kittehs currently part of yoor cathouz "
+"using /island party."
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr "§cYou can restart yoor cathouz in {0} seconds."
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr ""
+"§cYoor cathouz  iz in teh process of generating, you cannot restart now."
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§eNOTE: Yoor entire cathouz an' all yoor belongings will be RESET!"
+
+msgid "teleports you to the skyblock spawn"
+msgstr "teleports you to teh skyblock spawn"
+
+msgid "change the biome of the island"
+msgstr "change teh baium of teh cathouz"
+
+msgid "exempt player from biome-cooldown"
+msgstr "exempt kitteh from baium-cooldown"
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr "Let teh kitteh change their islands baium to {0}"
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr ""
+"§cYou do not have permission to change teh baium of yoor current cathouz."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4You do not have permission to change teh baium of this cathouz!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§eYou must be on yoor cathouz to change teh baium!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr "§cYou have misspelled teh baium name. Must be one of {0}"
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§eYou can change yoor baium again in {0,number,#} minutes."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr "§cYou do not have permission to change yoor baium to that type."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+"§7Teh pixies be busy changing teh baium near you to §9{0}§7, be patient."
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr "§eInvalid baium {0} supplied!"
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr "§aYou have changed yoor cathouz''s baium to {0}"
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0} changed teh cathouz baium to {1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr "§aYou have changed {0} bloks around you to teh {1} baium"
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr "{0} created an area with {1} baium"
+
+msgid "set your island''s warp location"
+msgstr "set yoor cathouz''s warp location"
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§cYou do not have permission to set yoor cathouz''s warp point!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§cYou need to be on yoor own cathouz to set teh warp!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d changed teh cathouz warp location."
+
+msgid "teleports you to your island (or create one)"
+msgstr "teleports you to yoor cathouz (or create one)"
+
+msgid "ban/unban a player from your island."
+msgstr "ban/unban a kitteh from yoor cathouz."
+
+msgid "exempts user from being banned"
+msgstr "exempts user from being banned"
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§eTeh following kittehs be banned from warping to yoor cathouz:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr "§eTo ban/unban from yoor cathouz, use /island ban <kitteh>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4You can't ban members. Remove 'dem first!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4You do not have permission to kick/ban kittehs."
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr "§eUnable to ban unknown kitteh {0}"
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr "§4{0} tried to ban you from their cathouz!"
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr "§4{0}  iz exempt from being banned."
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§eYou have banned §4{0}§e from warping to yoor cathouz."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr "§eYou have been §cBANNED§e from {0}§e''s cathouz."
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§eYou have unbanned §a{0}§e from warping to yoor cathouz."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr "§eYou have been §aUNBANNED§e from {0}§e''s cathouz."
+
+msgid "display log"
+msgstr "display log"
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr "set teh cathouz-home"
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr "enable/disable warping to yoor cathouz."
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr ""
+"§4Yoor cathouz  iz locked. You must unlock it before enabling yoor warp."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr "§b{0}§d activated teh cathouz warp."
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr "§cYou do not have permission to enable/disable yoor cathouz''s warp!"
+
+msgid "try to complete a challenge"
+msgstr "try to complete a challenge"
+
+msgid "show information about the challenge"
+msgstr "show information about teh challenge"
+
+msgid "§eRank: "
+msgstr "§eRank: "
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4This Challenge  can haz onlie wunce!"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr "§4You will lose all required items when you complete this challenge!"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+"§4All required items must be placed on yoor cathouz, wiffin {0} bloks of you."
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr "§eTo complete this challenge, use §f/c c {0}"
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4Invalid challenge name! Use /c help for moar information"
+
+msgid "§eSending you to spawn."
+msgstr "§eSending you to spawn."
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr "§eTeh cathouz haz been §cLOCKED§e."
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr "§4Unable to find a safe home-location on yoor cathouz!"
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr "§cWARNING: §eTeleporting you to mid-air."
+
+msgid "§aTeleporting you to your island."
+msgstr "§aTeleporting you to yoor cathouz."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§aYou will be teleported in {0} seconds."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4Unable to warp you to that kitteh''s cathouz!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr "§aTeleporting you to {0}''s cathouz."
+
+msgid "§7Teleport cancelled"
+msgstr "§7Teleport cancelled"
+
+#~ msgid ""
+#~ "§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
+#~ "that is not allowed."
+#~ msgstr ""
+#~ "§cNoe Access! §eYou be trying to teleport to teh roof of teh §cNETHER§e, "
+#~ "that  iz not allowed."
 
 #~ msgid "§9Item List Editor"
 #~ msgstr "§9stuffs List Editor"

--- a/uSkyBlock-Core/src/main/po/zh_CN.po
+++ b/uSkyBlock-Core/src/main/po/zh_CN.po
@@ -15,12 +15,45 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.7.6\n"
 
+msgid "d"
+msgstr "天"
+
+msgid "h"
+msgstr "小时"
+
+msgid "m"
+msgstr "分"
+
+msgid "s"
+msgstr "秒"
+
+#, java-format
+msgid "{0,number,0}:{1,number,00}.{2,number,000}"
+msgstr ""
+
+#, java-format
+msgid "§f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}"
+msgstr ""
+
 #, java-format
 msgid "§eYou do not have access (§4{0}§e)"
 msgstr ""
 
 #, java-format
 msgid "§eInvalid command: {0}"
+msgstr ""
+
+msgid "Command"
+msgstr ""
+
+msgid "Permission"
+msgstr ""
+
+msgid "Description"
 msgstr ""
 
 #, java-format
@@ -46,1644 +79,11 @@ msgstr ""
 msgid "§4Error writing documentation: {0}"
 msgstr ""
 
-msgid "Command"
+msgid "§cWither Despawned!§e It wandered too far from your island."
 msgstr ""
 
-msgid "Permission"
-msgstr ""
-
-msgid "Description"
-msgstr ""
-
-#, java-format
-msgid "§f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}"
-msgstr ""
-
-msgid "d"
-msgstr "天"
-
-msgid "h"
-msgstr "小时"
-
-msgid "m"
-msgstr "分"
-
-msgid "s"
-msgstr "秒"
-
-#, java-format
-msgid "{0,number,0}:{1,number,00}.{2,number,000}"
-msgstr ""
-
-#, java-format
-msgid " §f{0}x §7{1}"
-msgstr ""
-
-#, java-format
-msgid "§eStill the following blocks short: {0}"
-msgstr "§e任然缺少以下方块: {0}"
-
-#, java-format
-msgid "§4You can complete this {0} more time(s)."
-msgstr ""
-
-#, java-format
-msgid "§4Requirements will reset in {0} days."
-msgstr "§4需求将在 {0} 天后重置."
-
-#, java-format
-msgid "§4Requirements will reset in {0} hours."
-msgstr "§4需求将在 {0} 小时后重置"
-
-#, java-format
-msgid "§4Requirements will reset in {0} minutes."
-msgstr "§4需求将在 {0} 分钟后重置"
-
-msgid "§4This challenge is currently unavailable."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} days."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} hours."
-msgstr ""
-
-#, java-format
-msgid "§4You can complete this again in {0} minutes."
-msgstr ""
-
-msgid "§eThis challenge requires:"
-msgstr ""
-
-msgid "§7and more..."
-msgstr ""
-
-msgid "§eItems will be traded for reward."
-msgstr ""
-
-#, java-format
-msgid "§eMust be within {0} meters."
-msgstr ""
-
-msgid "§6Item Reward: §a"
-msgstr "§6物品奖励:"
-
-#, java-format
-msgid "§6Currency Reward: §a{0}"
-msgstr "§6货币奖励: §a{0}"
-
-#, java-format
-msgid "§6Exp Reward: §a{0}"
-msgstr "§6经验奖励: §a{0}"
-
-#, java-format
-msgid "§dTotal times completed: §f{0}"
-msgstr "§d总完成次数: §f{0}"
-
-#, java-format
-msgid "§7Requires {0}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} found"
-msgstr ""
-
-msgid "§4You must be on your island to do that!"
-msgstr "§4你必须在你的岛屿上才能这样做!"
-
-#, java-format
-msgid "§4The {0} challenge is not available yet!"
-msgstr ""
-
-#, java-format
-msgid "§4The {0} challenge is not repeatable!"
-msgstr "§4挑战:§e{0} §4不可重复完成!"
-
-#, java-format
-msgid "§4You cannot complete the {0} challenge again yet!"
-msgstr ""
-
-#, java-format
-msgid "§eTrying to complete challenge §a{0}"
-msgstr ""
-
-#, java-format
-msgid "§4{0}"
-msgstr "§4{0}"
-
-#, java-format
-msgid "§4You must be standing within {0} blocks of all required items."
-msgstr "§4在你周围 {0} 格以内必须包含挑战所需物品。"
-
-#, java-format
-msgid "§4Your island must be level {0} to complete this challenge!"
-msgstr "§4您的岛屿必须达到 {0} 级,才能完成当前挑战!"
-
-#, java-format
-msgid "§4Unknown type of challenge: {0}"
-msgstr "§4未知难度的挑战: {0}"
-
-#, java-format
-msgid ""
-"§eStill the following entities short:\n"
-"{0}"
-msgstr ""
-"§e任然缺少以下物品:\n"
-"{0}"
-
-#, java-format
-msgid " §4{0} §b{1}"
-msgstr ""
-
-#, java-format
-msgid "§eYou are the following items short:{0}"
-msgstr "§e你缺少以下物品: {0}"
-
-#, java-format
-msgid "§aYou have completed the {0} challenge!"
-msgstr "§a你完成了挑战:§e {0}"
-
-#, java-format
-msgid "§9{0}§f has completed the §9{1}§f challenge!"
-msgstr ""
-
-#, java-format
-msgid "§eItem reward(s): §f{0}"
-msgstr "§e物品奖励: §f{0}"
-
-#, java-format
-msgid "§eExp reward: §f{0,number,#.#}"
-msgstr "§e经验奖励: §f{0,number,#.#}"
-
-#, java-format
-msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-msgstr "§e货币奖励: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
-
-msgid "§eYour inventory is §4full§e. Items dropped on the ground."
-msgstr "§e背包§4已满§e。奖励物品掉落到了地上。"
-
-msgid "§e§lClick to complete this challenge."
-msgstr "§e§l点击来完成这个挑战。"
-
-msgid "§4§lYou can't repeat this challenge."
-msgstr "§4§l你无法重复完成这个挑战。"
-
-#, java-format
-msgid "Rank: {0}"
-msgstr ""
-
-msgid "§fComplete most challenges in"
-msgstr "§f完成大部分挑战在"
-
-msgid "§fthis rank to unlock the next rank."
-msgstr "§f这个难度中，才能解锁下一个等级。"
-
-msgid "§eClick here to show previous page"
-msgstr ""
-
-msgid "§eClick here to show next page"
-msgstr ""
-
-msgid "§4§lLocked Challenge"
-msgstr "§4§l挑战锁定"
-
-#, java-format
-msgid "§7Complete {0} more {1} §7challenges"
-msgstr ""
-
-#, java-format
-msgid "§7Complete {0}"
-msgstr ""
-
-msgid "to unlock this rank"
-msgstr ""
-
-msgid "But you are ALLLLLLL ALOOOOONE!"
-msgstr ""
-
-msgid "But you are Yelling in the wind!"
-msgstr ""
-
-msgid "But your fantasy friends are gone!"
-msgstr ""
-
-msgid "But you are Talking to your self!"
-msgstr ""
-
-#, java-format
-msgid "§cSorry! {0}"
-msgstr ""
-
-msgid "Either send a message directly to your group, or toggle it on/off."
-msgstr ""
-
-msgid "party"
-msgstr ""
-
-msgid "island"
-msgstr ""
-
-#, java-format
-msgid "§cToggled chat to {0} §aON"
-msgstr ""
-
-#, java-format
-msgid "§cRepeat §9{0}§c to toggle it off"
-msgstr ""
-
-#, java-format
-msgid "§aToggled chat §cOFF§a for {0}"
-msgstr ""
-
-msgid "§cCommand only available to players"
-msgstr ""
-
-msgid "talk to players on your island"
-msgstr ""
-
-msgid "talk to your island party"
-msgstr ""
-
-#, java-format
-msgid "§ePlayer {0} has no island!"
-msgstr "§e玩家 {0} 还未获得岛屿!"
-
-#, java-format
-msgid "§eInvalid player {0} supplied."
-msgstr "§e无效的玩家 {0}"
-
-msgid "Manage challenges for a player"
-msgstr ""
-
-msgid "resets the challenge for the player"
-msgstr ""
-
-msgid "§4Challenge has never been completed"
-msgstr "§4挑战从未完成过"
-
-#, java-format
-msgid "§echallenge: {0} has been reset for {1}"
-msgstr "§e挑战: {0} 已经为玩家 {1} 重置"
-
-msgid "resets all challenges for the player"
-msgstr ""
-
-#, java-format
-msgid "§e{0} has had all challenges reset."
-msgstr "§e{0} 的所有挑战已经重置"
-
-msgid "complete all challenges in the rank"
-msgstr ""
-
-#, java-format
-msgid "§4No player named {0} was found!"
-msgstr "§4没有名字为 {0} 的玩家被找到"
-
-#, java-format
-msgid "§4Challenge {0} has already been completed"
-msgstr ""
-
-#, java-format
-msgid "§eChallenge {0} has been completed for {1}"
-msgstr ""
-
-#, java-format
-msgid "§4No challenge named {0} was found!"
-msgstr "§4挑战: {0} 未找到!"
-
-#, java-format
-msgid "§4No rank named {0} was found!"
-msgstr ""
-
-msgid "manage islands"
-msgstr ""
-
-msgid "protects the island"
-msgstr ""
-
-msgid "delete the island (removes the blocks)"
-msgstr ""
-
-msgid "§9Deleted abandoned island at your current location."
-msgstr "§9你当前位置的岛屿已经删除。"
-
-msgid ""
-"§4Island at this location has members!\n"
-"§eUse §9/usb island delete <name>§e to delete it."
-msgstr ""
-"§4当前位置的岛屿拥有其他的成员!\n"
-"§e输入§9/usb island delete <玩家名> §e来删除"
-
-msgid "removes the player from the island"
-msgstr ""
-
-msgid "adds the player to the island"
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d has joined your island group."
-msgstr "§b{0}§d加入了你的岛屿团队。"
-
-#, java-format
-msgid "§4No player named {0} found!"
-msgstr ""
-
-msgid ""
-"§4No valid island provided, either stand within one, or provide an island "
-"name"
-msgstr ""
-
-msgid "print out info about the island"
-msgstr ""
-
-msgid "sets the biome of the island"
-msgstr ""
-
-msgid "§4That player has no island."
-msgstr "§4玩家仍未拥有岛屿。"
-
-msgid "§4No valid island at your location"
-msgstr "§4无效的岛屿在你的位置上。"
-
-msgid "purges the island"
-msgstr ""
-
-msgid "§4Error! §9No valid island found for purging."
-msgstr ""
-
-#, java-format
-msgid "§cPURGE: §9Purged island at {0}"
-msgstr ""
-
-msgid "toggles the islands ignore status"
-msgstr ""
-
-#, java-format
-msgid "§cSet {0}s island to be ignored on top-ten and purge."
-msgstr ""
-
-#, java-format
-msgid ""
-"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
-"purge."
-msgstr ""
-
-msgid "§4No valid player-name supplied."
-msgstr "§4无效的玩家名"
-
-#, java-format
-msgid "Removing {0} from island"
-msgstr "从岛屿上移除了 {0}"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to {1}."
-msgstr "§e将 {0} 的岛屿的生物群系更改为 {1}"
-
-#, java-format
-msgid "§eChanged biome of {0}s island to OCEAN."
-msgstr ""
-
-msgid "§aYou may need to go to spawn, or relog, to see the changes."
-msgstr "§a你需要返回出生点,或者重新登录才能看到改变。"
-
-#, java-format
-msgid "§e{0} has had their biome changed to {1}."
-msgstr "§e{0} 将他们的生物群系更改为了 {1}"
-
-#, java-format
-msgid "§e{0} has had their biome changed to OCEAN."
-msgstr "§e{0} 将他们的生物群系更改为了 OCEAN(海洋生物群系)"
-
-#, java-format
-msgid "§eRemoving {0}''s island."
-msgstr "§e移除了 {0} 的岛屿。"
-
-msgid "Error: That player does not have an island!"
-msgstr "错误: 玩家未拥有岛屿。"
-
-#, java-format
-msgid "§e{0}s island at {1} has been protected"
-msgstr "§e{0} 的岛屿在 {1} 被保护"
-
-#, java-format
-msgid "§4{0}s island at {1} was already protected"
-msgstr ""
-
-msgid "various chunk commands"
-msgstr ""
-
-msgid "regenerate current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully regenerated chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
-msgstr ""
-
-msgid "unload current chunk"
-msgstr ""
-
-#, java-format
-msgid "successfully unloaded chunk at {0},{1}"
-msgstr ""
-
-#, java-format
-msgid "§4FAILED!§e could not unload chunk at {0},{1}"
-msgstr ""
-
-msgid "load current chunk"
-msgstr ""
-
-#, java-format
-msgid "loaded chunk at {0},{1}"
-msgstr ""
-
-msgid "only available for players"
-msgstr ""
-
-#, java-format
-msgid "§4ERROR:§e {0}"
-msgstr ""
-
-msgid "open GUI for config"
-msgstr ""
-
-msgid "searches config for a specific key"
-msgstr ""
-
-#, java-format
-msgid "§c{0}§9"
-msgstr ""
-
-#, java-format
-msgid "§9{0}§8: §e{1}"
-msgstr ""
-
-#, java-format
-msgid "Found the following matching {0}:"
-msgstr ""
-
-msgid "§a<section>"
-msgstr ""
-
-#, java-format
-msgid "§3{0,number,#.##}"
-msgstr ""
-
-#, java-format
-msgid "§2{0}"
-msgstr ""
-
-msgid "§eInvalid configuration name"
-msgstr ""
-
-msgid "Controls player-cooldowns"
-msgstr ""
-
-msgid "clears the cooldown on a command (* = all)"
-msgstr ""
-
-msgid "§eThe player is not currently online"
-msgstr "§e玩家未在线"
-
-#, java-format
-msgid "Cleared cooldown on {0} for {1}"
-msgstr "清除冷却时间在{0} ~ {1}"
-
-#, java-format
-msgid "No active cooldown on {0} for {1} detected!"
-msgstr "在{0} ~ {1} 之间没有活跃的冷却时间"
-
-msgid "Invalid command supplied, only restart and biome supported!"
-msgstr "无效的命令,只支持restart 和 biome"
-
-msgid "restarts the cooldown on the command"
-msgstr ""
-
-#, java-format
-msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
-msgstr "§e重置冷却时间在{0} ~ {1} §e ~ {2} 秒"
-
-msgid "lists all the active cooldowns"
-msgstr ""
-
-msgid "§eCmd Cooldown"
-msgstr "§e 指令冷却时间"
-
-#, java-format
-msgid "§a{0} §c{1}"
-msgstr "§a{0} §c{1}"
-
-#, java-format
-msgid "§eNo active cooldowns for §9{0}§e found."
-msgstr "§e没有活跃的冷却时间 §9{0} 被找到"
-
-msgid "control debugging"
-msgstr ""
-
-msgid "set debug-level"
-msgstr ""
-
-msgid "toggle debug-logging"
-msgstr ""
-
-msgid "§4Logging wasn't active, so you can't disable it!"
-msgstr "§4记录未启用,所以你无法关闭。"
-
-msgid "flush current content of the logger to file."
-msgstr ""
-
-msgid "§eLog-file has been flushed."
-msgstr "§e日志文件已经更新。"
-
-msgid "§4Logging is not enabled, use §d/usb debug enable"
-msgstr "§4记录未启用，输入§d/usb debug 启用"
-
-msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
-msgstr "§4未知参数，请尝试 INFO, FINE, FINER, FINEST"
-
-msgid "§eLogging disabled!"
-msgstr "§e记录已经关闭"
-
-msgid "tries to fix the the area of flatland."
-msgstr ""
-
-msgid "§4No valid island found"
-msgstr "§4没有找到有效的岛屿"
-
-#, java-format
-msgid "§4No flatland detected at {0}''s island!"
-msgstr "§4在{0} 的岛上未检测到平地。"
-
-msgid "flushes all caches to files"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
-msgstr ""
-
-msgid "manually update the top 10 list"
-msgstr ""
-
-msgid "§eGenerating the Top Ten list"
-msgstr "§e生存排行榜前十名单"
-
-msgid "§eFinished generation of the Top Ten list"
-msgstr "§e排行榜前十名单生成完毕"
-
-msgid "advanced command for getting island-data"
-msgstr ""
-
-#, java-format
-msgid "§eCurrent value for {0} is ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to get state for {0}"
-msgstr ""
-
-#, java-format
-msgid "§eValid fields are {0}"
-msgstr ""
-
-msgid "teleport to another players island"
-msgstr ""
-
-msgid "§4Only supported for players"
-msgstr "§4近支持玩家"
-
-msgid "§4That player does not have an island!"
-msgstr "§4玩家仍未拥有岛屿。"
-
-#, java-format
-msgid "§aTeleporting to {0}''s island."
-msgstr ""
-
-msgid "imports players and islands from other formats"
-msgstr ""
-
-msgid "controls async jobs"
-msgstr ""
-
-msgid "§9Job Statistics"
-msgstr ""
-
-msgid "§7----------------"
-msgstr ""
-
-msgid "#"
-msgstr ""
-
-msgid "ms/job"
-msgstr ""
-
-msgid "ms/tick"
-msgstr ""
-
-msgid "ticks"
-msgstr ""
-
-msgid "act"
-msgstr ""
-
-msgid "time"
-msgstr ""
-
-msgid "name"
-msgstr ""
-
-msgid "changes the language of the plugin, and reloads"
-msgstr ""
-
-#, java-format
-msgid "§aSuccessfully changed language to §e{0}"
-msgstr ""
-
-#, java-format
-msgid "§cFailed to change language to §e{0}"
-msgstr ""
-
-msgid "§9Supported Languages:\n"
-msgstr ""
-
-#, java-format
-msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
-msgstr ""
-
-msgid "§cUnable to locate any languages."
-msgstr ""
-
-msgid "transfer leadership to another player"
-msgstr ""
-
-#, java-format
-msgid "§4Player {0} has no island to transfer!"
-msgstr "§4玩家 {0} 没有能够转让的岛屿!"
-
-#, java-format
-msgid ""
-"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
-"to remove him first."
-msgstr ""
-"§e玩家 §d{0} §e早就拥有了岛屿。§e输入§d/usb island remove <玩家名>§e将他移"
-"除。"
-
-#, java-format
-msgid "§bLeadership transferred by {0}§b to {1}"
-msgstr "§b岛屿主人由{0} 变更为{1}"
-
-msgid "advanced info about NBT stuff"
-msgstr ""
-
-msgid "shows the NBTTag for the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eInfo for §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - name: §9{0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - nbttag: §9{0}"
-msgstr ""
-
-msgid "§cNo item in hand!"
-msgstr ""
-
-msgid "§eCan only be executed as a player"
-msgstr ""
-
-msgid "sets the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eSet §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "adds the NBTTag on the currently held item"
-msgstr ""
-
-#, java-format
-msgid "§eAdded §9{0}§e to §c{1}"
-msgstr ""
-
-msgid "manage orphans"
-msgstr ""
-
-msgid "count orphans"
-msgstr ""
-
-#, java-format
-msgid "§e{0} old island locations will be used before new ones."
-msgstr "§e{0} 旧的岛屿位置将会被新岛屿所替换。"
-
-msgid "clear orphans"
-msgstr ""
-
-msgid "§eClearing all old (empty) island locations."
-msgstr "§e清除所有旧(空)的岛屿坐标。"
-
-msgid "list orphans"
-msgstr ""
-
-msgid "§eNo orphans currently registered."
-msgstr ""
-
-#, java-format
-msgid "§eOrphans ({0}/{1}): {2}"
-msgstr ""
-
-msgid "shows perk-information"
-msgstr ""
-
-msgid "shows a specific players perks"
-msgstr ""
-
-#, java-format
-msgid "additional perks {0}"
-msgstr ""
-
-msgid "protects all islands (time consuming)"
-msgstr ""
-
-msgid "§cTrying to abort protect-all task."
-msgstr ""
-
-msgid ""
-"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
-"§9usb protectall §cstop"
-msgstr ""
-
-msgid "§eStarting a protect-all task. It will take a while."
-msgstr "§e开始执行 全局保护,将会花费一定时间。"
-
-msgid "purges all abandoned islands"
-msgstr ""
-
-msgid "§4You must provide the age in days to purge!"
-msgstr "§4你必须指定一个天数来删除。"
-
-msgid "§4The level must be a valid number"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eFinding all islands that have been abandoned for more than {0} days below "
-"level {1}"
-msgstr ""
-
-#, java-format
-msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
-msgstr ""
-
-msgid "§4Trying to abort purge"
-msgstr ""
-
-msgid "§4Purge aborted!"
-msgstr ""
-
-msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
-msgstr ""
-
-msgid "§4Starting purge..."
-msgstr ""
-
-msgid "region manipulations"
-msgstr ""
-
-msgid "shows the borders of the current island"
-msgstr ""
-
-msgid "§eNo island found at your current location"
-msgstr ""
-
-msgid "shows the borders of the current chunk"
-msgstr ""
-
-msgid "shows the borders of the inner-chunks"
-msgstr ""
-
-msgid "shows the non-chunk-aligned borders"
-msgstr ""
-
-msgid "shows the borders of the outer-chunks"
-msgstr ""
-
-msgid "hides the regions again"
-msgstr ""
-
-msgid "§eStopped displaying regions"
-msgstr ""
-
-msgid "§eNo currently shown regions for this player"
-msgstr ""
-
-msgid "set the ticks between animations"
-msgstr ""
-
-#, java-format
-msgid "§eAnimation-tick changed to {0}."
-msgstr ""
-
-msgid "§eAnimation-tick must be a valid integer."
-msgstr ""
-
-msgid "refreshes the existing animations"
-msgstr ""
-
-msgid "set a player''s island to your location"
-msgstr ""
-
-#, java-format
-msgid "§aSet {0}''s island to the current island."
-msgstr ""
-
-msgid "§4Island not found: unable to set the island!"
-msgstr ""
-
-msgid "reload configuration from file."
-msgstr ""
-
-msgid "§eConfiguration reloaded from file."
-msgstr "§e配置重读。"
-
-msgid "advanced command for setting island-data"
-msgstr ""
-
-#, java-format
-msgid "§c{0} was set to ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}''"
-msgstr ""
-
-#, java-format
-msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid field {0}"
-msgstr ""
-
-msgid "toggles maintenance mode"
-msgstr ""
-
-msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
-msgstr ""
-
-msgid ""
-"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
-msgstr ""
-
-msgid "§cMaintenance mode can only be changed from console!"
-msgstr ""
-
-msgid "§cABORTED:§e Protect-All was aborted!"
-msgstr ""
-
-#, java-format
-msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
-msgstr ""
-
-#, java-format
-msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Scanning aborted."
-msgstr ""
-
-#, java-format
-msgid ""
-"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
-"purgatory."
-msgstr ""
-
-#, java-format
-msgid ""
-"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
-msgstr ""
-
-msgid "§4PURGE:§9 Finished purging abandoned islands."
-msgstr ""
-
-msgid "§4PURGE:§9 Aborted purging abandoned islands."
-msgstr ""
-
-msgid "displays version information"
-msgstr ""
-
-msgid "various WorldGuard utilities"
-msgstr ""
-
-msgid "refreshes the chunks around the player"
-msgstr ""
-
-msgid "§eResending chunks to the client"
-msgstr "§e重新发送区块数据至客户端"
-
-msgid "load the region chunks"
-msgstr ""
-
-#, java-format
-msgid "§eLoading chunks at {0}"
-msgstr "§e加载区块在{0}"
-
-#, java-format
-msgid "§eUnloading chunks at {0}"
-msgstr "§e卸载区块在{0}"
-
-msgid "update the WG regions"
-msgstr ""
-
-#, java-format
-msgid "§eIsland world-guard regions updated for {0}"
-msgstr ""
-
-msgid "§eNo island found at your location!"
-msgstr ""
-
-msgid "refreshes the chunk around the player"
-msgstr ""
-
-msgid "Ultimate SkyBlock Admin"
-msgstr ""
-
-msgid "show player-information"
-msgstr ""
-
-msgid "try to complete a challenge"
-msgstr ""
-
-msgid "§cCommand only available for players."
-msgstr ""
-
-msgid "show information about the challenge"
-msgstr ""
-
-msgid "§eRank: "
-msgstr ""
-
-msgid "§4This Challenge is not repeatable!"
-msgstr "§4当前任务不可重复。"
-
-msgid "§4You will lose all required items when you complete this challenge!"
-msgstr "§4挑战所需物品将会从你背包内移除。"
-
-#, java-format
-msgid ""
-"§4All required items must be placed on your island, within {0} blocks of you."
-msgstr ""
-
-#, java-format
-msgid "§eTo complete this challenge, use §f/c c {0}"
-msgstr ""
-
-msgid "§4Invalid challenge name! Use /c help for more information"
-msgstr "§4错误的挑战名!输入/c help 获取更多信息"
-
-msgid "complete and list challenges"
-msgstr ""
-
-msgid "§eChallenges has been disabled. Contact an administrator."
-msgstr "§e挑战不可用,请联系服务器管理员."
-
-msgid "§4You can only submit challenges in the skyblock world!"
-msgstr "§4你只能在空岛世界提交挑战。"
-
-msgid "§4You can only submit challenges when you have an island!"
-msgstr "§4你只能在拥有一个岛屿的情况下提交挑战。"
-
-msgid ""
-"§4Your island is full, or you have too many pending invites. You can't "
-"invite anyone else."
-msgstr "§4你的岛屿已经满员,或者你有太多等待邀请请求。你无法再邀请其他人。"
-
-msgid "§4That player is already leader on another island."
-msgstr "§4那个玩家早就是另外岛屿的主人了。"
-
-#, java-format
-msgid "§e{0}§e tried to invite you, but you are already in a party."
-msgstr "§e{0}§e 尝试邀请你加入他的岛屿,但是你早就在其他团队了。"
-
-#, java-format
-msgid "§aInvite sent to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0}§e has invited you to join their island!"
-msgstr "{0}§e邀请你加入他们的岛屿。"
-
-msgid "§f/island [accept/reject]§e to accept or reject the invite."
-msgstr "§f/island [accept/reject]§e 接受或者拒绝一个邀请。"
-
-msgid "§4WARNING: You will lose your current island if you accept!"
-msgstr "§4警告: 你当前的岛屿将会被清空,如果你接受请求的话。"
-
-#, java-format
-msgid "{0}§d invited {1}"
-msgstr "{0}§d邀请了{1}"
-
-#, java-format
-msgid "{0}§e has rejected the invitation."
-msgstr "{0}§e拒绝了邀请"
-
-msgid "§4You can't use that command right now. Leave your current party first."
-msgstr "§4你无法使用当前命令。请先离开你当前的团队。"
-
-msgid ""
-"§aYou have joined an island! Use /island party to see the other members."
-msgstr "§a你加入了一个岛屿!输入/island party 来查看团队成员。"
-
-#, java-format
-msgid "§eInvitation for {0}§e has timedout or been cancelled."
-msgstr "§e来自{0}§e的邀请已经过时或被取消。"
-
-#, java-format
-msgid "§eInvitation for {0}''s island has timedout or been cancelled."
-msgstr "§e来自{0}§e岛屿的邀请已经过时或被取消。"
-
-msgid "§eYou have accepted the invitation to join an island."
-msgstr "§e你接受了加入岛屿的邀请."
-
-msgid "§4You haven't been invited."
-msgstr "§4你没有被任何人邀请."
-
-msgid "§eYou have rejected the invitation to join an island."
-msgstr "§e你拒接了加入岛屿的邀请"
-
-msgid "accept/reject an invitation."
-msgstr ""
-
-msgid "teleports you to your island (or create one)"
-msgstr ""
-
-msgid "ban/unban a player from your island."
-msgstr ""
-
-msgid "exempts user from being banned"
-msgstr ""
-
-msgid "§eThe following players are banned from warping to your island:"
-msgstr "§e下列玩家被禁止传送到你的岛屿:"
-
-msgid "§eTo ban/unban from your island, use /island ban <player>"
-msgstr "§e禁止/允许一个玩家前往你的岛屿，输入§c/island ban §a<玩家名字>"
-
-msgid "§4You can't ban members. Remove them first!"
-msgstr "§4你无法封禁玩家.请先将他们从你的岛屿上移除!"
-
-msgid "§4You do not have permission to kick/ban players."
-msgstr "§4你没有权限踢出/禁止一个玩家"
-
-#, java-format
-msgid "§eUnable to ban unknown player {0}"
-msgstr ""
-
-#, java-format
-msgid "§4{0} tried to ban you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} is exempt from being banned."
-msgstr ""
-
-#, java-format
-msgid "§eYou have banned §4{0}§e from warping to your island."
-msgstr "§e你禁止了玩家§4{0}§e前往你的岛屿上."
-
-#, java-format
-msgid "§eYou have been §cBANNED§e from {0}§e''s island."
-msgstr ""
-
-#, java-format
-msgid "§eYou have unbanned §a{0}§e from warping to your island."
-msgstr "§e你解除了玩家§a{0}§e的封禁状态，现在他可以访问你的岛屿了."
-
-#, java-format
-msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
-msgstr ""
-
-msgid "change the biome of the island"
-msgstr ""
-
-msgid "exempt player from biome-cooldown"
-msgstr ""
-
-#, java-format
-msgid "Let the player change their islands biome to {0}"
-msgstr ""
-
-msgid ""
-"§cYou do not have permission to change the biome of your current island."
-msgstr "§c你没有权限更改你当前岛屿的生物群系."
-
-msgid "§4You do not have permission to change the biome of this island!"
-msgstr "§4你没有权限去变更岛屿的生物群系!"
-
-msgid "§eYou must be on your island to change the biome!"
-msgstr "§e你必须在你的岛屿上才能更改生物群系!"
-
-#, java-format
-msgid "§cYou have misspelled the biome name. Must be one of {0}"
-msgstr ""
-
-#, java-format
-msgid "§eYou can change your biome again in {0,number,#} minutes."
-msgstr "§e你需要等待{0,number,#}分钟才能再次更改生物群系."
-
-msgid "§cYou do not have permission to change your biome to that type."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
-"be patient."
-msgstr ""
-
-#, java-format
-msgid ""
-"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
-"patient."
-msgstr ""
-
-#, java-format
-msgid "§eInvalid biome {0} supplied!"
-msgstr ""
-
-#, java-format
-msgid "§aYou have changed your island''s biome to {0}"
-msgstr ""
-
-#, java-format
-msgid "{0} changed the island biome to {1}"
-msgstr "{0}将岛屿的生物群系更改为{1}"
-
-#, java-format
-msgid "§aYou have changed {0} blocks around you to the {1} biome"
-msgstr ""
-
-#, java-format
-msgid "{0} created an area with {1} biome"
-msgstr ""
-
-msgid "create an island"
-msgstr ""
-
-msgid "exempt player from create-cooldown"
-msgstr ""
-
-msgid ""
-"§4Island found!§e You already have an island. If you want a fresh island, "
-"type§b /is restart§e to get one"
-msgstr ""
-"§4岛屿已存在!§e你早就拥有一个岛屿了.如果你想要一个权限的岛屿，输入§b /is "
-"restart §e来重新开始岛屿生涯."
-
-msgid ""
-"§4Island found!§e You are already a member of an island. To start your own, "
-"first§b /is leave"
-msgstr ""
-"§4岛屿已存在!§e你已经加入了一个岛屿.如果你想开始一个属于自己的岛屿生涯，请先"
-"输入§b /is leave §e来离开当前团队."
-
-#, java-format
-msgid "§eYou can create a new island in {0,number,#} seconds."
-msgstr "§e你需要等待{0,number,#}秒才能创建一个新的岛屿."
-
-msgid "teleport to the island home"
-msgstr ""
-
-msgid ""
-"§cYour island is in the process of generating, you cannot teleport home "
-"right now."
-msgstr ""
-
-msgid "check your or another''s island info"
-msgstr ""
-
-msgid "allows user to see others island info"
-msgstr ""
-
-msgid "§4Island level has been disabled, contact an administrator."
-msgstr "§4岛屿等级系统未启用,请联系管理员."
-
-msgid "§4Hold your horses! §eYou have to be patient..."
-msgstr ""
-
-msgid "§eYou must be on your island to use this command."
-msgstr "§e你必须在你的岛屿上来使用这个指令."
-
-msgid "§4You do not have an island!"
-msgstr "§4你还未拥有一个岛屿!"
-
-msgid "§4You do not have access to that command!"
-msgstr "§4你没有权限使用这个指令!"
-
-msgid "§4That player is invalid or does not have an island!"
-msgstr "§4玩家不存在或仍未拥有一个岛屿!"
-
-#, java-format
-msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
-msgstr "eBlocks on {0}s Island (page {1,number} of {2,number}):"
-
-msgid "Score Count Block"
-msgstr "计分方块"
-
-#, java-format
-msgid "{0,number,00.00}  {1,number,#} {2}"
-msgstr ""
-
-#, java-format
-msgid "§aIsland level is {0,number,###.##}"
-msgstr "§a岛屿等级: {0,number,###.##}"
-
-msgid "invite a player to your island"
-msgstr ""
-
-msgid ""
-"§eUse§f /island invite <playername>§e to invite a player to your island."
-msgstr "§e驶入§f/island invite <玩家ID> §e邀请玩家加入你的岛屿."
-
-msgid "§4Only the island''s owner can invite!"
-msgstr "§4只有岛屿的主人才能邀请!"
-
-#, java-format
-msgid "§aYou can invite {0} more players."
-msgstr "§a你还能邀请{0}个玩家"
-
-msgid "§4You can't invite any more players."
-msgstr "§4你无法邀请更多的玩家了."
-
-msgid "§4You do not have permission to invite others to this island!"
-msgstr "§4你没有在这个岛屿上邀请别人的权限!"
-
-msgid "§4That player is offline or doesn't exist."
-msgstr "§4玩家未在线或不存在."
-
-msgid "§4You can't invite yourself!"
-msgstr "§4你无法邀请你自己!"
-
-msgid "§4That player is the leader of your island!"
-msgstr "§4玩家是你当前所处岛屿的主人!"
-
-msgid "remove a member from your island."
-msgstr ""
-
-msgid "§4You do not have permission to kick others from this island!"
-msgstr "§4你没有在当前岛屿踢出玩家的权限!"
-
-msgid "§4You can't remove the leader from the Island!"
-msgstr "§4你无法将岛屿的主人移除!"
-
-msgid "§4Stop kickin' yourself!"
-msgstr "§4请不要尝试踢出你自己!"
-
-#, java-format
-msgid "§4{0} has removed you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} has been removed from the island."
-msgstr "§4{0}被从当前岛屿上移除."
-
-#, java-format
-msgid "§4{0} tried to kick you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} is exempt from being kicked."
-msgstr ""
-
-#, java-format
-msgid "§4{0} has kicked you from their island!"
-msgstr ""
-
-#, java-format
-msgid "§4{0} has been kicked from the island."
-msgstr "§4{0}被从当前岛屿上踢出."
-
-msgid "§4That player is not part of your island group, and not on your island!"
-msgstr "§4玩家不是你岛屿上的一员,并且不在你的岛屿上!"
-
-msgid "leave your party"
-msgstr ""
-
-msgid ""
-"§4You can't leave your island if you are the only person. Try using /island "
-"restart if you want a new one!"
-msgstr ""
-"§4如果你是岛屿上唯一的成员,你将无法离开岛屿.如果你想重新开始,输入§e/island "
-"restart"
-
-msgid "§eYou own this island, use /island remove <player> instead."
-msgstr "§e你拥有了当前岛屿,输入/island remove <玩家ID> 来取代他"
-
-msgid "§eYou have left the island and returned to the player spawn."
-msgstr "§e你离开了当前岛屿,并且传送到了玩家出生点."
-
-#, java-format
-msgid "§4{0} has left your island!"
-msgstr "§4{0}离开了你的岛屿!"
-
-msgid "§4You must be in the skyblock world to leave your party!"
-msgstr "§4你必须在岛屿世界才能离开你的团队!"
-
-msgid "check your or anothers island level"
-msgstr ""
-
-msgid "allows user to query for others levels"
-msgstr ""
-
-#, java-format
-msgid "§eInformation about {0}''s Island:"
-msgstr ""
-
-#, java-format
-msgid "§9Rank is {0}"
-msgstr "§9排名: {0}"
-
-#, java-format
-msgid "§4Could not locate rank of {0}"
-msgstr ""
-
-msgid "lock your island to non-party members."
-msgstr ""
-
-msgid "§4You do not have permission to lock your island!"
-msgstr "§4你没有权限锁定你的岛屿!"
-
-msgid "§4You don't have access to this command!"
-msgstr "§4你无法使用当前指令。"
-
-msgid "§4You do not have permission to unlock your island!"
-msgstr "§4你没有权限解锁你的岛屿!"
-
-msgid "display log"
-msgstr ""
-
-msgid "transfer leadership to another member"
-msgstr ""
-
-msgid "§4You can only transfer ownership to party-members!"
-msgstr "§4你只能将岛屿主人的权限转移给他们的成员玩家!"
-
-#, java-format
-msgid "{0}§e is already leader of your island!"
-msgstr "{0}§e早就是你们岛屿的成员了!"
-
-msgid "§4Only leader can transfer leadership!"
-msgstr "§4只有岛屿的主人才能转移权限!"
-
-#, java-format
-msgid "{0} tried to take over the island!"
-msgstr "{0}试图接管当前岛屿!"
-
-msgid "show the islands limits"
-msgstr ""
-
-msgid "show party information"
-msgstr ""
-
-msgid "shows information about your party"
-msgstr ""
-
-msgid "show pending invites"
-msgstr ""
-
-msgid "§eNo pending invites"
-msgstr "§e没有等待的邀请"
-
-msgid "withdraw an invite"
-msgstr ""
-
-msgid "§4You don't have permissions to uninvite players."
-msgstr ""
-
-msgid "§4This command can only be executed by a player"
-msgstr "§4这个指令只能由玩家来执行."
-
-msgid "§4No Island. §eUse §b/is create§e to get one"
-msgstr "§4未拥有岛屿.§e输入§b/is create§e创建一个岛屿"
-
-msgid "changes a members island-permissions"
-msgstr ""
-
-#, java-format
-msgid "§ePermissions for §9{0}§e:"
-msgstr ""
-
-msgid "§aON"
-msgstr ""
-
-msgid "§cOFF"
-msgstr ""
-
-#, java-format
-msgid "§7 - §6{0}§7 : {1}"
-msgstr ""
-
-#, java-format
-msgid "§cInvalid permission {0}. Must be one of {1}"
-msgstr ""
-
-#, java-format
-msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
-msgstr ""
-
-#, java-format
-msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
-msgstr ""
-
-msgid "delete your island and start a new one."
-msgstr ""
-
-msgid "exempt player from restart-cooldown"
-msgstr ""
-
-msgid ""
-"§4Only the owner may restart this island. Leave this island in order to "
-"start your own (/island leave)."
-msgstr ""
-"§4只有岛屿的主人才能重新开始岛屿.离开当前岛屿开始属于你自己的岛屿生涯请输入(/"
-"island leave)"
-
-msgid ""
-"§eYou must remove all players from your island before you can restart it (/"
-"island kick <player>). See a list of players currently part of your island "
-"using /island party."
-msgstr ""
-"§e想要重新开始你的岛屿，你必须移除所有岛屿成员(/island kick <玩家ID>).查看当"
-"前岛屿玩家列表请输入/island party"
-
-#, java-format
-msgid "§cYou can restart your island in {0} seconds."
-msgstr ""
-
-msgid "§cYour island is in the process of generating, you cannot restart now."
-msgstr ""
-
-msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
-msgstr "§e注意: 你所有财产和你的岛屿将被§c§l重置"
-
-msgid "set the island-home"
-msgstr ""
-
-msgid "set your island''s warp location"
-msgstr ""
-
-msgid "§cYou do not have permission to set your island''s warp point!"
-msgstr "§c你没有权限设置你岛屿的传送点!"
-
-msgid "§cYou need to be on your own island to set the warp!"
-msgstr "§c你需要在你的岛屿上才能设置传送点!"
-
-#, java-format
-msgid "§b{0}§d changed the island warp location."
-msgstr "§b{0}§d更改岛屿传送坐标."
-
-msgid "teleports you to the skyblock spawn"
-msgstr ""
-
-msgid "enable/disable warping to your island."
-msgstr ""
-
-msgid "§4Your island is locked. You must unlock it before enabling your warp."
-msgstr "§4你的岛屿已经锁定,在启用传送点之前请先解锁."
-
-#, java-format
-msgid "§b{0}§d activated the island warp."
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d deactivated the island warp."
-msgstr "§b{0}§d禁止了岛屿传送点."
-
-msgid "§cYou do not have permission to enable/disable your island''s warp!"
-msgstr "§c你没有权限启用/禁用岛屿的传送点!"
-
-msgid "display the top10 of islands"
-msgstr ""
-
-msgid "enables user to all-ways generate top-ten (no caching)"
-msgstr ""
-
-msgid "trust/untrust a player to help on your island."
-msgstr ""
-
-msgid "§eThe following players are trusted on your island:"
-msgstr ""
-
-msgid "§eThe following leaders trusts you:"
-msgstr ""
-
-msgid "§eTo trust/untrust from your island, use /island trust <player>"
-msgstr ""
-
-msgid "§4Members are already trusted!"
-msgstr ""
-
-#, java-format
-msgid "§4Unknown player {0}"
-msgstr ""
-
-#, java-format
-msgid "§eYou are now trusted on §4{0}''s §eisland."
-msgstr ""
-
-#, java-format
-msgid "§a{0} trusted {1} on the island"
-msgstr ""
-
-#, java-format
-msgid "§eYou are no longer trusted on §4{0}''s §eisland."
-msgstr ""
-
-#, java-format
-msgid "§c{0} revoked trust in {1} on the island"
-msgstr ""
-
-msgid "warp to another player''s island"
-msgstr ""
-
-msgid "§aYour incoming warp is active, players may warp to your island."
-msgstr "§a你启用了传送点,玩家可以传送到你的岛屿上了."
-
-msgid "§4Your incoming warp is inactive, players may not warp to your island."
-msgstr "§4你禁用了传送点,玩家无法传送到你的岛屿上."
-
-msgid "§fSet incoming warp to your current location using §e/island setwarp"
-msgstr "§f设置岛屿传送点在你当前位置上请收入与§e/island setwarp"
-
-msgid "§fToggle your warp on/off using §e/island togglewarp"
-msgstr "§f启用/禁止岛屿的传送点请输入§e/island togglewarp"
-
-msgid "§4You do not have permission to create a warp on your island!"
-msgstr "§4你就没有权限在你的岛屿上创建一个传送点!"
-
-msgid "§fWarp to another island using §e/island warp <player>"
-msgstr "§f传送到别人的岛屿请输入§e/island warp <玩家ID>"
-
-msgid "§4You do not have permission to warp to other islands!"
-msgstr "§4你没有权限传送到其他玩家的岛屿上"
-
-msgid ""
-"§cYour island is in the process of generating, you cannot warp to other "
-"players islands right now."
-msgstr ""
-
-msgid "§4That player does not exist!"
-msgstr "§4玩家不存在!"
-
-msgid "§4That player does not have an active warp."
-msgstr "§4玩家未拥有激活的传送点."
-
-msgid ""
-"§cThat players island is in the process of generating, you cannot warp to it "
-"right now."
-msgstr ""
-
 #, java-format
-msgid "§cWARNING: §9{0}§e is warping to your island!"
-msgstr ""
-
-msgid "§4That player has forbidden you from warping to their island."
-msgstr "§4玩家禁止你传送到他们的岛屿上."
-
-msgid "general island command"
-msgstr ""
-
-msgid "allows user to bypass cooldowns"
-msgstr ""
-
-msgid "allows user to bypass visitor-protections"
-msgstr ""
-
-msgid "allows user to bypass teleport-delay"
-msgstr ""
-
-msgid "allows user to use [usb] signs"
-msgstr ""
-
-msgid "allows user to place [usb] signs"
+msgid "{0}''s Wither"
 msgstr ""
 
 msgid "§eYou can not use another island''s portals!"
@@ -1699,31 +99,6 @@ msgid "§eRiding is only allowed on your own island!"
 msgstr ""
 
 msgid "§eYou cannot break vehicles while being a visitor!"
-msgstr ""
-
-msgid "§cWither Despawned!§e It wandered too far from your island."
-msgstr ""
-
-#, java-format
-msgid "{0}''s Wither"
-msgstr ""
-
-msgid "§eVisitors can't drop items!"
-msgstr ""
-
-#, java-format
-msgid "Owner: {0}"
-msgstr ""
-
-msgid "You cannot pick up other players' loot when you are a visitor!"
-msgstr ""
-
-msgid "Config:"
-msgstr ""
-
-msgid ""
-"§cNo Access! §eYou are trying to teleport to the roof of the §cNETHER§e, "
-"that is not allowed."
 msgstr ""
 
 msgid "§4You can only convert obsidian once every 10 seconds"
@@ -1768,19 +143,80 @@ msgstr ""
 msgid "§cYou have reached your spawn-limit for your island."
 msgstr ""
 
+msgid "§eVisitors can't drop items!"
+msgstr ""
+
+#, java-format
+msgid "Owner: {0}"
+msgstr ""
+
+msgid "You cannot pick up other players' loot when you are a visitor!"
+msgstr ""
+
 msgid "§cBanned:§e You are banned from this island."
 msgstr ""
 
 msgid "§cLocked:§e That island is locked! No entry allowed."
 msgstr ""
 
-#, java-format
-msgid "§eWaiting for our turn §c{0,number,###}%"
+msgid "Something went wrong saving the island and/or party data!"
+msgstr "在存储岛屿或者团队记录的时候发生了一些错误!"
+
+msgid "Converting data to UUID, this make take a while!"
+msgstr ""
+
+msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
 msgstr ""
 
 #, java-format
-msgid "§9Creating island...§e{0,number,###}%"
+msgid ""
+"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
 msgstr ""
+
+#, java-format
+msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
+msgstr ""
+
+msgid "§eYou do not have access to that island-schematic!"
+msgstr ""
+
+msgid "§4Player is already assigned to this island!"
+msgstr "§4玩家早就已经分配给这个岛屿了!"
+
+msgid "§4You must be closer to your island to set your skyblock home!"
+msgstr "§4你必须在岛屿上才能设置你的家!"
+
+msgid "§aYour skyblock home has been set to your current location."
+msgstr "§a你岛屿家的位置已经设置在你当前位置."
+
+msgid "§4Your current location is not a safe home-location."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome of your island to §9{0}§7, be "
+"patient."
+msgstr ""
+
+msgid "§cYour island is in the process of generating, you cannot create now."
+msgstr ""
+
+msgid "Could not create your Island. Please contact a server moderator."
+msgstr "无法为你创建岛屿.请联系管理员."
+
+msgid "§eGetting your island ready, please be patient, it can take a while."
+msgstr ""
+
+msgid "§cCommand is currently disabled!"
+msgstr ""
+
+#, java-format
+msgid " §f{0}x §7{1}"
+msgstr ""
+
+#, java-format
+msgid "§eStill the following blocks short: {0}"
+msgstr "§e任然缺少以下方块: {0}"
 
 #, java-format
 msgid "§9{0}§7 timed out"
@@ -1791,9 +227,6 @@ msgid ""
 "§eDoing §9{0}§e is §cRISKY§e. Repeat the command within §a{1}§e seconds to "
 "accept!"
 msgstr "§9{0}§e是§c危险的§e.请等待§a{1}§e秒后在这样做."
-
-msgid "N/A"
-msgstr ""
 
 msgid "§4** You are entering a protected - but abandoned - island area."
 msgstr ""
@@ -1826,203 +259,31 @@ msgid "§4You must be the party leader to unlock your island!"
 msgstr "§4你必须得是岛屿的主人才能解锁你的岛屿!"
 
 #, java-format
-msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgid "§eWaiting for our turn §c{0,number,###}%"
 msgstr ""
 
 #, java-format
-msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgid "§9Creating island...§e{0,number,###}%"
+msgstr ""
+
+msgid "N/A"
+msgstr ""
+
+msgid "§4§lLocked Challenge"
+msgstr "§4§l挑战锁定"
+
+msgid "READY"
 msgstr ""
 
 #, java-format
-msgid "§7PlayerDB: Filtered {0} names"
-msgstr ""
-
-#, java-format
-msgid ""
-"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
-"{6}"
-msgstr ""
-
-#, java-format
-msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
-msgstr ""
-
-msgid "SUCCESS"
-msgstr ""
-
-msgid "FAILED"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
-msgstr ""
-
-#, java-format
-msgid "§7 - MojangAPI:§cERROR: {0}"
-msgstr ""
-
-#, java-format
-msgid ""
-"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
-"~ {6}"
-msgstr ""
-
-#, java-format
-msgid "§4No importer named §e{0}§4 found"
-msgstr "§4输入的名字§e{0}§4未找到"
-
-#, java-format
-msgid "§eConverted {0}/{1} files in {2}"
-msgstr ""
-
-msgid "The island has been created."
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d locked the island."
-msgstr ""
-
-msgid "§4Since your island is locked, your incoming warp has been deactivated."
-msgstr "§4因为你的岛屿处于锁定状态,岛屿传送点也将禁用."
-
-#, java-format
-msgid "§b{0}§d unlocked the island."
-msgstr ""
-
-#, java-format
-msgid "§cSKY §f> §7 {0}"
-msgstr ""
-
-#, java-format
-msgid "§b{0}§d has been removed from the island group."
-msgstr ""
-
-#, java-format
-msgid "§9{1} §7- {0}"
-msgstr ""
-
-msgid "§9Creating an island at your location"
-msgstr ""
-
-#, java-format
-msgid "§9Creating an island §7{0}§9 of you"
+msgid "§4The {0} challenge is not available yet!"
 msgstr ""
 
 msgid ""
-"§cThe island owning this piece of nether is being deleted! Sending you to "
-"spawn."
+"§cWARNING:§e Could not transfer all the required items to your inventory!"
 msgstr ""
 
-msgid "§cThe island you are on is being deleted! Sending you to spawn."
-msgstr "§c你所处的岛屿正在被删除!将你传送到出生点."
-
-#, java-format
-msgid "§eWALL OF FAME (page {0} of {1}):"
-msgstr "§e荣誉墙 (页数 {0} - {1}):"
-
-#, java-format
-msgid "§4Top ten list is empty! Only islands above level {0} is considered."
-msgstr ""
-
-msgid "§a#%2d §7(%5.2f): §e%s §7%s"
-msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
-
-#, java-format
-msgid "§eYour rank is: §f{0}"
-msgstr "§e你的排名是: §f{0}"
-
-msgid "UNKNOWN"
-msgstr ""
-
-msgid "ANIMAL"
-msgstr ""
-
-msgid "MONSTER"
-msgstr ""
-
-msgid "VILLAGER"
-msgstr ""
-
-msgid "GOLEM"
-msgstr ""
-
-#, java-format
-msgid "§c{0}"
-msgstr ""
-
-#, java-format
-msgid "§7{0}: §a{1}§7 (max. {2})"
-msgstr ""
-
-#, java-format
-msgid "Unable to locate schematic {0}, contact a server-admin"
-msgstr ""
-
-msgid "§aCongratulations! §eYour island has appeared."
-msgstr ""
-
-msgid "§cNote:§e Construction might still be ongoing."
-msgstr ""
-
-msgid "Use §9/is h§r or the §9/is§r menu to go there."
-msgstr ""
-
-#, java-format
-msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
-msgstr ""
-
-#, java-format
-msgid "§7Page {0}"
-msgstr ""
-
-#, java-format
-msgid "§c{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a+{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "§a{0,number,#}"
-msgstr ""
-
-#, java-format
-msgid "&aLeft:&7 Increment with {0}"
-msgstr ""
-
-#, java-format
-msgid "&cRight-Click:&7 Set to {0}"
-msgstr ""
-
-msgid "Return"
-msgstr ""
-
-msgid "§9Integer Editor"
-msgstr ""
-
-msgid "§eConfiguration saved and reloaded."
-msgstr ""
-
-msgid "§cError! §9Unable to save config file!"
-msgstr ""
-
-msgid "§3First Page"
-msgstr ""
-
-msgid "§3Last Page"
-msgstr ""
-
-msgid "§cSave & Reload config"
-msgstr ""
-
-msgid ""
-"§7Saves the settings to\n"
-"§7file & reloads again.\n"
-"§cNote: §7Use with care!"
-msgstr ""
-
-msgid "§7 (readonly)"
+msgid "§cNot enough items in chest to complete challenge!"
 msgstr ""
 
 msgid "true"
@@ -2389,6 +650,10 @@ msgstr ""
 msgid "§7Current page"
 msgstr ""
 
+#, java-format
+msgid "§7Page {0}"
+msgstr ""
+
 msgid "§7First Page"
 msgstr ""
 
@@ -2642,7 +907,7 @@ msgstr ""
 msgid "Island Restart Menu"
 msgstr ""
 
-msgid "§eYou do not have access to that island-schematic!"
+msgid "Config:"
 msgstr ""
 
 #, java-format
@@ -2659,110 +924,114 @@ msgstr ""
 msgid "§aClick to restart!"
 msgstr ""
 
+#, java-format
+msgid "§c{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a+{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "§a{0,number,#}"
+msgstr ""
+
+#, java-format
+msgid "&aLeft:&7 Increment with {0}"
+msgstr ""
+
+#, java-format
+msgid "&cRight-Click:&7 Set to {0}"
+msgstr ""
+
+msgid "Return"
+msgstr ""
+
+msgid "§9Integer Editor"
+msgstr ""
+
 msgid "Caps On"
 msgstr ""
 
 msgid "§9Text Editor"
 msgstr ""
 
+msgid "§eConfiguration saved and reloaded."
+msgstr ""
+
+msgid "§cError! §9Unable to save config file!"
+msgstr ""
+
+msgid "§3First Page"
+msgstr ""
+
+msgid "§3Last Page"
+msgstr ""
+
+msgid "§cSave & Reload config"
+msgstr ""
+
+msgid ""
+"§7Saves the settings to\n"
+"§7file & reloads again.\n"
+"§cNote: §7Use with care!"
+msgstr ""
+
+msgid "§7 (readonly)"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eProgress: {0,number,##}% ({1}/{2} - success:{3}, failed:{4}, skipped:{5}) "
+"~ {6}"
+msgstr ""
+
+#, java-format
+msgid "§4No importer named §e{0}§4 found"
+msgstr "§4输入的名字§e{0}§4未找到"
+
+#, java-format
+msgid "§eConverted {0}/{1} files in {2}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtering {0} players from uuid2name.yml"
+msgstr ""
+
+#, java-format
+msgid "§7 - {0,number,##}% ({1}/{2}) ~ {3}"
+msgstr ""
+
+#, java-format
+msgid "§7PlayerDB: Filtered {0} names"
+msgstr ""
+
+#, java-format
+msgid ""
+"§7 - MojangAPI:{4}: {0,number,##}% ({1}/{2}, failed:{3} ~ {5,number,##}%), "
+"{6}"
+msgstr ""
+
+#, java-format
+msgid "§7MojangAPI: Trying to fetch {0} players from Mojang"
+msgstr ""
+
+msgid "SUCCESS"
+msgstr ""
+
+msgid "FAILED"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§aCOMPLETED: {0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - MojangAPI:§cERROR: {0}"
+msgstr ""
+
 #, java-format
 msgid "Too many requests for Mojangs API ({0} within {1}), sleeping {2}"
-msgstr ""
-
-msgid "§9Hold your horses! You have to be patient..."
-msgstr ""
-
-msgid "§9Not really patient, are you?"
-msgstr ""
-
-msgid "§9Be patient, young padawan"
-msgstr ""
-
-msgid "§9Patience you MUST have, young padawan"
-msgstr ""
-
-msgid "§9The two most powerful warriors are patience and time."
-msgstr ""
-
-msgid "§eSending you to spawn."
-msgstr ""
-
-msgid "§eThe island has been §cLOCKED§e."
-msgstr ""
-
-#, java-format
-msgid "§aYou will be teleported in {0} seconds."
-msgstr "§a将在 {0} 秒后进行传送."
-
-msgid "§7Teleport cancelled"
-msgstr ""
-
-msgid "READY"
-msgstr ""
-
-msgid ""
-"§cWARNING:§e Could not transfer all the required items to your inventory!"
-msgstr ""
-
-msgid "§cNot enough items in chest to complete challenge!"
-msgstr ""
-
-msgid "Something went wrong saving the island and/or party data!"
-msgstr "在存储岛屿或者团队记录的时候发生了一些错误!"
-
-msgid "Converting data to UUID, this make take a while!"
-msgstr ""
-
-msgid "§cMAINTENANCE:§e uSkyBlock is currently in maintenance mode"
-msgstr ""
-
-#, java-format
-msgid ""
-"§buSkyBlock§e depends on §9{0}§e >= §av{1}§e but only §cv{2}§e was found!\n"
-msgstr ""
-
-#, java-format
-msgid "§buSkyBlock§e depends on §9{0}§e >= §av{1}"
-msgstr ""
-
-msgid "§4Player is already assigned to this island!"
-msgstr "§4玩家早就已经分配给这个岛屿了!"
-
-msgid "§4Unable to find a safe home-location on your island!"
-msgstr ""
-
-msgid "§cWARNING: §eTeleporting you to mid-air."
-msgstr ""
-
-msgid "§aTeleporting you to your island."
-msgstr "§a将你传送回自己的岛屿."
-
-msgid "§4Unable to warp you to that player''s island!"
-msgstr "§4无法传送至玩家的岛屿!"
-
-#, java-format
-msgid "§aTeleporting you to {0}''s island."
-msgstr ""
-
-msgid "§4You must be closer to your island to set your skyblock home!"
-msgstr "§4你必须在岛屿上才能设置你的家!"
-
-msgid "§aYour skyblock home has been set to your current location."
-msgstr "§a你岛屿家的位置已经设置在你当前位置."
-
-msgid "§4Your current location is not a safe home-location."
-msgstr ""
-
-msgid "§cYour island is in the process of generating, you cannot create now."
-msgstr ""
-
-msgid "Could not create your Island. Please contact a server moderator."
-msgstr "无法为你创建岛屿.请联系管理员."
-
-msgid "§eGetting your island ready, please be patient, it can take a while."
-msgstr ""
-
-msgid "§cCommand is currently disabled!"
 msgstr ""
 
 msgid "North"
@@ -2787,4 +1056,1733 @@ msgid "West"
 msgstr ""
 
 msgid "North-West"
+msgstr ""
+
+msgid "The island has been created."
+msgstr ""
+
+#, java-format
+msgid "§b{0}§d locked the island."
+msgstr ""
+
+msgid "§4Since your island is locked, your incoming warp has been deactivated."
+msgstr "§4因为你的岛屿处于锁定状态,岛屿传送点也将禁用."
+
+#, java-format
+msgid "§b{0}§d deactivated the island warp."
+msgstr "§b{0}§d禁止了岛屿传送点."
+
+#, java-format
+msgid "§b{0}§d unlocked the island."
+msgstr ""
+
+#, java-format
+msgid "§cSKY §f> §7 {0}"
+msgstr ""
+
+#, java-format
+msgid "§b{0}§d has been removed from the island group."
+msgstr ""
+
+#, java-format
+msgid "§9{1} §7- {0}"
+msgstr ""
+
+msgid "§9Creating an island at your location"
+msgstr ""
+
+#, java-format
+msgid "§9Creating an island §7{0}§9 of you"
+msgstr ""
+
+msgid "§aCongratulations! §eYour island has appeared."
+msgstr ""
+
+msgid "§cNote:§e Construction might still be ongoing."
+msgstr ""
+
+msgid "Use §9/is h§r or the §9/is§r menu to go there."
+msgstr ""
+
+#, java-format
+msgid "Unable to locate schematic {0}, contact a server-admin"
+msgstr ""
+
+#, java-format
+msgid "§cWatchdog!§9 Unable to locate a chest within {0}, bailing out."
+msgstr ""
+
+msgid "UNKNOWN"
+msgstr ""
+
+msgid "ANIMAL"
+msgstr ""
+
+msgid "MONSTER"
+msgstr ""
+
+msgid "VILLAGER"
+msgstr ""
+
+msgid "GOLEM"
+msgstr ""
+
+#, java-format
+msgid "§c{0}"
+msgstr ""
+
+#, java-format
+msgid "§7{0}: §a{1}§7 (max. {2})"
+msgstr ""
+
+msgid ""
+"§cThe island owning this piece of nether is being deleted! Sending you to "
+"spawn."
+msgstr ""
+
+msgid "§cThe island you are on is being deleted! Sending you to spawn."
+msgstr "§c你所处的岛屿正在被删除!将你传送到出生点."
+
+#, java-format
+msgid "§eWALL OF FAME (page {0} of {1}):"
+msgstr "§e荣誉墙 (页数 {0} - {1}):"
+
+#, java-format
+msgid "§4Top ten list is empty! Only islands above level {0} is considered."
+msgstr ""
+
+msgid "§4Island level has been disabled, contact an administrator."
+msgstr "§4岛屿等级系统未启用,请联系管理员."
+
+msgid "§a#%2d §7(%5.2f): §e%s §7%s"
+msgstr "§a#%2d §7(%5.2f): §e%s §7%s"
+
+msgid "Click to warp to the island!"
+msgstr ""
+
+#, java-format
+msgid "§eYour rank is: §f{0}"
+msgstr "§e你的排名是: §f{0}"
+
+#, java-format
+msgid "§7Complete {0} more {1} §7challenges"
+msgstr ""
+
+#, java-format
+msgid "§7Complete {0}"
+msgstr ""
+
+msgid "to unlock this rank"
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this {0} more time(s)."
+msgstr ""
+
+#, java-format
+msgid "§4Requirements will reset in {0} days."
+msgstr "§4需求将在 {0} 天后重置."
+
+#, java-format
+msgid "§4Requirements will reset in {0} hours."
+msgstr "§4需求将在 {0} 小时后重置"
+
+#, java-format
+msgid "§4Requirements will reset in {0} minutes."
+msgstr "§4需求将在 {0} 分钟后重置"
+
+msgid "§4This challenge is currently unavailable."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} days."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} hours."
+msgstr ""
+
+#, java-format
+msgid "§4You can complete this again in {0} minutes."
+msgstr ""
+
+msgid "§eThis challenge requires:"
+msgstr ""
+
+msgid "§7and more..."
+msgstr ""
+
+msgid "§eItems will be traded for reward."
+msgstr ""
+
+#, java-format
+msgid "§eMust be within {0} meters."
+msgstr ""
+
+msgid "§6Item Reward: §a"
+msgstr "§6物品奖励:"
+
+#, java-format
+msgid "§6Currency Reward: §a{0}"
+msgstr "§6货币奖励: §a{0}"
+
+#, java-format
+msgid "§6Exp Reward: §a{0}"
+msgstr "§6经验奖励: §a{0}"
+
+#, java-format
+msgid "§dTotal times completed: §f{0}"
+msgstr "§d总完成次数: §f{0}"
+
+#, java-format
+msgid "§7Requires {0}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} found"
+msgstr ""
+
+msgid "§4You must be on your island to do that!"
+msgstr "§4你必须在你的岛屿上才能这样做!"
+
+#, java-format
+msgid "§4The {0} challenge is not repeatable!"
+msgstr "§4挑战:§e{0} §4不可重复完成!"
+
+#, java-format
+msgid "§4You cannot complete the {0} challenge again yet!"
+msgstr ""
+
+#, java-format
+msgid "§eTrying to complete challenge §a{0}"
+msgstr ""
+
+#, java-format
+msgid "§4{0}"
+msgstr "§4{0}"
+
+#, java-format
+msgid "§4You must be standing within {0} blocks of all required items."
+msgstr "§4在你周围 {0} 格以内必须包含挑战所需物品。"
+
+#, java-format
+msgid "§4Your island must be level {0} to complete this challenge!"
+msgstr "§4您的岛屿必须达到 {0} 级,才能完成当前挑战!"
+
+#, java-format
+msgid "§4Unknown type of challenge: {0}"
+msgstr "§4未知难度的挑战: {0}"
+
+#, java-format
+msgid ""
+"§eStill the following entities short:\n"
+"{0}"
+msgstr ""
+"§e任然缺少以下物品:\n"
+"{0}"
+
+#, java-format
+msgid " §4{0} §b{1}"
+msgstr ""
+
+#, java-format
+msgid "§eYou are the following items short:{0}"
+msgstr "§e你缺少以下物品: {0}"
+
+#, java-format
+msgid "§aYou have completed the {0} challenge!"
+msgstr "§a你完成了挑战:§e {0}"
+
+#, java-format
+msgid "§9{0}§f has completed the §9{1}§f challenge!"
+msgstr ""
+
+#, java-format
+msgid "§eItem reward(s): §f{0}"
+msgstr "§e物品奖励: §f{0}"
+
+#, java-format
+msgid "§eExp reward: §f{0,number,#.#}"
+msgstr "§e经验奖励: §f{0,number,#.#}"
+
+#, java-format
+msgid "§eCurrency reward: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+msgstr "§e货币奖励: §f{0,number,###.##} {1} §a ({2,number,##.##})%"
+
+msgid "§eYour inventory is §4full§e. Items dropped on the ground."
+msgstr "§e背包§4已满§e。奖励物品掉落到了地上。"
+
+msgid "§e§lClick to complete this challenge."
+msgstr "§e§l点击来完成这个挑战。"
+
+msgid "§4§lYou can't repeat this challenge."
+msgstr "§4§l你无法重复完成这个挑战。"
+
+#, java-format
+msgid "Rank: {0}"
+msgstr ""
+
+msgid "§fComplete most challenges in"
+msgstr "§f完成大部分挑战在"
+
+msgid "§fthis rank to unlock the next rank."
+msgstr "§f这个难度中，才能解锁下一个等级。"
+
+msgid "§eClick here to show previous page"
+msgstr ""
+
+msgid "§eClick here to show next page"
+msgstr ""
+
+msgid "But you are ALLLLLLL ALOOOOONE!"
+msgstr ""
+
+msgid "But you are Yelling in the wind!"
+msgstr ""
+
+msgid "But your fantasy friends are gone!"
+msgstr ""
+
+msgid "But you are Talking to your self!"
+msgstr ""
+
+#, java-format
+msgid "§cSorry! {0}"
+msgstr ""
+
+msgid "Either send a message directly to your group, or toggle it on/off."
+msgstr ""
+
+msgid "party"
+msgstr ""
+
+msgid "island"
+msgstr ""
+
+#, java-format
+msgid "§cToggled chat to {0} §aON"
+msgstr ""
+
+#, java-format
+msgid "§cRepeat §9{0}§c to toggle it off"
+msgstr ""
+
+#, java-format
+msgid "§aToggled chat §cOFF§a for {0}"
+msgstr ""
+
+msgid "§cCommand only available to players"
+msgstr ""
+
+msgid "talk to your island party"
+msgstr ""
+
+msgid "talk to players on your island"
+msgstr ""
+
+msgid "manually update the top 10 list"
+msgstr ""
+
+msgid "§eGenerating the Top Ten list"
+msgstr "§e生存排行榜前十名单"
+
+msgid "§eFinished generation of the Top Ten list"
+msgstr "§e排行榜前十名单生成完毕"
+
+msgid "purges all abandoned islands"
+msgstr ""
+
+msgid "§4You must provide the age in days to purge!"
+msgstr "§4你必须指定一个天数来删除。"
+
+msgid "§4The level must be a valid number"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFinding all islands that have been abandoned for more than {0} days below "
+"level {1}"
+msgstr ""
+
+#, java-format
+msgid "§4PURGE:§e Do §9usb purge confirm§e within {0} to accept."
+msgstr ""
+
+msgid "§4Trying to abort purge"
+msgstr ""
+
+msgid "§4Purge aborted!"
+msgstr ""
+
+msgid "§4A purge is already running.§e Either §9confirm§e or §9stop§e it."
+msgstr ""
+
+msgid "§4Starting purge..."
+msgstr ""
+
+msgid "Controls player-cooldowns"
+msgstr ""
+
+msgid "clears the cooldown on a command (* = all)"
+msgstr ""
+
+msgid "§eThe player is not currently online"
+msgstr "§e玩家未在线"
+
+#, java-format
+msgid "Cleared cooldown on {0} for {1}"
+msgstr "清除冷却时间在{0} ~ {1}"
+
+#, java-format
+msgid "No active cooldown on {0} for {1} detected!"
+msgstr "在{0} ~ {1} 之间没有活跃的冷却时间"
+
+msgid "Invalid command supplied, only restart and biome supported!"
+msgstr "无效的命令,只支持restart 和 biome"
+
+msgid "restarts the cooldown on the command"
+msgstr ""
+
+#, java-format
+msgid "§eReset cooldown on {0} for {1}§e to {2} seconds"
+msgstr "§e重置冷却时间在{0} ~ {1} §e ~ {2} 秒"
+
+msgid "lists all the active cooldowns"
+msgstr ""
+
+msgid "§eCmd Cooldown"
+msgstr "§e 指令冷却时间"
+
+#, java-format
+msgid "§a{0} §c{1}"
+msgstr "§a{0} §c{1}"
+
+#, java-format
+msgid "§eNo active cooldowns for §9{0}§e found."
+msgstr "§e没有活跃的冷却时间 §9{0} 被找到"
+
+msgid "toggles maintenance mode"
+msgstr ""
+
+msgid "§cMAINTENANCE: §aActivated§e all uSkyBlock features currently disabled."
+msgstr ""
+
+msgid ""
+"§cMAINTENANCE: §4Deactivated§e all uSkyBlock features back to operational."
+msgstr ""
+
+msgid "§cMaintenance mode can only be changed from console!"
+msgstr ""
+
+msgid "controls async jobs"
+msgstr ""
+
+msgid "§9Job Statistics"
+msgstr ""
+
+msgid "§7----------------"
+msgstr ""
+
+msgid "#"
+msgstr ""
+
+msgid "ms/job"
+msgstr ""
+
+msgid "ms/tick"
+msgstr ""
+
+msgid "ticks"
+msgstr ""
+
+msgid "act"
+msgstr ""
+
+msgid "time"
+msgstr ""
+
+msgid "name"
+msgstr ""
+
+#, java-format
+msgid "§ePlayer {0} has no island!"
+msgstr "§e玩家 {0} 还未获得岛屿!"
+
+#, java-format
+msgid "§eInvalid player {0} supplied."
+msgstr "§e无效的玩家 {0}"
+
+msgid "flushes all caches to files"
+msgstr ""
+
+#, java-format
+msgid ""
+"§eFlushed §a{0} islands§e, §b{1} players and §6{2} challenge-completions."
+msgstr ""
+
+msgid "tries to fix the the area of flatland."
+msgstr ""
+
+msgid "§4No valid island found"
+msgstr "§4没有找到有效的岛屿"
+
+#, java-format
+msgid "§4No flatland detected at {0}''s island!"
+msgstr "§4在{0} 的岛上未检测到平地。"
+
+msgid "manage orphans"
+msgstr ""
+
+msgid "count orphans"
+msgstr ""
+
+#, java-format
+msgid "§e{0} old island locations will be used before new ones."
+msgstr "§e{0} 旧的岛屿位置将会被新岛屿所替换。"
+
+msgid "clear orphans"
+msgstr ""
+
+msgid "§eClearing all old (empty) island locations."
+msgstr "§e清除所有旧(空)的岛屿坐标。"
+
+msgid "list orphans"
+msgstr ""
+
+msgid "§eNo orphans currently registered."
+msgstr ""
+
+#, java-format
+msgid "§eOrphans ({0}/{1}): {2}"
+msgstr ""
+
+msgid "transfer leadership to another player"
+msgstr ""
+
+#, java-format
+msgid "§4Player {0} has no island to transfer!"
+msgstr "§4玩家 {0} 没有能够转让的岛屿!"
+
+#, java-format
+msgid ""
+"§ePlayer §d{0}§e already has an island.§eUse §d/usb island remove <name>§e "
+"to remove him first."
+msgstr ""
+"§e玩家 §d{0} §e早就拥有了岛屿。§e输入§d/usb island remove <玩家名>§e将他移"
+"除。"
+
+#, java-format
+msgid "§bLeadership transferred by {0}§b to {1}"
+msgstr "§b岛屿主人由{0} 变更为{1}"
+
+msgid "open GUI for config"
+msgstr ""
+
+msgid "searches config for a specific key"
+msgstr ""
+
+#, java-format
+msgid "§c{0}§9"
+msgstr ""
+
+#, java-format
+msgid "§9{0}§8: §e{1}"
+msgstr ""
+
+#, java-format
+msgid "Found the following matching {0}:"
+msgstr ""
+
+msgid "§a<section>"
+msgstr ""
+
+#, java-format
+msgid "§3{0,number,#.##}"
+msgstr ""
+
+#, java-format
+msgid "§2{0}"
+msgstr ""
+
+msgid "§eInvalid configuration name"
+msgstr ""
+
+msgid "teleport to another players island"
+msgstr ""
+
+msgid "§4Only supported for players"
+msgstr "§4近支持玩家"
+
+msgid "§4That player does not have an island!"
+msgstr "§4玩家仍未拥有岛屿。"
+
+#, java-format
+msgid "§aTeleporting to {0}''s island."
+msgstr ""
+
+msgid "various WorldGuard utilities"
+msgstr ""
+
+msgid "refreshes the chunks around the player"
+msgstr ""
+
+msgid "§eResending chunks to the client"
+msgstr "§e重新发送区块数据至客户端"
+
+msgid "load the region chunks"
+msgstr ""
+
+#, java-format
+msgid "§eLoading chunks at {0}"
+msgstr "§e加载区块在{0}"
+
+#, java-format
+msgid "§eUnloading chunks at {0}"
+msgstr "§e卸载区块在{0}"
+
+msgid "update the WG regions"
+msgstr ""
+
+#, java-format
+msgid "§eIsland world-guard regions updated for {0}"
+msgstr ""
+
+msgid "§eNo island found at your location!"
+msgstr ""
+
+msgid "refreshes the chunk around the player"
+msgstr ""
+
+msgid "region manipulations"
+msgstr ""
+
+msgid "shows the borders of the current island"
+msgstr ""
+
+msgid "§eNo island found at your current location"
+msgstr ""
+
+msgid "§eCan only be executed as a player"
+msgstr ""
+
+msgid "shows the borders of the current chunk"
+msgstr ""
+
+msgid "shows the borders of the inner-chunks"
+msgstr ""
+
+msgid "shows the non-chunk-aligned borders"
+msgstr ""
+
+msgid "shows the borders of the outer-chunks"
+msgstr ""
+
+msgid "hides the regions again"
+msgstr ""
+
+msgid "§eStopped displaying regions"
+msgstr ""
+
+msgid "§eNo currently shown regions for this player"
+msgstr ""
+
+msgid "set the ticks between animations"
+msgstr ""
+
+#, java-format
+msgid "§eAnimation-tick changed to {0}."
+msgstr ""
+
+msgid "§eAnimation-tick must be a valid integer."
+msgstr ""
+
+msgid "refreshes the existing animations"
+msgstr ""
+
+#, java-format
+msgid ""
+"- PURGING: {0,number,##}% ({1}/{2}), elapsed {3}, estimated completion ~{4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Finished purging abandoned islands."
+msgstr ""
+
+msgid "§4PURGE:§9 Aborted purging abandoned islands."
+msgstr ""
+
+#, java-format
+msgid "§7- SCANNING: {0,number,##}% ({1}/{2} failed: {3}) ~ {4}"
+msgstr ""
+
+msgid "§4PURGE:§9 Scanning aborted."
+msgstr ""
+
+#, java-format
+msgid ""
+"§4PURGE:§9 Scanning done, found {0} candidates, below level {1}, ready for "
+"purgatory."
+msgstr ""
+
+msgid "§cABORTED:§e Protect-All was aborted!"
+msgstr ""
+
+#, java-format
+msgid "§eCompleted protect-all in {0}, {1} new regions were created!"
+msgstr ""
+
+msgid "control debugging"
+msgstr ""
+
+msgid "set debug-level"
+msgstr ""
+
+msgid "toggle debug-logging"
+msgstr ""
+
+msgid "§4Logging wasn't active, so you can't disable it!"
+msgstr "§4记录未启用,所以你无法关闭。"
+
+msgid "flush current content of the logger to file."
+msgstr ""
+
+msgid "§eLog-file has been flushed."
+msgstr "§e日志文件已经更新。"
+
+msgid "§4Logging is not enabled, use §d/usb debug enable"
+msgstr "§4记录未启用，输入§d/usb debug 启用"
+
+msgid "§4Invalid argument, try INFO, FINE, FINER, FINEST"
+msgstr "§4未知参数，请尝试 INFO, FINE, FINER, FINEST"
+
+msgid "§eLogging disabled!"
+msgstr "§e记录已经关闭"
+
+msgid "advanced command for setting island-data"
+msgstr ""
+
+#, java-format
+msgid "§c{0} was set to ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to set field {0} to ''{1}'', a number was expected"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid field {0}"
+msgstr ""
+
+#, java-format
+msgid "§eCurrent value for {0} is ''{1}''"
+msgstr ""
+
+#, java-format
+msgid "§cUnable to get state for {0}"
+msgstr ""
+
+#, java-format
+msgid "§eValid fields are {0}"
+msgstr ""
+
+msgid "set a player''s island to your location"
+msgstr ""
+
+#, java-format
+msgid "§aSet {0}''s island to the current island."
+msgstr ""
+
+msgid "§4Island not found: unable to set the island!"
+msgstr ""
+
+msgid "advanced info about NBT stuff"
+msgstr ""
+
+msgid "shows the NBTTag for the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eInfo for §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - name: §9{0}"
+msgstr ""
+
+#, java-format
+msgid "§7 - nbttag: §9{0}"
+msgstr ""
+
+msgid "§cNo item in hand!"
+msgstr ""
+
+msgid "sets the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eSet §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "adds the NBTTag on the currently held item"
+msgstr ""
+
+#, java-format
+msgid "§eAdded §9{0}§e to §c{1}"
+msgstr ""
+
+msgid "Manage challenges for a player"
+msgstr ""
+
+msgid "resets the challenge for the player"
+msgstr ""
+
+msgid "§4Challenge has never been completed"
+msgstr "§4挑战从未完成过"
+
+#, java-format
+msgid "§echallenge: {0} has been reset for {1}"
+msgstr "§e挑战: {0} 已经为玩家 {1} 重置"
+
+msgid "resets all challenges for the player"
+msgstr ""
+
+#, java-format
+msgid "§e{0} has had all challenges reset."
+msgstr "§e{0} 的所有挑战已经重置"
+
+msgid "complete all challenges in the rank"
+msgstr ""
+
+#, java-format
+msgid "§4No player named {0} was found!"
+msgstr "§4没有名字为 {0} 的玩家被找到"
+
+#, java-format
+msgid "§4Challenge {0} has already been completed"
+msgstr ""
+
+#, java-format
+msgid "§eChallenge {0} has been completed for {1}"
+msgstr ""
+
+#, java-format
+msgid "§4No challenge named {0} was found!"
+msgstr "§4挑战: {0} 未找到!"
+
+#, java-format
+msgid "§4No rank named {0} was found!"
+msgstr ""
+
+msgid "various chunk commands"
+msgstr ""
+
+msgid "regenerate current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully regenerated chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not regenerate chunk at {0},{1}"
+msgstr ""
+
+msgid "unload current chunk"
+msgstr ""
+
+#, java-format
+msgid "successfully unloaded chunk at {0},{1}"
+msgstr ""
+
+#, java-format
+msgid "§4FAILED!§e could not unload chunk at {0},{1}"
+msgstr ""
+
+msgid "load current chunk"
+msgstr ""
+
+#, java-format
+msgid "loaded chunk at {0},{1}"
+msgstr ""
+
+msgid "only available for players"
+msgstr ""
+
+#, java-format
+msgid "§4ERROR:§e {0}"
+msgstr ""
+
+msgid "protects all islands (time consuming)"
+msgstr ""
+
+msgid "§cTrying to abort protect-all task."
+msgstr ""
+
+msgid ""
+"§4Sorry!§e A protect-all is already running. Let it complete first, or use "
+"§9usb protectall §cstop"
+msgstr ""
+
+msgid "§eStarting a protect-all task. It will take a while."
+msgstr "§e开始执行 全局保护,将会花费一定时间。"
+
+msgid "reload configuration from file."
+msgstr ""
+
+msgid "§eConfiguration reloaded from file."
+msgstr "§e配置重读。"
+
+msgid "manage islands"
+msgstr ""
+
+msgid "protects the island"
+msgstr ""
+
+msgid "delete the island (removes the blocks)"
+msgstr ""
+
+msgid "§9Deleted abandoned island at your current location."
+msgstr "§9你当前位置的岛屿已经删除。"
+
+msgid ""
+"§4Island at this location has members!\n"
+"§eUse §9/usb island delete <name>§e to delete it."
+msgstr ""
+"§4当前位置的岛屿拥有其他的成员!\n"
+"§e输入§9/usb island delete <玩家名> §e来删除"
+
+msgid "removes the player from the island"
+msgstr ""
+
+msgid "adds the player to the island"
+msgstr ""
+
+#, java-format
+msgid "§b{0}§d has joined your island group."
+msgstr "§b{0}§d加入了你的岛屿团队。"
+
+#, java-format
+msgid "§4No player named {0} found!"
+msgstr ""
+
+msgid ""
+"§4No valid island provided, either stand within one, or provide an island "
+"name"
+msgstr ""
+
+msgid "print out info about the island"
+msgstr ""
+
+msgid "sets the biome of the island"
+msgstr ""
+
+msgid "§4That player has no island."
+msgstr "§4玩家仍未拥有岛屿。"
+
+msgid "§4No valid island at your location"
+msgstr "§4无效的岛屿在你的位置上。"
+
+msgid "purges the island"
+msgstr ""
+
+msgid "§4Error! §9No valid island found for purging."
+msgstr ""
+
+#, java-format
+msgid "§cPURGE: §9Purged island at {0}"
+msgstr ""
+
+msgid "toggles the islands ignore status"
+msgstr ""
+
+#, java-format
+msgid "§cSet {0}s island to be ignored on top-ten and purge."
+msgstr ""
+
+#, java-format
+msgid ""
+"§cRemoved ignore-flag of {0}s island, it will now show up on top-ten and "
+"purge."
+msgstr ""
+
+msgid "§4No valid player-name supplied."
+msgstr "§4无效的玩家名"
+
+#, java-format
+msgid "Removing {0} from island"
+msgstr "从岛屿上移除了 {0}"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to {1}."
+msgstr "§e将 {0} 的岛屿的生物群系更改为 {1}"
+
+#, java-format
+msgid "§eChanged biome of {0}s island to OCEAN."
+msgstr ""
+
+msgid "§aYou may need to go to spawn, or relog, to see the changes."
+msgstr "§a你需要返回出生点,或者重新登录才能看到改变。"
+
+#, java-format
+msgid "§e{0} has had their biome changed to {1}."
+msgstr "§e{0} 将他们的生物群系更改为了 {1}"
+
+#, java-format
+msgid "§e{0} has had their biome changed to OCEAN."
+msgstr "§e{0} 将他们的生物群系更改为了 OCEAN(海洋生物群系)"
+
+#, java-format
+msgid "§eRemoving {0}''s island."
+msgstr "§e移除了 {0} 的岛屿。"
+
+msgid "Error: That player does not have an island!"
+msgstr "错误: 玩家未拥有岛屿。"
+
+#, java-format
+msgid "§e{0}s island at {1} has been protected"
+msgstr "§e{0} 的岛屿在 {1} 被保护"
+
+#, java-format
+msgid "§4{0}s island at {1} was already protected"
+msgstr ""
+
+msgid "displays version information"
+msgstr ""
+
+msgid "imports players and islands from other formats"
+msgstr ""
+
+msgid "shows perk-information"
+msgstr ""
+
+msgid "shows a specific players perks"
+msgstr ""
+
+#, java-format
+msgid "additional perks {0}"
+msgstr ""
+
+msgid "changes the language of the plugin, and reloads"
+msgstr ""
+
+#, java-format
+msgid "§aSuccessfully changed language to §e{0}"
+msgstr ""
+
+#, java-format
+msgid "§cFailed to change language to §e{0}"
+msgstr ""
+
+msgid "§9Supported Languages:\n"
+msgstr ""
+
+#, java-format
+msgid "§f{0} §7{1} §9 by {2} §7{3}\n"
+msgstr ""
+
+msgid "§cUnable to locate any languages."
+msgstr ""
+
+msgid "advanced command for getting island-data"
+msgstr ""
+
+msgid "Ultimate SkyBlock Admin"
+msgstr ""
+
+msgid "show player-information"
+msgstr ""
+
+msgid ""
+"§4Your island is full, or you have too many pending invites. You can't "
+"invite anyone else."
+msgstr "§4你的岛屿已经满员,或者你有太多等待邀请请求。你无法再邀请其他人。"
+
+msgid "§4That player is already leader on another island."
+msgstr "§4那个玩家早就是另外岛屿的主人了。"
+
+#, java-format
+msgid "§e{0}§e tried to invite you, but you are already in a party."
+msgstr "§e{0}§e 尝试邀请你加入他的岛屿,但是你早就在其他团队了。"
+
+#, java-format
+msgid "§aInvite sent to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0}§e has invited you to join their island!"
+msgstr "{0}§e邀请你加入他们的岛屿。"
+
+msgid "§f/island [accept/reject]§e to accept or reject the invite."
+msgstr "§f/island [accept/reject]§e 接受或者拒绝一个邀请。"
+
+msgid "§4WARNING: You will lose your current island if you accept!"
+msgstr "§4警告: 你当前的岛屿将会被清空,如果你接受请求的话。"
+
+#, java-format
+msgid "{0}§d invited {1}"
+msgstr "{0}§d邀请了{1}"
+
+#, java-format
+msgid "{0}§e has rejected the invitation."
+msgstr "{0}§e拒绝了邀请"
+
+msgid "§4You can't use that command right now. Leave your current party first."
+msgstr "§4你无法使用当前命令。请先离开你当前的团队。"
+
+msgid ""
+"§aYou have joined an island! Use /island party to see the other members."
+msgstr "§a你加入了一个岛屿!输入/island party 来查看团队成员。"
+
+#, java-format
+msgid "§eInvitation for {0}§e has timedout or been cancelled."
+msgstr "§e来自{0}§e的邀请已经过时或被取消。"
+
+#, java-format
+msgid "§eInvitation for {0}''s island has timedout or been cancelled."
+msgstr "§e来自{0}§e岛屿的邀请已经过时或被取消。"
+
+msgid "§eYou have accepted the invitation to join an island."
+msgstr "§e你接受了加入岛屿的邀请."
+
+msgid "§4You haven't been invited."
+msgstr "§4你没有被任何人邀请."
+
+msgid "§eYou have rejected the invitation to join an island."
+msgstr "§e你拒接了加入岛屿的邀请"
+
+msgid "general island command"
+msgstr ""
+
+msgid "allows user to bypass cooldowns"
+msgstr ""
+
+msgid "allows user to bypass visitor-protections"
+msgstr ""
+
+msgid "allows user to bypass teleport-delay"
+msgstr ""
+
+msgid "allows user to use [usb] signs"
+msgstr ""
+
+msgid "allows user to place [usb] signs"
+msgstr ""
+
+msgid "complete and list challenges"
+msgstr ""
+
+msgid "§cCommand only available for players."
+msgstr ""
+
+msgid "§eChallenges has been disabled. Contact an administrator."
+msgstr "§e挑战不可用,请联系服务器管理员."
+
+msgid "§4You can only submit challenges in the skyblock world!"
+msgstr "§4你只能在空岛世界提交挑战。"
+
+msgid "§4You can only submit challenges when you have an island!"
+msgstr "§4你只能在拥有一个岛屿的情况下提交挑战。"
+
+msgid "warp to another player''s island"
+msgstr ""
+
+msgid "§aYour incoming warp is active, players may warp to your island."
+msgstr "§a你启用了传送点,玩家可以传送到你的岛屿上了."
+
+msgid "§4Your incoming warp is inactive, players may not warp to your island."
+msgstr "§4你禁用了传送点,玩家无法传送到你的岛屿上."
+
+msgid "§fSet incoming warp to your current location using §e/island setwarp"
+msgstr "§f设置岛屿传送点在你当前位置上请收入与§e/island setwarp"
+
+msgid "§fToggle your warp on/off using §e/island togglewarp"
+msgstr "§f启用/禁止岛屿的传送点请输入§e/island togglewarp"
+
+msgid "§4You do not have permission to create a warp on your island!"
+msgstr "§4你就没有权限在你的岛屿上创建一个传送点!"
+
+msgid "§fWarp to another island using §e/island warp <player>"
+msgstr "§f传送到别人的岛屿请输入§e/island warp <玩家ID>"
+
+msgid "§4You do not have permission to warp to other islands!"
+msgstr "§4你没有权限传送到其他玩家的岛屿上"
+
+msgid ""
+"§cYour island is in the process of generating, you cannot warp to other "
+"players islands right now."
+msgstr ""
+
+msgid "§4That player does not exist!"
+msgstr "§4玩家不存在!"
+
+msgid "§4That player does not have an active warp."
+msgstr "§4玩家未拥有激活的传送点."
+
+msgid ""
+"§cThat players island is in the process of generating, you cannot warp to it "
+"right now."
+msgstr ""
+
+#, java-format
+msgid "§cWARNING: §9{0}§e is warping to your island!"
+msgstr ""
+
+msgid "§4That player has forbidden you from warping to their island."
+msgstr "§4玩家禁止你传送到他们的岛屿上."
+
+msgid "§4No Island. §eUse §b/is create§e to get one"
+msgstr "§4未拥有岛屿.§e输入§b/is create§e创建一个岛屿"
+
+msgid "accept/reject an invitation."
+msgstr ""
+
+msgid "leave your party"
+msgstr ""
+
+msgid ""
+"§4You can't leave your island if you are the only person. Try using /island "
+"restart if you want a new one!"
+msgstr ""
+"§4如果你是岛屿上唯一的成员,你将无法离开岛屿.如果你想重新开始,输入§e/island "
+"restart"
+
+msgid "§eYou own this island, use /island remove <player> instead."
+msgstr "§e你拥有了当前岛屿,输入/island remove <玩家ID> 来取代他"
+
+msgid "§eYou have left the island and returned to the player spawn."
+msgstr "§e你离开了当前岛屿,并且传送到了玩家出生点."
+
+#, java-format
+msgid "§4{0} has left your island!"
+msgstr "§4{0}离开了你的岛屿!"
+
+msgid "§4You must be in the skyblock world to leave your party!"
+msgstr "§4你必须在岛屿世界才能离开你的团队!"
+
+msgid "check your or anothers island level"
+msgstr ""
+
+msgid "allows user to query for others levels"
+msgstr ""
+
+msgid "§eYou must be on your island to use this command."
+msgstr "§e你必须在你的岛屿上来使用这个指令."
+
+msgid "§4You do not have an island!"
+msgstr "§4你还未拥有一个岛屿!"
+
+msgid "§4You do not have access to that command!"
+msgstr "§4你没有权限使用这个指令!"
+
+msgid "§4That player is invalid or does not have an island!"
+msgstr "§4玩家不存在或仍未拥有一个岛屿!"
+
+#, java-format
+msgid "§eInformation about {0}''s Island:"
+msgstr ""
+
+#, java-format
+msgid "§aIsland level is {0,number,###.##}"
+msgstr "§a岛屿等级: {0,number,###.##}"
+
+#, java-format
+msgid "§9Rank is {0}"
+msgstr "§9排名: {0}"
+
+#, java-format
+msgid "§4Could not locate rank of {0}"
+msgstr ""
+
+msgid "create an island"
+msgstr ""
+
+msgid "exempt player from create-cooldown"
+msgstr ""
+
+msgid ""
+"§4Island found!§e You already have an island. If you want a fresh island, "
+"type§b /is restart§e to get one"
+msgstr ""
+"§4岛屿已存在!§e你早就拥有一个岛屿了.如果你想要一个权限的岛屿，输入§b /is "
+"restart §e来重新开始岛屿生涯."
+
+msgid ""
+"§4Island found!§e You are already a member of an island. To start your own, "
+"first§b /is leave"
+msgstr ""
+"§4岛屿已存在!§e你已经加入了一个岛屿.如果你想开始一个属于自己的岛屿生涯，请先"
+"输入§b /is leave §e来离开当前团队."
+
+#, java-format
+msgid "§eYou can create a new island in {0,number,#} seconds."
+msgstr "§e你需要等待{0,number,#}秒才能创建一个新的岛屿."
+
+msgid "invite a player to your island"
+msgstr ""
+
+msgid ""
+"§eUse§f /island invite <playername>§e to invite a player to your island."
+msgstr "§e驶入§f/island invite <玩家ID> §e邀请玩家加入你的岛屿."
+
+msgid "§4Only the island''s owner can invite!"
+msgstr "§4只有岛屿的主人才能邀请!"
+
+#, java-format
+msgid "§aYou can invite {0} more players."
+msgstr "§a你还能邀请{0}个玩家"
+
+msgid "§4You can't invite any more players."
+msgstr "§4你无法邀请更多的玩家了."
+
+msgid "§4You do not have permission to invite others to this island!"
+msgstr "§4你没有在这个岛屿上邀请别人的权限!"
+
+msgid "§4That player is offline or doesn't exist."
+msgstr "§4玩家未在线或不存在."
+
+msgid "§4You can't invite yourself!"
+msgstr "§4你无法邀请你自己!"
+
+msgid "§4That player is the leader of your island!"
+msgstr "§4玩家是你当前所处岛屿的主人!"
+
+msgid "lock your island to non-party members."
+msgstr ""
+
+msgid "§4You do not have permission to lock your island!"
+msgstr "§4你没有权限锁定你的岛屿!"
+
+msgid "§4You don't have access to this command!"
+msgstr "§4你无法使用当前指令。"
+
+msgid "§4You do not have permission to unlock your island!"
+msgstr "§4你没有权限解锁你的岛屿!"
+
+msgid "display the top10 of islands"
+msgstr ""
+
+msgid "enables user to all-ways generate top-ten (no caching)"
+msgstr ""
+
+msgid "remove a member from your island."
+msgstr ""
+
+msgid "§4You do not have permission to kick others from this island!"
+msgstr "§4你没有在当前岛屿踢出玩家的权限!"
+
+msgid "§4You can't remove the leader from the Island!"
+msgstr "§4你无法将岛屿的主人移除!"
+
+msgid "§4Stop kickin' yourself!"
+msgstr "§4请不要尝试踢出你自己!"
+
+#, java-format
+msgid "§4{0} has removed you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} has been removed from the island."
+msgstr "§4{0}被从当前岛屿上移除."
+
+#, java-format
+msgid "§4{0} tried to kick you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} is exempt from being kicked."
+msgstr ""
+
+#, java-format
+msgid "§4{0} has kicked you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} has been kicked from the island."
+msgstr "§4{0}被从当前岛屿上踢出."
+
+msgid "§4That player is not part of your island group, and not on your island!"
+msgstr "§4玩家不是你岛屿上的一员,并且不在你的岛屿上!"
+
+msgid "teleport to the island home"
+msgstr ""
+
+msgid ""
+"§cYour island is in the process of generating, you cannot teleport home "
+"right now."
+msgstr ""
+
+msgid "§4This command can only be executed by a player"
+msgstr "§4这个指令只能由玩家来执行."
+
+msgid "transfer leadership to another member"
+msgstr ""
+
+msgid "§4You can only transfer ownership to party-members!"
+msgstr "§4你只能将岛屿主人的权限转移给他们的成员玩家!"
+
+#, java-format
+msgid "{0}§e is already leader of your island!"
+msgstr "{0}§e早就是你们岛屿的成员了!"
+
+msgid "§4Only leader can transfer leadership!"
+msgstr "§4只有岛屿的主人才能转移权限!"
+
+#, java-format
+msgid "{0} tried to take over the island!"
+msgstr "{0}试图接管当前岛屿!"
+
+msgid "show party information"
+msgstr ""
+
+msgid "shows information about your party"
+msgstr ""
+
+msgid "show pending invites"
+msgstr ""
+
+msgid "§eNo pending invites"
+msgstr "§e没有等待的邀请"
+
+msgid "withdraw an invite"
+msgstr ""
+
+msgid "§4You don't have permissions to uninvite players."
+msgstr ""
+
+msgid "check your or another''s island info"
+msgstr ""
+
+msgid "allows user to see others island info"
+msgstr ""
+
+msgid "§4Hold your horses! §eYou have to be patient..."
+msgstr ""
+
+#, java-format
+msgid "§eBlocks on {0}s Island (page {1,number} of {2,number}):"
+msgstr "eBlocks on {0}s Island (page {1,number} of {2,number}):"
+
+msgid "Score Count Block"
+msgstr "计分方块"
+
+#, java-format
+msgid "{0,number,00.00}  {1,number,#} {2}"
+msgstr ""
+
+msgid "trust/untrust a player to help on your island."
+msgstr ""
+
+msgid "§eThe following players are trusted on your island:"
+msgstr ""
+
+msgid "§eThe following leaders trusts you:"
+msgstr ""
+
+msgid "§eTo trust/untrust from your island, use /island trust <player>"
+msgstr ""
+
+msgid "§4Members are already trusted!"
+msgstr ""
+
+#, java-format
+msgid "§4Unknown player {0}"
+msgstr ""
+
+#, java-format
+msgid "§eYou are now trusted on §4{0}''s §eisland."
+msgstr ""
+
+#, java-format
+msgid "§a{0} trusted {1} on the island"
+msgstr ""
+
+#, java-format
+msgid "§eYou are no longer trusted on §4{0}''s §eisland."
+msgstr ""
+
+#, java-format
+msgid "§c{0} revoked trust in {1} on the island"
+msgstr ""
+
+msgid "delete your island and start a new one."
+msgstr ""
+
+msgid "exempt player from restart-cooldown"
+msgstr ""
+
+msgid ""
+"§4Only the owner may restart this island. Leave this island in order to "
+"start your own (/island leave)."
+msgstr ""
+"§4只有岛屿的主人才能重新开始岛屿.离开当前岛屿开始属于你自己的岛屿生涯请输入(/"
+"island leave)"
+
+msgid ""
+"§eYou must remove all players from your island before you can restart it (/"
+"island kick <player>). See a list of players currently part of your island "
+"using /island party."
+msgstr ""
+"§e想要重新开始你的岛屿，你必须移除所有岛屿成员(/island kick <玩家ID>).查看当"
+"前岛屿玩家列表请输入/island party"
+
+#, java-format
+msgid "§cYou can restart your island in {0} seconds."
+msgstr ""
+
+msgid "§cYour island is in the process of generating, you cannot restart now."
+msgstr ""
+
+msgid "§eNOTE: Your entire island and all your belongings will be RESET!"
+msgstr "§e注意: 你所有财产和你的岛屿将被§c§l重置"
+
+msgid "teleports you to the skyblock spawn"
+msgstr ""
+
+msgid "change the biome of the island"
+msgstr ""
+
+msgid "exempt player from biome-cooldown"
+msgstr ""
+
+#, java-format
+msgid "Let the player change their islands biome to {0}"
+msgstr ""
+
+msgid ""
+"§cYou do not have permission to change the biome of your current island."
+msgstr "§c你没有权限更改你当前岛屿的生物群系."
+
+msgid "§4You do not have permission to change the biome of this island!"
+msgstr "§4你没有权限去变更岛屿的生物群系!"
+
+msgid "§eYou must be on your island to change the biome!"
+msgstr "§e你必须在你的岛屿上才能更改生物群系!"
+
+#, java-format
+msgid "§cYou have misspelled the biome name. Must be one of {0}"
+msgstr ""
+
+#, java-format
+msgid "§eYou can change your biome again in {0,number,#} minutes."
+msgstr "§e你需要等待{0,number,#}分钟才能再次更改生物群系."
+
+msgid "§cYou do not have permission to change your biome to that type."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome near you to §9{0}§7, be patient."
+msgstr ""
+
+#, java-format
+msgid ""
+"§7The pixies are busy changing the biome in your current chunk to §9{0}§7, "
+"be patient."
+msgstr ""
+
+#, java-format
+msgid "§eInvalid biome {0} supplied!"
+msgstr ""
+
+#, java-format
+msgid "§aYou have changed your island''s biome to {0}"
+msgstr ""
+
+#, java-format
+msgid "{0} changed the island biome to {1}"
+msgstr "{0}将岛屿的生物群系更改为{1}"
+
+#, java-format
+msgid "§aYou have changed {0} blocks around you to the {1} biome"
+msgstr ""
+
+#, java-format
+msgid "{0} created an area with {1} biome"
+msgstr ""
+
+msgid "set your island''s warp location"
+msgstr ""
+
+msgid "§cYou do not have permission to set your island''s warp point!"
+msgstr "§c你没有权限设置你岛屿的传送点!"
+
+msgid "§cYou need to be on your own island to set the warp!"
+msgstr "§c你需要在你的岛屿上才能设置传送点!"
+
+#, java-format
+msgid "§b{0}§d changed the island warp location."
+msgstr "§b{0}§d更改岛屿传送坐标."
+
+msgid "teleports you to your island (or create one)"
+msgstr ""
+
+msgid "ban/unban a player from your island."
+msgstr ""
+
+msgid "exempts user from being banned"
+msgstr ""
+
+msgid "§eThe following players are banned from warping to your island:"
+msgstr "§e下列玩家被禁止传送到你的岛屿:"
+
+msgid "§eTo ban/unban from your island, use /island ban <player>"
+msgstr "§e禁止/允许一个玩家前往你的岛屿，输入§c/island ban §a<玩家名字>"
+
+msgid "§4You can't ban members. Remove them first!"
+msgstr "§4你无法封禁玩家.请先将他们从你的岛屿上移除!"
+
+msgid "§4You do not have permission to kick/ban players."
+msgstr "§4你没有权限踢出/禁止一个玩家"
+
+#, java-format
+msgid "§eUnable to ban unknown player {0}"
+msgstr ""
+
+#, java-format
+msgid "§4{0} tried to ban you from their island!"
+msgstr ""
+
+#, java-format
+msgid "§4{0} is exempt from being banned."
+msgstr ""
+
+#, java-format
+msgid "§eYou have banned §4{0}§e from warping to your island."
+msgstr "§e你禁止了玩家§4{0}§e前往你的岛屿上."
+
+#, java-format
+msgid "§eYou have been §cBANNED§e from {0}§e''s island."
+msgstr ""
+
+#, java-format
+msgid "§eYou have unbanned §a{0}§e from warping to your island."
+msgstr "§e你解除了玩家§a{0}§e的封禁状态，现在他可以访问你的岛屿了."
+
+#, java-format
+msgid "§eYou have been §aUNBANNED§e from {0}§e''s island."
+msgstr ""
+
+msgid "display log"
+msgstr ""
+
+msgid "changes a members island-permissions"
+msgstr ""
+
+#, java-format
+msgid "§ePermissions for §9{0}§e:"
+msgstr ""
+
+msgid "§aON"
+msgstr ""
+
+msgid "§cOFF"
+msgstr ""
+
+#, java-format
+msgid "§7 - §6{0}§7 : {1}"
+msgstr ""
+
+#, java-format
+msgid "§cInvalid permission {0}. Must be one of {1}"
+msgstr ""
+
+#, java-format
+msgid "§eToggled permission §9{0}§e for §9{1}§e to {2}"
+msgstr ""
+
+#, java-format
+msgid "§eUnable to toggle permission §9{0}§e for §9{1}"
+msgstr ""
+
+msgid "set the island-home"
+msgstr ""
+
+msgid "show the islands limits"
+msgstr ""
+
+msgid "enable/disable warping to your island."
+msgstr ""
+
+msgid "§4Your island is locked. You must unlock it before enabling your warp."
+msgstr "§4你的岛屿已经锁定,在启用传送点之前请先解锁."
+
+#, java-format
+msgid "§b{0}§d activated the island warp."
+msgstr ""
+
+msgid "§cYou do not have permission to enable/disable your island''s warp!"
+msgstr "§c你没有权限启用/禁用岛屿的传送点!"
+
+msgid "try to complete a challenge"
+msgstr ""
+
+msgid "show information about the challenge"
+msgstr ""
+
+msgid "§eRank: "
+msgstr ""
+
+msgid "§4This Challenge is not repeatable!"
+msgstr "§4当前任务不可重复。"
+
+msgid "§4You will lose all required items when you complete this challenge!"
+msgstr "§4挑战所需物品将会从你背包内移除。"
+
+#, java-format
+msgid ""
+"§4All required items must be placed on your island, within {0} blocks of you."
+msgstr ""
+
+#, java-format
+msgid "§eTo complete this challenge, use §f/c c {0}"
+msgstr ""
+
+msgid "§4Invalid challenge name! Use /c help for more information"
+msgstr "§4错误的挑战名!输入/c help 获取更多信息"
+
+msgid "§eSending you to spawn."
+msgstr ""
+
+msgid "§eThe island has been §cLOCKED§e."
+msgstr ""
+
+msgid "§9Hold your horses! You have to be patient..."
+msgstr ""
+
+msgid "§9Not really patient, are you?"
+msgstr ""
+
+msgid "§9Be patient, young padawan"
+msgstr ""
+
+msgid "§9Patience you MUST have, young padawan"
+msgstr ""
+
+msgid "§9The two most powerful warriors are patience and time."
+msgstr ""
+
+msgid "§4Unable to find a safe home-location on your island!"
+msgstr ""
+
+msgid "§cWARNING: §eTeleporting you to mid-air."
+msgstr ""
+
+msgid "§aTeleporting you to your island."
+msgstr "§a将你传送回自己的岛屿."
+
+#, java-format
+msgid "§aYou will be teleported in {0} seconds."
+msgstr "§a将在 {0} 秒后进行传送."
+
+msgid "§4Unable to warp you to that player''s island!"
+msgstr "§4无法传送至玩家的岛屿!"
+
+#, java-format
+msgid "§aTeleporting you to {0}''s island."
+msgstr ""
+
+msgid "§7Teleport cancelled"
 msgstr ""


### PR DESCRIPTION
The po-utils package is a relatively small package (two classes) currently living in it's own Git repository. By re-adding it to uSkyBlock as a Maven module, we avoid having all kinds of small repositories and side-projects for essential parts of uSkyBlock (bukkit-utils is another point). This makes it easier for other developers to contribute to Ultimate Skyblock while still giving developers the option to use po-utils in their project by using our Maven repository.

I will remove the draft status after some additional testing tomorrow when I'm back at a computer that's able to run Minecraft.