### PR TITLE
topchef requires GOLDEN_APPLE instead of LAPIS_BLOCK

### DIFF
--- a/uSkyBlock-Core/src/main/resources/challenges.yml
+++ b/uSkyBlock-Core/src/main/resources/challenges.yml
@@ -1250,7 +1250,7 @@ ranks:
         - TROPICAL_FISH:1
         - COOKED_PORKCHOP:1
         - COOKIE:1
-        - LAPIS_BLOCK:1
+        - GOLDEN_APPLE:1
         - GOLDEN_CARROT:1
         - MUSHROOM_STEW:1
         - PUMPKIN_PIE:1


### PR DESCRIPTION
presumably 1.12 migration error (322:0:1 should be golden_apple, not lapis_block).