### PR TITLE
NewIslandLocatorLogic

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/Settings.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/Settings.java
@@ -17,6 +17,10 @@ public class Settings {
     public static String general_worldName;
     public static int island_distance;
     public static int island_height;
+    public static int orgx;
+    public static int orgz;
+    public static String path;
+    public static int forbid;
     public static int general_spawnSize;
     public static boolean island_removeCreaturesByTeleport;
     public static int island_protectionRange;
@@ -58,6 +62,53 @@ public class Settings {
         } catch (Exception e) {
             island_distance = 110;
         }
+        try {
+            orgx = config.getInt("options.island.orgx");
+            orgx = (orgx/island_distance)*island_distance;
+        } catch (Exception e) {
+            orgx = 0;
+        }
+        try {
+            orgz = config.getInt("options.island.orgz");
+            orgz = (orgz/island_distance)*island_distance;
+        } catch (Exception e) {
+            orgz = 0;
+        }
+        path = config.getString("options.island.path");
+        if( path == null ) {
+            path = "UNI";
+        }
+        path.toUpperCase();
+        //
+        // Forbidden quadrants will not be populated:
+        //
+        //         N
+        //         ^
+        //  forbid |
+        //  bit 3  | bit 0
+        //         |
+        //  W <----O-----> E
+        //         |
+        //  bit 2  | bit 1
+        //         |
+        //         v
+        //         S
+        //
+        switch(path) { 
+            case "N":   forbid = 0b0110; break; 
+            case "NE":  forbid = 0b1110; break; 
+            case "!NE": forbid = 0b0001; break; 
+            case "E":   forbid = 0b1100; break; 
+            case "SE":  forbid = 0b1101; break; 
+            case "!SE": forbid = 0b0010; break; 
+            case "S":   forbid = 0b1001; break; 
+            case "SW":  forbid = 0b1011; break; 
+            case "!SW": forbid = 0b0100; break; 
+            case "W":   forbid = 0b0011; break; 
+            case "NW":  forbid = 0b0111; break; 
+            case "!NW": forbid = 0b1000; break; 
+            default:   path   = "UNI"; forbid = 0; 
+        } 
         try {
             island_protectionRange = config.getInt("options.island.protectionRange");
             if (island_protectionRange > island_distance) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/IslandLocatorLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/IslandLocatorLogic.java
@@ -53,9 +53,11 @@ public class IslandLocatorLogic {
 
     private Location getLastIsland() {
         if (lastIsland == null) {
-            lastIsland = new Location(plugin.getWorldManager().getWorld(),
-                    config.getInt("options.general.lastIslandX", 0), Settings.island_height,
-                    config.getInt("options.general.lastIslandZ", 0));
+            lastIsland = new Location(
+               plugin.getWorldManager().getWorld(),
+               config.getInt("options.general.lastIslandX", Settings.orgx), 
+               Settings.island_height,
+               config.getInt("options.general.lastIslandZ", Settings.orgz));
         }
         return LocationUtil.alignToDistance(lastIsland, Settings.island_distance);
     }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/IslandLocatorLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/IslandLocatorLogic.java
@@ -34,12 +34,19 @@ public class IslandLocatorLogic {
         this.configFile = new File(plugin.getDataFolder(), "lastIslandConfig.yml");
         this.config = new YmlConfiguration();
         FileUtil.readConfig(config, configFile);
-        // Backward compatibility
-        if (!config.contains("options.general.lastIslandX") && plugin.getConfig().contains("options.general.lastIslandX")) {
-            config.set("options.general.lastIslandX", plugin.getConfig().getInt("options.general.lastIslandX"));
-            config.set("options.general.lastIslandZ", plugin.getConfig().getInt("options.general.lastIslandZ"));
-            plugin.getConfig().set("options.general.lastIslandX", null);
-            plugin.getConfig().set("options.general.lastIslandZ", null);
+
+        if (!config.contains("options.general.lastIslandX") ) {
+           // Backward compatibility
+           if (plugin.getConfig().contains("options.general.lastIslandX")) {
+               config.set("options.general.lastIslandX", plugin.getConfig().getInt("options.general.lastIslandX"));
+               config.set("options.general.lastIslandZ", plugin.getConfig().getInt("options.general.lastIslandZ"));
+               plugin.getConfig().set("options.general.lastIslandX", null);
+               plugin.getConfig().set("options.general.lastIslandZ", null);
+           }
+           else {
+               config.set("options.general.lastIslandX", Settings.orgx );
+               config.set("options.general.lastIslandZ", Settings.orgz );
+           }
         }
         reservationTimeout = plugin.getConfig().getLong("options.island.reservationTimeout", 5 * 60000);
     }
@@ -127,56 +134,67 @@ public class IslandLocatorLogic {
     private boolean isReserved(Location next) {
         return reservations.containsKey(LocationUtil.getIslandName(next));
     }
-
     /**
      * <pre>
-     *                            z
-     *   x = -z                   ^                    x = z
-     *        \        -x < z     |     x < z         /
-     *           \                |                /
+     *  [NW]                      -z                     [NE]
+     *   x = z                    ^                    x = -z
+     *        \        -x < -z    |     x < -z        /
+     *           \               [N]               /
      *              \             |             /
-     *                 \          |          /
-     *                    \       |       /          x > z
-     *        -x > z         \    |    /
-     *                          \ | /
-     *     -----------------------+-----------------------------> x
-     *                          / | \
-     *        -x > -z        /    |    \
-     *        (x < z)     /       |       \          x > -z
-     *                 /          |          \
-     *              /             |             \
-     *           /     -x < -z    |   x < -z       \
-     *       x = z                |                x = -z
-     *                            |
-     *                            v
+     *  forbid=0b1000  \          |          / forbid=0b0001
+     *  quadrant 3        \       |       /    quadrant 0
+     *        -x > -z        \    |    /             x > -z
+     *                        /~~~^~~~\
+     *     -------[W]--------<orgx,orgz>----------[E]-----------> x
+     *                        \---v---/
+     *        -x > z         /    |    \       quadrant 1
+     *        (x < -z)    /       |       \          x >  z
+     *  forbid=0b0100  /          |          \ forbid=0b0010
+     *  quadrant 2  /             |             \
+     *           /     -x < z     |   x < z        \
+     *       x = -z              [S]               x = z
+     *       /                    |                    \
+     *    [SW]                    v                   [SE]
      * </pre>
      */
     static Location nextIslandLocation(final Location lastIsland) {
         int d = Settings.island_distance;
+        boolean isforbidden = false;
         LocationUtil.alignToDistance(lastIsland, d);
-        int x = lastIsland.getBlockX();
-        int z = lastIsland.getBlockZ();
-        if (x < z) {
-            if (-1 * x < z) {
-                x += d;
-            } else {
-                z += d;
-            }
-        } else if (x > z) {
-            if (-1 * x >= z) {
-                x -= d;
-            } else {
-                z -= d;
-            }
-        } else { // x == z
-            if (x <= 0) {
-                z += d;
-            } else {
-                z -= d;
-            }
-        }
-        lastIsland.setX(x);
-        lastIsland.setZ(z);
+        int x = lastIsland.getBlockX()-Settings.orgx;
+        int z = lastIsland.getBlockZ()-Settings.orgz;
+        do {
+           // Snake, counterclockwise
+           if (x < z) {
+              if (-x < z)  x += d;  // E
+              else         z += d;  // S
+           } 
+           else if (x > z) {
+              if (-x >= z) x -= d;  // W
+              else         z -= d;  // N
+           } 
+           else { // x == z
+              if (x <= 0)  z += d;  // S
+              else         z -= d;  // N
+           }
+           if( Settings.forbid == 0 ) break;
+           // Check the new location for forbidden areas
+           isforbidden = false;
+           if( x>0 && z<0 && (Settings.forbid & 0b0001) !=0 ) isforbidden = true;
+           if( x>0 && z>0 && (Settings.forbid & 0b0010) !=0 ) isforbidden = true;
+           if( x<0 && z>0 && (Settings.forbid & 0b0100) !=0 ) isforbidden = true;
+           if( x<0 && z<0 && (Settings.forbid & 0b1000) !=0 ) isforbidden = true;
+        } while( isforbidden );
+        //
+        // A BIG FAT WARNING!
+        // ==================
+        // This code is a Quick And Dirty solution!
+        // In case of large SkyBlock, it might cause severe LAGG!
+        // Volunteers! It is a TODO for one step path-finding :-)
+        // (scrolling through the path this way is quite brainless)
+        // 
+        lastIsland.setX(x+Settings.orgx);
+        lastIsland.setZ(z+Settings.orgz);
         return lastIsland;
     }
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/world/SkyBlockChunkGenerator.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/world/SkyBlockChunkGenerator.java
@@ -34,6 +34,6 @@ public class SkyBlockChunkGenerator extends ChunkGenerator {
 
     @Override
     public Location getFixedSpawnLocation(World world, Random random) {
-        return new Location(world, 0.5d, Settings.island_height, 0.5d);
+        return new Location(world, Settings.orgx, Settings.island_height, Settings.orgz);
     }
 }

--- a/uSkyBlock-Core/src/main/resources/config.yml
+++ b/uSkyBlock-Core/src/main/resources/config.yml
@@ -35,6 +35,28 @@ options:
     # [integer] The number of blocks between islands.
     distance: 128
 
+    # [integer] The x origin for the first placement.
+    orgx: 0
+
+    # [integer] The z origin for the first placement.
+    orgz: 0
+
+    # [string] Path for the placement as:
+    # N:   Northern hemisphere only
+    # NE:  North-Eastern quadrant only
+    # !NE: North-Eastern quadrant is forbidden
+    # E:   Eastern
+    # SE:  South-Eastern
+    # !SE: Forbid South-East
+    # S:   Southern hemisphere
+    # SW:  South-West
+    # !SW: Forbid South-West
+    # W:   Western
+    # NW:  North-West
+    # !NW: Forbid North-West
+    # UNI: No restrictions (default)
+    path: UNI
+
     # [integer] The size of the protective region for each island. Can't be higher than 'distance'
     # and MUST be divisible by 32 if you intend to use nether.
     protectionRange: 128


### PR DESCRIPTION
It was A Long Way To Tipperary...

I am requesting to made a more flexible method to populate newly created islands.

**The aims of this pull:**
- to set the SkyBlock origin to (orgx,orgz)
- to set the quadrants where new islands are about to be deployed

Therefore I have introduced new settings in config.yml 
under the island section as follows:

```
    # [integer] The x origin for the first placement.
    orgx: 0

    # [integer] The z origin for the first placement.
    orgz: 0

    # [string] Path for the placement as:
    # N:   Northern hemisphere only
    # NE:  North-Eastern quadrant only
    # !NE: North-Eastern quadrant is forbidden
    # E:   Eastern
    # SE:  South-Eastern
    # !SE: Forbid South-East
    # S:   Southern hemisphere
    # SW:  South-West
    # !SW: Forbid South-West
    # W:   Western
    # NW:  North-West
    # !NW: Forbid North-West
    # UNI: No restrictions (default)
    path: UNI
```
The support code to implement these features are included.
(in Settings and IslandLocatorLogic)

**Background:**

I'd like to create a SkyWorld with prefilled regions and a living SkyBlock.
Those are:
Northern hemisphere - SkyGrid with tons of secrets
Spawn region with a Sky City (nowadays CityWorld)
South-Eastern region with ancient dead SkyBlocks and SkyLands
South-West: the new living SkyBlock

**Notes:**

1. Do not beat me concerning my java code. I am on pure C and VHDL (and fortran - decades ago)
2. Until now, I've made just short, single ended java compilations of my plugins.
3. This is the first time I contribute to a GIT project.
4. I'am just getting started to familiarize myself to the Maven stuff auto-build system :-)

That's all for now Folks...