### PR TITLE
Update region limits to reflect the new 1.18 world height

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
@@ -214,11 +214,11 @@ public class WorldGuardHandler {
     }
 
     public static BlockVector3 getProtectionVectorLeft(final Location island) {
-        return BlockVector3.at(island.getX() + Settings.island_radius - 1, 255.0, island.getZ() + Settings.island_radius - 1);
+        return BlockVector3.at(island.getX() + Settings.island_radius - 1, 319.0, island.getZ() + Settings.island_radius - 1);
     }
 
     public static BlockVector3 getProtectionVectorRight(final Location island) {
-        return BlockVector3.at(island.getX() - Settings.island_radius, 0.0, island.getZ() - Settings.island_radius);
+        return BlockVector3.at(island.getX() - Settings.island_radius, -64.0, island.getZ() - Settings.island_radius);
     }
 
     public static String getIslandNameAt(Location location) {


### PR DESCRIPTION
Some of the players on our server are complaining that they cannot build below Y0 after the new 1.18 update. I briefly looked into the code and found that the minimum and maximum region height values are hard coded to the old world limits. 

I propose to change these values to reflect the new world height limits.