### PR TITLE
Dependency horror on 1.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,10 @@
                         <groupId>dk.lockfuglsang.minecraft</groupId>
                         <artifactId>po-utils</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.bukkit</groupId>
+                        <artifactId>bukkit</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -185,4 +189,12 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <profiles>
+        <profile>
+            <id>1.16</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -189,12 +189,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <profiles>
-        <profile>
-            <id>1.16</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,12 @@
                 <artifactId>VaultAPI</artifactId>
                 <optional>true</optional>
                 <version>${vault.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bukkit</groupId>
+                        <artifactId>bukkit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.github.rlf</groupId>

--- a/uSkyBlock-API/pom.xml
+++ b/uSkyBlock-API/pom.xml
@@ -32,6 +32,7 @@
             <artifactId>spigot-api</artifactId>
             <version>1.16.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -332,13 +332,13 @@
             <artifactId>VaultAPI</artifactId>
             <optional>true</optional>
         </dependency>
-
         <!-- Spigot API -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <!-- PaperLib -->
         <dependency>
@@ -379,6 +379,12 @@
             <artifactId>worldedit-bukkit</artifactId>
             <version>7.0.1</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- WorldGuard -->
         <dependency>
@@ -390,6 +396,10 @@
                 <exclusion>
                     <groupId>com.sk89q</groupId>
                     <artifactId>worldedit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -413,6 +423,12 @@
             <artifactId>ActionBarAPI</artifactId>
             <version>1.5.4</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>be.maximvdw</groupId>

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -217,21 +217,6 @@
 
     <profiles>
         <profile>
-            <id>1.16</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.spigotmc</groupId>
-                    <artifactId>spigot-api</artifactId>
-                    <version>1.16.1-R0.1-SNAPSHOT</version>
-                    <scope>compile</scope>
-                    <optional>true</optional>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>i18n</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -345,6 +330,14 @@
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>VaultAPI</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- Spigot API -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <scope>compile</scope>
             <optional>true</optional>
         </dependency>
         <!-- PaperLib -->

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -312,6 +312,12 @@
         <dependency>
             <groupId>dk.lockfuglsang.minecraft</groupId>
             <artifactId>bukkit-utils</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>dk.lockfuglsang.minecraft</groupId>

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -312,12 +312,6 @@
         <dependency>
             <groupId>dk.lockfuglsang.minecraft</groupId>
             <artifactId>bukkit-utils</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bukkit</groupId>
-                    <artifactId>bukkit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>dk.lockfuglsang.minecraft</groupId>
@@ -336,6 +330,7 @@
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>VaultAPI</artifactId>
+            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <!-- Spigot API -->
@@ -343,7 +338,7 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.1-R0.1-SNAPSHOT</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <!-- PaperLib -->

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -217,6 +217,21 @@
 
     <profiles>
         <profile>
+            <id>1.16</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.spigotmc</groupId>
+                    <artifactId>spigot-api</artifactId>
+                    <version>1.16.1-R0.1-SNAPSHOT</version>
+                    <scope>compile</scope>
+                    <optional>true</optional>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>i18n</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -330,14 +345,6 @@
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>VaultAPI</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <!-- Spigot API -->
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <!-- PaperLib -->

--- a/uSkyBlock-FAWE/pom.xml
+++ b/uSkyBlock-FAWE/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>spigot-api</artifactId>
             <version>1.16.1-R0.1-SNAPSHOT</version>
             <optional>true</optional>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <!-- WorldEdit -->
         <dependency>

--- a/uSkyBlock-FAWE/pom.xml
+++ b/uSkyBlock-FAWE/pom.xml
@@ -33,9 +33,9 @@
             <artifactId>uSkyBlock-Core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.16.1-R0.1-SNAPSHOT</version>
             <optional>true</optional>
             <scope>compile</scope>
         </dependency>

--- a/uSkyBlock-FAWE/pom.xml
+++ b/uSkyBlock-FAWE/pom.xml
@@ -45,6 +45,12 @@
             <artifactId>worldedit-bukkit</artifactId>
             <version>7.0.1</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- WorldGuard -->
         <dependency>
@@ -53,6 +59,10 @@
             <version>7.0.1</version>
             <scope>provided</scope>
             <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>com.sk89q</groupId>
                     <artifactId>worldedit</artifactId>


### PR DESCRIPTION
It worked on my machine... :/

Since the new 1.16.1 API is only available as org.spigotmc:spigot-api, old Bukkit versions from our dependencies are sometimes used when building. Every old Bukkit dependency should be excluded now. The exclusion rules can be removed in the future when developers switch to spigot-api.