### PR TITLE
Fisherman’s repeated challenge rewarded 2 INK_SAC instead of 2 LAPIS_LAZULI

### DIFF
--- a/uSkyBlock-Core/src/main/resources/challenges.yml
+++ b/uSkyBlock-Core/src/main/resources/challenges.yml
@@ -726,7 +726,7 @@ ranks:
         repeatReward:
           text: 2 lapis, 5 prismarine, kelp and a chance at prismarine crystals
           items:
-          - INK_SAC:2
+          - LAPIS_LAZULI:2
           - PRISMARINE:5
           - KELP:1
           - '{p=0.20}PRISMARINE_CRYSTALS:5'


### PR DESCRIPTION
The reward text was saying 2 lapis, but the actual reward was 2 ink sac